### PR TITLE
Quarkus native mode support

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ mvn clean install
 ## Quarkus extension
 
 Since 2.3-next a Quarkus extension is available. A sample project can be found here: https://github.com/apache/myfaces/blob/master/extensions/quarkus/showcase/  
-Native mode is currently not supported as EL makes extensive use of reflection.
+
 
 ### Differences to a normal servlet container
 - You need to put your views under src/main/resources/META-INF/resources as Quarkus doesn't create a WAR and src/main/webapp is ignored!

--- a/extensions/quarkus/deployment/src/main/java/org/apache/myfaces/core/extensions/quarkus/deployment/MyFacesProcessor.java
+++ b/extensions/quarkus/deployment/src/main/java/org/apache/myfaces/core/extensions/quarkus/deployment/MyFacesProcessor.java
@@ -142,23 +142,16 @@ class MyFacesProcessor
     private static final Class[] BEAN_CLASSES =
     {
             JsfApplicationArtifactHolder.class,
-
             JsfArtifactProducer.class,
-
             FacesConfigBeanHolder.class,
-
             FacesDataModelManager.class,
-
             ViewScopeBeanHolder.class,
-
             CdiAnnotationProviderExtension.class,
-
             PushContextFactoryBean.class,
             WebsocketChannelTokenBuilderBean.class,
             WebsocketSessionBean.class,
             WebsocketViewBean.class,
             WebsocketApplicationBean.class,
-
             FlowBuilderFactoryBean.class,
             FlowScopeBeanHolder.class
     };
@@ -435,13 +428,10 @@ class MyFacesProcessor
         }
 
         classNames.addAll(Arrays.asList(
-            "org.primefaces.behavior.ajax.AjaxBehavior",
             "org.primefaces.config.PrimeEnvironment",
             "com.lowagie.text.pdf.MappedRandomAccessFile",
             "org.apache.myfaces.application._ApplicationUtils",
-             "org.apache.el.ExpressionFactoryImpl",
-            "com.sun.el.util.ReflectionUtil",
-            "com.sun.org.apache.xerces.internal.jaxp.SAXParserFactoryImpl",
+            "org.apache.el.ExpressionFactoryImpl",
             "org.primefaces.util.MessageFactory",
             "javax.faces.component._DeltaStateHelper",
             "javax.faces.component._DeltaStateHelper$InternalMap"));
@@ -485,7 +475,6 @@ class MyFacesProcessor
         classNames.addAll(collectClassAndSubclasses(combinedIndex, ELResolver.class.getName()));
         classNames.addAll(collectClassAndSubclasses(combinedIndex, MethodRule.class.getName()));
         classNames.addAll(collectClassAndSubclasses(combinedIndex, MetaRuleset.class.getName()));
-        classNames.addAll(collectClassAndSubclasses(combinedIndex, "org.primefaces.component.api.Widget"));
         classNames.addAll(Arrays.asList(
                 "org.primefaces.util.ComponentUtils",
                 "org.primefaces.expression.SearchExpressionUtils",

--- a/extensions/quarkus/pom.xml
+++ b/extensions/quarkus/pom.xml
@@ -37,6 +37,7 @@
     <modules>
         <module>deployment</module>
         <module>runtime</module>
+        <module>showcase</module>
     </modules>
 
     <properties>

--- a/extensions/quarkus/runtime/pom.xml
+++ b/extensions/quarkus/runtime/pom.xml
@@ -74,6 +74,61 @@
             <artifactId>quarkus-jsonp</artifactId>
             <version>${quarkus.version}</version>
         </dependency>
+        <dependency>
+            <groupId>jakarta.ejb</groupId>
+            <artifactId>jakarta.ejb-api</artifactId>
+            <version>3.2.5</version>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.persistence</groupId>
+            <artifactId>jakarta.persistence-api</artifactId>
+            <version>2.2.2</version>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.validation</groupId>
+            <artifactId>jakarta.validation-api</artifactId>
+            <version>2.0.2</version>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.servlet.jsp.jstl</groupId>
+            <artifactId>jakarta.servlet.jsp.jstl-api</artifactId>
+            <version>1.2.4</version>
+        </dependency>
+        <dependency>
+            <groupId>commons-fileupload</groupId> <!-- primefaces fileupload, needed in quarkus native mode -->
+            <artifactId>commons-fileupload</artifactId>
+            <version>1.3.3</version>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.xml.bind</groupId> <!-- java 11 support -->
+            <artifactId>jakarta.xml.bind-api</artifactId>
+            <version>2.3.2</version>
+        </dependency>
+        <dependency>
+            <groupId>com.googlecode.owasp-java-html-sanitizer</groupId> <!-- primefaces textEditor renderer -->
+            <artifactId>owasp-java-html-sanitizer</artifactId>
+            <version>20181114.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.poi</groupId> <!-- primefaces exporter -->
+            <artifactId>poi</artifactId>
+            <version>3.17</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.poi</groupId>
+            <artifactId>poi-ooxml</artifactId>
+            <version>3.17</version>
+        </dependency>
+        <dependency>
+            <groupId>com.rometools</groupId> <!-- primefaces feed -->
+            <artifactId>rome</artifactId>
+            <version>1.9.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.github.librepdf</groupId>
+            <artifactId>openpdf</artifactId>
+            <version>1.2.21</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/extensions/quarkus/showcase/README.md
+++ b/extensions/quarkus/showcase/README.md
@@ -1,0 +1,35 @@
+# Quarkus MyFaces Showcase
+
+This sample application 
+
+## Running
+
+`mvn clean package && java -jar `
+
+## Dev mode
+
+In [dev mode](https://quarkus.io/guides/maven-tooling#development-mode) you can easily debug and hot deploy your quarkus application:
+
+`mvn quarkus:dev` 
+
+> Hot deployment also works for facelets pages  
+
+## Native mode
+
+For native mode you need at least [graalvm 20](https://github.com/graalvm/graalvm-ce-builds/releases/tag/vm-20.0.0), see graalvm instalation [instructions here](https://quarkus.io/guides/building-native-image).
+
+Following is how to `build and run` the native image:
+
+`mvn clean package -Pnative && ./target/quarkus-myfaces-showcase-1.0-SNAPSHOT-runner`
+
+## Testing 
+
+Tests use [HTMLUnit](https://github.com/HtmlUnit/htmlunit) to retrieve web pages and assert their content.
+
+A `mvn clean test` will run JVM mode tests
+
+For `native mode ` tests use:
+
+```
+mvn verify -Pnative
+``` 

--- a/extensions/quarkus/showcase/README.md
+++ b/extensions/quarkus/showcase/README.md
@@ -1,10 +1,10 @@
 # Quarkus MyFaces Showcase
 
-This sample application 
+This sample application shows Quarkus Myfaces extension usage
 
 ## Running
 
-`mvn clean package && java -jar `
+`mvn clean package -DskipTests && java -jar ./target/quarkus-myfaces-showcase-1.0-SNAPSHOT-runner.jar`
 
 ## Dev mode
 

--- a/extensions/quarkus/showcase/pom.xml
+++ b/extensions/quarkus/showcase/pom.xml
@@ -59,17 +59,33 @@
             <artifactId>myfaces-quarkus-runtime</artifactId>
             <version>${myfaces.version}</version>
         </dependency>
-
         <dependency>
             <groupId>org.primefaces</groupId>
             <artifactId>primefaces</artifactId>
             <version>7.0</version>
         </dependency>
-
         <dependency>
             <groupId>javax.validation</groupId>
             <artifactId>validation-api</artifactId>
             <version>2.0.1.Final</version>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5</artifactId>
+            <version>${quarkus.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>net.sourceforge.htmlunit</groupId>
+            <artifactId>htmlunit</artifactId>
+            <version>2.35.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>3.6.2</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/extensions/quarkus/showcase/src/main/java/org/apache/myfaces/core/extensions/quarkus/showcase/view/InputController.java
+++ b/extensions/quarkus/showcase/src/main/java/org/apache/myfaces/core/extensions/quarkus/showcase/view/InputController.java
@@ -30,7 +30,7 @@ public class InputController implements Serializable{
     
     @Inject
     @ManagedProperty(value = "#{carService}")
-    private CarService carService;
+    CarService carService;
     
     private String val;
 

--- a/extensions/quarkus/showcase/src/main/java/org/apache/myfaces/core/extensions/quarkus/showcase/view/LazySorter.java
+++ b/extensions/quarkus/showcase/src/main/java/org/apache/myfaces/core/extensions/quarkus/showcase/view/LazySorter.java
@@ -21,6 +21,8 @@ package org.apache.myfaces.core.extensions.quarkus.showcase.view;
 import java.util.Comparator;
 import org.primefaces.model.SortOrder;
 
+import static org.apache.commons.lang3.StringUtils.capitalize;
+
 public class LazySorter implements Comparator<Car> {
  
     private String sortField;
@@ -34,8 +36,8 @@ public class LazySorter implements Comparator<Car> {
     @Override
     public int compare(Car car1, Car car2) {
         try {
-            Object value1 = Car.class.getField(this.sortField).get(car1);
-            Object value2 = Car.class.getField(this.sortField).get(car2);
+            Object value1 = Car.class.getMethod("get"+capitalize(this.sortField)).invoke(car1);
+            Object value2 = Car.class.getMethod("get"+capitalize(this.sortField)).invoke(car2);
  
             int value = ((Comparable) value1).compareTo(value2);
              

--- a/extensions/quarkus/showcase/src/main/java/org/apache/myfaces/core/extensions/quarkus/showcase/view/LazySorter.java
+++ b/extensions/quarkus/showcase/src/main/java/org/apache/myfaces/core/extensions/quarkus/showcase/view/LazySorter.java
@@ -42,7 +42,7 @@ public class LazySorter implements Comparator<Car> {
             return SortOrder.ASCENDING.equals(sortOrder) ? value : -1 * value;
         } 
         catch(Exception e) {
-            throw new RuntimeException();
+            throw new RuntimeException(e);
         }
     }
 }

--- a/extensions/quarkus/showcase/src/main/java/org/apache/myfaces/core/extensions/quarkus/showcase/view/LazyView.java
+++ b/extensions/quarkus/showcase/src/main/java/org/apache/myfaces/core/extensions/quarkus/showcase/view/LazyView.java
@@ -37,7 +37,7 @@ public class LazyView implements Serializable {
     private Car selectedCar;
 
     @Inject
-    private CarService service;
+    CarService service;
 
     @PostConstruct
     public void init() {

--- a/extensions/quarkus/showcase/src/main/java/org/apache/myfaces/core/extensions/quarkus/showcase/view/MethodHandleELResolverBean.java
+++ b/extensions/quarkus/showcase/src/main/java/org/apache/myfaces/core/extensions/quarkus/showcase/view/MethodHandleELResolverBean.java
@@ -33,7 +33,7 @@ import javax.inject.Named;
 public class MethodHandleELResolverBean implements Serializable, PhaseListener {
 
     @Inject
-    private CarService service;
+    CarService service;
     
     private List<Car> cars;
     

--- a/extensions/quarkus/showcase/src/main/java/org/apache/myfaces/core/extensions/quarkus/showcase/view/MyBacking.java
+++ b/extensions/quarkus/showcase/src/main/java/org/apache/myfaces/core/extensions/quarkus/showcase/view/MyBacking.java
@@ -27,7 +27,8 @@ import javax.inject.Named;
 @RequestScoped
 public class MyBacking {
     
-    @Inject private CarService carService;
+    @Inject
+    CarService carService;
     
     private MyCollection<Car> cars;
     

--- a/extensions/quarkus/showcase/src/main/java/org/apache/myfaces/core/extensions/quarkus/showcase/view/MyValidator.java
+++ b/extensions/quarkus/showcase/src/main/java/org/apache/myfaces/core/extensions/quarkus/showcase/view/MyValidator.java
@@ -28,7 +28,8 @@ import javax.inject.Inject;
 @FacesValidator(value = "myVal", managed = true)
 public class MyValidator implements Validator<String>{
     
-    @Inject private CarService carService;
+    @Inject
+    CarService carService;
     
     public MyValidator()
     {

--- a/extensions/quarkus/showcase/src/main/resources/application.properties
+++ b/extensions/quarkus/showcase/src/main/resources/application.properties
@@ -13,5 +13,7 @@
 # limitations under the License.
 
 quarkus.log.console.format=%s%n
-javax.faces.PROJECT_STAGE = Production
+javax.faces.PROJECT_STAGE=Development
 javax.faces.ENABLE_WEBSOCKET_ENDPOINT=true
+quarkus.log.console.level=INFO
+quarkus.log.file.path=/tmp/debug.log

--- a/extensions/quarkus/showcase/src/test/java/org/apache/myfaces/core/extensions/quarkus/showcase/QuarkusMyFacesNativeIT.java
+++ b/extensions/quarkus/showcase/src/test/java/org/apache/myfaces/core/extensions/quarkus/showcase/QuarkusMyFacesNativeIT.java
@@ -1,0 +1,7 @@
+package org.apache.myfaces.core.extensions.quarkus.showcase;
+
+import io.quarkus.test.junit.NativeImageTest;
+
+@NativeImageTest
+public class QuarkusMyFacesNativeIT extends QuarkusMyFacesShowcaseTest {
+}

--- a/extensions/quarkus/showcase/src/test/java/org/apache/myfaces/core/extensions/quarkus/showcase/QuarkusMyFacesShowcaseTest.java
+++ b/extensions/quarkus/showcase/src/test/java/org/apache/myfaces/core/extensions/quarkus/showcase/QuarkusMyFacesShowcaseTest.java
@@ -1,0 +1,43 @@
+package org.apache.myfaces.core.extensions.quarkus.showcase;
+
+import com.gargoylesoftware.htmlunit.BrowserVersion;
+import com.gargoylesoftware.htmlunit.NicelyResynchronizingAjaxController;
+import com.gargoylesoftware.htmlunit.WebClient;
+import com.gargoylesoftware.htmlunit.html.HtmlDivision;
+import com.gargoylesoftware.htmlunit.html.HtmlPage;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import java.net.URL;
+
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+
+@QuarkusTest
+public class QuarkusMyFacesShowcaseTest {
+
+    @TestHTTPResource
+    URL url;
+
+    @Test
+    public void shouldOpenIndexPage() throws Exception {
+        try (final WebClient webClient = new WebClient(BrowserVersion.CHROME)) {
+            webClient.getOptions().setJavaScriptEnabled(true);
+            webClient.getOptions().setCssEnabled(false);
+            webClient.getOptions().setUseInsecureSSL(true);
+            webClient.getOptions().setThrowExceptionOnFailingStatusCode(false);
+            webClient.getCookieManager().setCookiesEnabled(true);
+            webClient.setAjaxController(new NicelyResynchronizingAjaxController());
+            webClient.getCookieManager().setCookiesEnabled(true);
+
+            final HtmlPage page = webClient.getPage(url + "/index.xhtml");
+
+            final HtmlDivision datatable = (HtmlDivision) page.getElementById("form:carTable");
+
+            assertThat(datatable).isNotNull();
+            assertThat(datatable.getByXPath("//tr[contains(@role,'row') and contains(@class,'ui-datatable-selectable')]"))
+                    .hasSize(10);
+
+        }
+    }
+}


### PR DESCRIPTION
* Enable native mode
* Adds tests on showcase module (jvm and native)


We still miss an automatic way to [register JSF managed beans](https://github.com/rmpestano/myfaces/blob/2fe17af334422284aa9362307535ecf91b2a447e/extensions/quarkus/deployment/src/main/java/org/apache/myfaces/core/extensions/quarkus/deployment/MyFacesProcessor.java#L622) for reflection