### PR TITLE
Add missing license to test files

### DIFF
--- a/impl/src/test/resources/org/apache/myfaces/view/facelets/stateless/stateless.xhtml
+++ b/impl/src/test/resources/org/apache/myfaces/view/facelets/stateless/stateless.xhtml
@@ -1,3 +1,16 @@
+<!--
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
 <ui:composition xmlns="http://www.w3.org/1999/xhtml"
                 xmlns:c="http://java.sun.com/jsp/jstl/core"
                 xmlns:h="http://xmlns.jcp.org/jsf/html"

--- a/impl/src/test/resources/org/apache/myfaces/view/facelets/stateless/template.xhtml
+++ b/impl/src/test/resources/org/apache/myfaces/view/facelets/stateless/template.xhtml
@@ -1,3 +1,16 @@
+<!--
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml"
       xmlns:c="http://java.sun.com/jsp/jstl/core"


### PR DESCRIPTION
Without this I get a failure when trying to perform a new release:

[INFO] [ERROR] Failed to execute goal org.apache.rat:apache-rat-plugin:0.12:check (default) on project myfaces-impl: Too many files with unapproved license: 2 See RAT report in: