### PR TITLE
 MYFACES-4353 javax.faces.bean.ViewScoped cleanup 2.2.x

### DIFF
--- a/impl/src/main/java/org/apache/myfaces/webapp/ManagedBeanDestroyerListener.java
+++ b/impl/src/main/java/org/apache/myfaces/webapp/ManagedBeanDestroyerListener.java
@@ -166,6 +166,7 @@ public class ManagedBeanDestroyerListener implements
                 {
                     ServletContext servletContext = event.getSession().getServletContext();
                     ExternalContext externalContext = new StartupServletExternalContextImpl(servletContext, false);
+                    ((StartupServletExternalContextImpl)externalContext).setSession(event.getSession());
                     ExceptionHandler exceptionHandler = new ExceptionHandlerImpl();
                     facesContext = new StartupFacesContextImpl(externalContext, 
                             (ReleaseableExternalContext) externalContext, exceptionHandler, false);


### PR DESCRIPTION
Allow an `HttpSession` to be set on `StartupServletExternalContextImpl` so that `javax.faces.bean.ViewScoped` cleanup can work correctly in `DefaultViewScopeProvider`

For https://issues.apache.org/jira/browse/MYFACES-4353