### PR TITLE
Rollback assembly pom

### DIFF
--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.apache.myfaces.core</groupId>
     <artifactId>myfaces-core-project</artifactId>
-    <version>2.2.14-SNAPSHOT</version>
+    <version>2.2.13-SNAPSHOT</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 


### PR DESCRIPTION
During my last attempt at a 2.2.13 release the release rollback did not return the assembly/pom.xml back to its original state.

This needs to be fixed before trying a 2.2.13 release again.

Doing a comparison between these three commits I think everything will be good once this is merged:

1. https://github.com/apache/myfaces/commit/bc8234438a19816befc2093867e6adf6f2257f3d
2. https://github.com/apache/myfaces/commit/e36407e900e6bc602553b414e3de8a27c883d67e
3. https://github.com/apache/myfaces/commit/2387543c1fc0b77a6493eb2c7f258b6bb4ca3b9d