### PR TITLE
Update 3.0.0 site information 

### DIFF
--- a/api/src/site/apt/index.apt
+++ b/api/src/site/apt/index.apt
@@ -1,5 +1,5 @@
  ------
- MyFaces Core 2.3: API
+ MyFaces Core 3.0: API
  ------
 
  ~~ Licensed to the Apache Software Foundation (ASF) under one
@@ -19,11 +19,10 @@
  ~~ specific language governing permissions and limitations
  ~~ under the License.
 
-MyFaces Core 2.3: API Project
+MyFaces Core 3.0: API Project
 
   The API submodule implements all of the classes that are defined in the specification.
   If you are looking for API documentation about the classes that your JSF application
   needs to use, then see the javadoc for this module.
-  
+
   Check the download page or you can check the nightly builds {{{https://repository.apache.org/content/repositories/snapshots/org/apache/myfaces/core}here}}.
-  

--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -30,7 +30,7 @@
     <artifactId>myfaces-impl</artifactId>
     <name>Apache MyFaces JSF-3.0 Core Impl</name>
     <description>
-        The private implementation classes of the Apache MyFaces Core JSF-2.3 Implementation
+        The private implementation classes of the Apache MyFaces Core JSF-3.0 Implementation
     </description>
     <url>http://myfaces.apache.org/core23/myfaces-impl</url>
 

--- a/impl/src/site/apt/index.apt
+++ b/impl/src/site/apt/index.apt
@@ -1,5 +1,5 @@
  ------
- MyFaces Core 2.3: Impl
+ MyFaces Core 3.0: Impl
  ------
 
  ~~ Licensed to the Apache Software Foundation (ASF) under one
@@ -19,7 +19,7 @@
  ~~ specific language governing permissions and limitations
  ~~ under the License.
 
-MyFaces Core 2.3: Impl Project
+MyFaces Core 3.0: Impl Project
 
   The Impl submodule implements all of the "invisible" classes that are needed for a functioning
   JSF implementation but which are not part of the public api.

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -30,7 +30,7 @@
     <packaging>pom</packaging>
     <name>Apache MyFaces JSF-3.0 Core Project</name>
     <description>
-        This project is the home of the MyFaces implementation of the JavaServer Faces 2.3 specification, and
+        This project is the home of the MyFaces implementation of the Jakarta Server Faces 3.0 specification, and
         consists of an API module (jakarta.faces.* classes) and an implementation module (org.apache.myfaces.* classes).
     </description>
     <version>3.0.0-SNAPSHOT</version>

--- a/parent/src/site/apt/index.apt
+++ b/parent/src/site/apt/index.apt
@@ -1,5 +1,5 @@
  ------
- Myfaces Core 2.3
+ MyFaces Core 3.0
  ------
 
  ~~ Licensed to the Apache Software Foundation (ASF) under one
@@ -18,13 +18,13 @@
  ~~ KIND, either express or implied.  See the License for the
  ~~ specific language governing permissions and limitations
  ~~ under the License.
- 
 
-MyFaces Core 2.3 Project
 
-  This project provides an implementation of the JavaServer Faces 2.3 (JSF 2.3) specification.
+MyFaces Core 3.0 Project
 
-    * The API submodule implements all of the classes that are defined in the specification. 
+  This project provides an implementation of the Jakarta Server Faces 3.0 (JSF (Faces) 3.0) specification.
+
+    * The API submodule implements all of the classes that are defined in the specification.
       If you are looking for API documentation about the classes that your JSF application
       needs to use, then see the javadoc for the API module.
 
@@ -34,26 +34,27 @@ MyFaces Core 2.3 Project
 
   These two libraries (myfaces-api.jar and myfaces-impl.jar) are deployed together with your
   code to form a JSF web application.
-  
-  Additionally, there are other submodules:  
-      
-    * The Shared internal submodule provides support "invisible" classes "shared" between other 
-      projects in MyFaces land like Tomahawk, Orchestra and Portlet Bridge. A copy of these 
+
+  Additionally, there are other submodules:
+
+    * The Shared internal submodule provides support "invisible" classes "shared" between other
+      projects in MyFaces land like Tomahawk, Orchestra and Portlet Bridge. A copy of these
       classes are added to Impl submodule.
-      
-    * The Bundle submodule provides both API and Impl classes into a single jar file with 
+
+    * The Bundle submodule provides both API and Impl classes into a single jar file with
       a OSGi MANIFEST.MF.
 
-  If you want to know more about how JavaServer(tm) Faces works, take a look at the documentation
+  If you want to know more about how Jakarta Server Faces works, take a look at the documentation
   referenced from the main MyFaces site.
 
 Requirements
 
-  JSF 2.3 requires java 1.8 or later, JSP 2.2, JSTL 1.2, CDI 2.0, WebSocket 1.1 and a Java Servlet 4.0 implementation.
+  JSF (Faces) 3.0 requires Java 1.8 or later, JSP (Pages) 3.0, JSTL 2.0, CDI 3.0, WebSocket 2.0 and a Jakarta Servlet 5.0 implementation.
 
 Specifications
 
-  MyFaces implements {{{https://www.jcp.org/en/jsr/detail?id=372}Java Specification Request 372}}
-  Each major release of MyFaces is certified against the Sun TCK to ensure compliance.
-  
+  MyFaces implements {{{https://jakarta.ee/specifications/faces/3.0/} EE4J Jakarta Server Faces Specification }}
+
+  As the Jakarta Server Faces 3.0 TCK has not yet been released, no certification has yet been performed to assure compliance.
+
   Check the download page or you can check the nightly builds {{{https://repository.apache.org/content/repositories/snapshots/org/apache/myfaces/core}here}}.

--- a/parent/src/site/site.xml
+++ b/parent/src/site/site.xml
@@ -28,21 +28,21 @@
         <src>img/banners/MyFaces_logo.jpg</src>
         <href>http://myfaces.apache.org/index.html</href>
     </bannerLeft>
-    
+
     <bannerRight>
         <name>Apache Banner</name>
         <src>img/banners/apache_banner.png</src>
         <href>http://www.apache.org</href>
     </bannerRight>
-    
+
     <publishDate format="dd MMM yyyy" />
-    
+
     <skin>
       	<groupId>org.apache.myfaces.maven</groupId>
       	<artifactId>myfaces-site-skin</artifactId>
       	<version>3</version>
     </skin>
-    
+
     <body>
         <links>
             <item name="Apache"         href="http://www.apache.org/"/>
@@ -55,15 +55,18 @@
         </links>
 
         <menu name="JSF Implementations" inherit="top">
-            <item name="Core JSF-2.3"   href="./index.html" collapse="false">
-              <item name="API"          href="http://myfaces.apache.org/core23/myfaces-api/index.html"/>
-              <item name="Impl"         href="http://myfaces.apache.org/core23/myfaces-impl/index.html"/>
-              <item name="Shared"       href="http://myfaces.apache.org/core23/myfaces-impl-shared/index.html"/>
-              <item name="Bundle"       href="http://myfaces.apache.org/core23/myfaces-bundle/index.html"/>
-            </item> 
+            <item name="Core JSF-3.0"   href="./index.html" collapse="false">
+              <item name="API"          href="http://myfaces.apache.org/core30/myfaces-api/index.html"/>
+              <item name="Impl"         href="http://myfaces.apache.org/core30/myfaces-impl/index.html"/>
+              <item name="Shared"       href="http://myfaces.apache.org/core30/myfaces-impl-shared/index.html"/>
+              <item name="Bundle"       href="http://myfaces.apache.org/core30/myfaces-bundle/index.html"/>
+            </item>
+            <item name="Core JSF-2.3"   href="../core23/index.html" collapse="true">
+              <item name="dummy"        href="dummy"/>
+            </item>
             <item name="Core JSF-2.2"   href="../core22/index.html" collapse="true">
               <item name="dummy"        href="dummy"/>
-            </item>        
+            </item>
             <item name="Core JSF-2.1"   href="../core21/index.html" collapse="true">
               <item name="dummy"        href="dummy"/>
             </item>
@@ -101,7 +104,7 @@
             </item>
             <item name="Others"         href="../otherProjects.html"/>
         </menu>
-        
+
         <menu name="Documentation" inherit="top">
             <item name="Quick Start"     href="http://myfaces.apache.org/wiki/core/user-guide/quick-start.html"/>
             <item name="Getting Started" href="http://myfaces.apache.org/wiki/core/user-guide/getting-started.html"/>

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
     <packaging>pom</packaging>
     <name>Apache MyFaces JSF-3.0 Core Module</name>
     <description>
-        This project is the home of the MyFaces implementation of the JavaServer Faces 2.3 specification, and
+        This project is the home of the MyFaces implementation of the Jakarta Server Faces 3.0 specification, and
         consists of an API module (jakarta.faces.* classes) and an implementation module (org.apache.myfaces.* classes).
     </description>
     <version>3.0.0-SNAPSHOT</version>
@@ -60,7 +60,7 @@
     </modules>
 
     <build>
-    
+
         <!-- Since Maven 3.0, this is required to add scpexe as protocol for deploy. -->
         <extensions>
           <extension>
@@ -87,7 +87,7 @@
           </plugins>
         </pluginManagement>
         <plugins>
-    
+
           <!-- license checker needs to exclude some kinds of files -->
           <plugin>
                 <groupId>org.apache.rat</groupId>
@@ -121,7 +121,7 @@
           </plugin>
         </plugins>
     </build>
-    
+
     <profiles>
 
         <!-- TODO jakobk: we could change this to -Papache-release -->
@@ -197,8 +197,8 @@
         </repository>
 
     </repositories>
-    
-    <!-- 
+
+    <!--
     <distributionManagement>
         <site>
             <id>apache.website</id>
@@ -208,8 +208,8 @@
     </distributionManagement>
     -->
     <!-- To deploy the site, use site:stage-deploy goal and commit changes manually on
-         https://svn.apache.org/repos/asf/myfaces/site/publish/ 
-         
+         https://svn.apache.org/repos/asf/myfaces/site/publish/
+
          -->
   <distributionManagement>
     <site>


### PR DESCRIPTION
Although the 3.0.0-RC1 has been released I had not finished the remaining steps on the [checklist](https://myfaces.apache.org/core23/release-checklist.html). 

9. Site deploy for shared and core

For the above step, I've created the the site files during the commits [in this PR and uploaded them](https://svn.apache.org/repos/asf/myfaces/site/publish/core30/).  Let me know if I should change anything or make any additional updates. 

I'm not sure if I should start referring to JSF as Faces since it's now part of EE4J, but I used both. 

Let me know if I should change the [specification link](https://jakarta.ee/specifications/faces/3.0/), too. 

Thanks 
