### PR TITLE
Incorrect Last-Modified header for resources

### DIFF
--- a/shared/src/main/java/org/apache/myfaces/shared/resource/ResourceLoaderUtils.java
+++ b/shared/src/main/java/org/apache/myfaces/shared/resource/ResourceLoaderUtils.java
@@ -18,7 +18,6 @@
  */
 package org.apache.myfaces.shared.resource;
 
-import java.io.File;
 import java.io.IOException;
 import java.net.JarURLConnection;
 import java.net.URL;
@@ -79,18 +78,7 @@ public class ResourceLoaderUtils
     //Taken from trinidad URLUtils
     public static long getResourceLastModified(URL url) throws IOException
     {
-        if ("file".equals(url.getProtocol()))
-        {
-            String externalForm = url.toExternalForm();
-            // Remove the "file:"
-            File file = new File(externalForm.substring(5));
-
-            return file.lastModified();
-        }
-        else
-        {
-            return getResourceLastModified(url.openConnection());
-        }
+        return getResourceLastModified(url.openConnection());
     }
 
     //Taken from trinidad URLUtils


### PR DESCRIPTION
We conduct an issue that our resources have incorrect header: `Last-Modified: Thu, 01 Jan 1970 00:00:00 GMT`.

After investigating the issue, I found that we deploy using Tomcat with a version tag and a path to resources contains special characters (`#`).
And this method can not read the resources, because the URL (file path) contains URL Encoded characters (for OS this is not a valid path) like this: `/some-path/tomcat/webapps/v3%23%233.2.1/resources/layout/js/layout.js`.

I'm not sure if this PR is the best solution. But it solves this issue for us.
Now I created a custom implementation of ResourceHalder and Resource (just a copy of myfaces impls) to update the method and fix this issue. It would be good if you can release a fix, or give a hint on how to patch it easier.