### PR TITLE
Animal sniffer plugin updates and ignores

### DIFF
--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -1060,9 +1060,9 @@
             <build>
                 <plugins>
                     <plugin>
-                        <groupId>org.jvnet</groupId>
-                        <artifactId>animal-sniffer</artifactId>
-                        <version>1.2</version>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>animal-sniffer-maven-plugin</artifactId>
+                        <version>1.18</version>
                         <executions>
                             <execution>
                                 <goals>
@@ -1070,8 +1070,8 @@
                                 </goals>
                                 <configuration>
                                     <signature>
-                                        <groupId>org.jvnet.animal-sniffer</groupId>
-                                        <artifactId>java1.6</artifactId>
+                                        <groupId>org.codehaus.mojo.signature</groupId>
+                                        <artifactId>java16</artifactId>
                                         <version>1.0</version>
                                     </signature>
                                 </configuration>
@@ -1268,6 +1268,14 @@
             <groupId>com.google.code.guice</groupId>
             <artifactId>guice</artifactId>
             <optional>true</optional> <!-- optional does not completely work in dependencyManagement (MNG-1630) -->
+        </dependency>
+
+        <!-- Required for @IgnoreJRERequirement -->
+        <dependency>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>animal-sniffer-annotations</artifactId>
+            <version>1.18</version>
+            <optional>true</optional>
         </dependency>
         
 

--- a/impl/src/main/java/org/apache/myfaces/util/IllegalXmlCharacterFilterWriter.java
+++ b/impl/src/main/java/org/apache/myfaces/util/IllegalXmlCharacterFilterWriter.java
@@ -22,6 +22,7 @@ import java.io.FilterWriter;
 import java.io.IOException;
 import java.io.Writer;
 import org.apache.myfaces.shared.util.ClassUtils;
+import org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement;
 
 /**
  * There are unicodes outside the ranges defined in the
@@ -103,6 +104,7 @@ public class IllegalXmlCharacterFilterWriter extends FilterWriter
         super.write(encodeString(str, off, len), off, len);
     }
 
+    @IgnoreJRERequirement // Java 1.6 doesnt support Character.isSurrogate
     private static String encodeString(String str, int off, int len)
     {
         if (str == null)
@@ -161,7 +163,8 @@ public class IllegalXmlCharacterFilterWriter extends FilterWriter
 
         return str;
     }
-    
+
+    @IgnoreJRERequirement // Java 1.6 doesnt support Character.isSurrogate
     private static char[] encodeCharArray(char[] cbuf, int off, int len)
     {
         if (cbuf == null)


### PR DESCRIPTION
1) Update the Animal Sniffer Plugin to the latest version as the old version was not working correctly with the `@IgnoreJRERequirement` annotation. 

2) Add the `animal-sniffer-annotations` as a dependency so we can compile with `@IgnoreJRERequirment`

3) Add `@IgnoreJRERequirement` to the methods that use `isSurrogate`