### PR TITLE
Update parent pom to 19

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -82,7 +82,6 @@
                 </executions>
             </plugin>
 
-
             <!-- license checker needs to exclude some kinds of files -->
             <plugin>
                 <groupId>org.apache.rat</groupId>
@@ -97,7 +96,15 @@
                     </excludes>
                 </configuration>
             </plugin>
-            
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+                <configuration>
+                    <excludes>javax/faces/component/**/*.java</excludes>
+                </configuration>
+            </plugin>
+
             <!-- compilation and compression of our javascripts -->
             <plugin>
                 <artifactId>myfaces-javascript-plugin</artifactId>

--- a/api/src/main/java/javax/faces/component/UIInput.java
+++ b/api/src/main/java/javax/faces/component/UIInput.java
@@ -93,7 +93,7 @@ public class UIInput extends UIOutput implements EditableValueHolder
 
     /** 
      * When INTERPRET_EMPTY_STRING_SUBMITTED_VALUES_AS_NULL is enabled, clear required input fields when empty strings 
-     * are submitted on them
+     * are submitted on them.
      *
      * <p>Note this param is only applicable when INTERPRET_EMPTY_STRING_SUBMITTED_VALUES_AS_NULL is enabled.  This 
      * property addresses an issue wherein values that had previously been populated by the model are re-displayed on 

--- a/impl-test/src/main/java/org/apache/myfaces/mc/test/core/AbstractMyFacesTestCase.java
+++ b/impl-test/src/main/java/org/apache/myfaces/mc/test/core/AbstractMyFacesTestCase.java
@@ -106,7 +106,8 @@ public abstract class AbstractMyFacesTestCase
     private static final Class<?> PHASE_EXECUTOR_CLASS;
     private static final Class<?> PHASE_MANAGER_CLASS;
     
-    static {
+    static 
+    {
         Class<?> phaseExecutorClass = null;
         Class<?> phaseManagerClass = null;
         try

--- a/impl-test/src/main/java/org/apache/myfaces/mc/test/core/runner/AbstractJsfTestContainer.java
+++ b/impl-test/src/main/java/org/apache/myfaces/mc/test/core/runner/AbstractJsfTestContainer.java
@@ -105,7 +105,8 @@ public class AbstractJsfTestContainer
     private static final Class<?> PHASE_EXECUTOR_CLASS;
     private static final Class<?> PHASE_MANAGER_CLASS;
     
-    static {
+    static 
+    {
         Class<?> phaseExecutorClass = null;
         Class<?> phaseManagerClass = null;
         try

--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -104,7 +104,19 @@
                     </excludes>
                 </configuration>
             </plugin>
-            
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+                <configuration>
+                    <excludes>
+                        org/apache/myfaces/taglib/core/*,
+                        org/apache/myfaces/taglib/html/*,
+                        org/apache/myfaces/view/facelets/component/JsfElement.java,
+                        org/apache/myfaces/webapp/WebConfigParamsLogger.java</excludes>
+                </configuration>
+            </plugin>
+
             <!-- myfaces-build-plugin - we generate a lot of stuff with this plugin (see executions) -->
             <plugin>
                 <groupId>org.apache.myfaces.buildtools</groupId>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -75,6 +75,7 @@
                   -->
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
+                <version>2.17</version>
                 <executions>
                     <execution>
                         <id>verify-style</id>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.myfaces</groupId>
         <artifactId>myfaces</artifactId>
-        <version>16</version>
+        <version>19</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>


### PR DESCRIPTION
When I was building the site for the 2.2.13 release I ran into a number of problems since we're using git now. It was necessary to update the parent pom to 19 locally to get the 2.2.13 tag site to build properly and deployed.

Updating here so we don't have the issue going forward on the next 2.2.x release. However in order to make this change for compilation there were a number of new check styles and the poms/files had to be updated to resolve these issues.

This PR contains all the necessary changes.

1) Update pom version from 16 to 19.
2) Update check style issues found when updating number 1.
3) Updated to use 2.17 version of maven-checkstyle-plugin to be consistent with 2.3/master
4) Add period to javadoc for:
```
@JSFWebConfigParam(defaultValue="false", expectedValues="true, false", since="2.2.13", group="validation")
    private static final String EMPTY_VALUES_AS_NULL_CLEAR_INPUT_PARAM_NAME
            = "org.apache.myfaces.INTERPRET_EMPTY_STRING_SUBMITTED_VALUES_AS_NULL_CLEAR_INPUT";
```
`ERROR] Failed to execute goal org.apache.maven.plugins:maven-site-plugin:3.3:site (default-site) on project myfaces-impl: Error during page generation: Error parsing '/root/myfaces/myfacesGit22/myfaces/impl/target/generated-site/xdoc/webconfig.xml': line [519] Error parsing the model: end tag name </td> must match start tag name <p> from line 519 (position: TEXT seen ...en INTERPRET_EMPTY_STRING_SUBMITTED_VALUES_AS_NULL is enabled</td>... @519:107) -> [Help 1]`

The problem is that the description for the webconfig param ends at the first period. So in this case the generated files we're messed up b/c the first period came after a `<p>` but before `</p>`

