### PR TITLE
Update MavenReleasePlugin version to 2.5.4

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -127,10 +127,15 @@
               </configuration>
             </plugin>
 
-			<plugin>
-			  <artifactId>maven-release-plugin</artifactId>
-			  <version>2.5.3</version>
-			</plugin>
+            <plugin>
+              <artifactId>maven-release-plugin</artifactId>
+              <version>2.5.3</version>
+            </plugin>
+
+            <plugin>
+              <artifactId>maven-assembly-plugin</artifactId>
+              <version>2.5.4</version>
+            </plugin>
 
         </plugins>
 

--- a/pom.xml
+++ b/pom.xml
@@ -80,9 +80,13 @@
               <version>3.3</version>
             </plugin>
             <plugin>
-			  <artifactId>maven-release-plugin</artifactId>
-			  <version>2.5.3</version>
-			</plugin>
+              <artifactId>maven-release-plugin</artifactId>
+              <version>2.5.3</version>
+            </plugin>
+            <plugin>
+              <artifactId>maven-assembly-plugin</artifactId>
+              <version>2.5.4</version>
+            </plugin>
           </plugins>
         </pluginManagement>
         <plugins>


### PR DESCRIPTION
The master pom here https://github.com/apache/myfaces-master-pom/blob/master/pom.xml lists 2.2.1 and we are getting failures in the myfaces core when trying to do a release: 

Failed to execute goal org.apache.maven.plugins:maven-assembly-plugin:2.2.1:attached (make_assembly_src) on project myfaces-core-assembly: Failed to create assembly: Error creating assembly archive coresrc: posix is not a legal value for this attribute -> [Help 1]
[INFO] org.apache.maven.lifecycle.LifecycleExecutionException: Failed to execute goal org.apache.maven.plugins:maven-assembly-plugin:2.2.1:attached (make_assembly_src) on project myfaces-core-assembly: Failed to create 

