### PR TITLE
demo for ignored flag javax.faces.INTERPRET_EMPTY_STRING_SUBMITTED_VALUES_AS_NULL

### DIFF
--- a/extensions/quarkus/showcase/src/main/java/org/apache/myfaces/core/extensions/quarkus/showcase/view/LazyView.java
+++ b/extensions/quarkus/showcase/src/main/java/org/apache/myfaces/core/extensions/quarkus/showcase/view/LazyView.java
@@ -36,6 +36,8 @@ public class LazyView implements Serializable {
 
     private Car selectedCar;
 
+    private String inputVal;
+
     @Inject
     CarService service;
 
@@ -63,5 +65,18 @@ public class LazyView implements Serializable {
     public void onRowSelect(SelectEvent event) {
         FacesMessage msg = new FacesMessage("Car Selected", ((Car) event.getObject()).getId());
         FacesContext.getCurrentInstance().addMessage(null, msg);
+    }
+
+    public String getInputVal() {
+        return inputVal;
+    }
+
+    public void setInputVal(String inputVal) {
+        this.inputVal = inputVal;
+    }
+    
+    public void saveInput() {
+        System.out.println("Input val is: " + inputVal);
+        
     }
 }

--- a/extensions/quarkus/showcase/src/main/java/org/apache/myfaces/core/extensions/quarkus/showcase/view/StartupListener.java
+++ b/extensions/quarkus/showcase/src/main/java/org/apache/myfaces/core/extensions/quarkus/showcase/view/StartupListener.java
@@ -1,0 +1,16 @@
+package org.apache.myfaces.core.extensions.quarkus.showcase.view;
+
+import javax.servlet.ServletContext;
+import javax.servlet.ServletContextEvent;
+import javax.servlet.ServletContextListener;
+import javax.servlet.annotation.WebListener;
+
+@WebListener
+public class StartupListener implements ServletContextListener {
+
+    @Override
+    public void contextInitialized(ServletContextEvent sce) {
+        ServletContext context = sce.getServletContext();
+        context.setInitParameter("javax.faces.INTERPRET_EMPTY_STRING_SUBMITTED_VALUES_AS_NULL", "true");
+    }
+}

--- a/extensions/quarkus/showcase/src/main/resources/META-INF/resources/issue4.xhtml
+++ b/extensions/quarkus/showcase/src/main/resources/META-INF/resources/issue4.xhtml
@@ -29,7 +29,8 @@
 
         <h:body>
             <h:form id="form">
-                <p:commandButton value="property action listener">
+                <p:inputText style="width:100%;" value="#{dtLazyView.inputVal}" />
+                <p:commandButton value="property action listener" actionListener="#{dtLazyView.saveInput()}">
                     <f:setPropertyActionListener value="true"
                                                  target="#{facesContext.externalContext.flash.keepMessages}"/>
                 </p:commandButton>

--- a/extensions/quarkus/showcase/src/main/resources/META-INF/web.xml
+++ b/extensions/quarkus/showcase/src/main/resources/META-INF/web.xml
@@ -32,6 +32,10 @@
         <param-value>luna-amber</param-value>
     </context-param>
     <context-param>
+        <param-name>javax.faces.INTERPRET_EMPTY_STRING_SUBMITTED_VALUES_AS_NULL</param-name>
+        <param-value>true</param-value>
+    </context-param>
+    <context-param>
         <param-name>org.apache.myfaces.AUTOMATIC_EXTENSIONLESS_MAPPING</param-name>
         <param-value>true</param-value>
     </context-param>


### PR DESCRIPTION
Empty inputs are still submitted as empty strings "". Even though the flag `javax.faces.INTERPRET_EMPTY_STRING_SUBMITTED_VALUES_AS_NULL` is set to true (in web.xml and also in ServletContextEvent lsitener).