### PR TITLE
Roll back assembly pom to 2.2.13-SNAPSHOT

### DIFF
--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.apache.myfaces.core</groupId>
     <artifactId>myfaces-core-project</artifactId>
-    <version>2.2.13</version>
+    <version>2.2.13-SNAPSHOT</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 


### PR DESCRIPTION
Tried another release and my local tags were out of sync with the remote tags so it failed since there was already a `myfaces-core-module-2.2.13` tag in my local repository. The tag is deleted  on the 2.2.x remote branch.

I've deleted it locally as well now and things look good. I got in a bad state with the release so I had to perform a `mvn release:rollback` but that seems to always miss the assembly/pom file updates and needs to be done manually.

Initial release commit this go around: https://github.com/apache/myfaces/commit/d811bdbd5b89c5dc6e471b0fa8329b215b52df08

rollback: https://github.com/apache/myfaces/commit/14a3300cc713f862fda65445b3df4d9d6938ef8d

Should be good to try again once this is merged.