### PR TITLE
MYFACES-4372: String Constants and Add Deprecated Annotations  (3.0 Branch)

### DIFF
--- a/api/src/main/java/jakarta/faces/application/Application.java
+++ b/api/src/main/java/jakarta/faces/application/Application.java
@@ -364,6 +364,7 @@ public abstract class Application
      * 
      * @deprecated
      */
+    @Deprecated
     public abstract UIComponent createComponent(ValueBinding componentBinding, FacesContext context,
                     String componentType) throws FacesException;
 
@@ -481,6 +482,7 @@ public abstract class Application
      * 
      * @deprecated
      */
+    @Deprecated
     public abstract MethodBinding createMethodBinding(String ref, Class<?>[] params) throws ReferenceSyntaxException;
 
     /**
@@ -507,6 +509,7 @@ public abstract class Application
      * 
      * @deprecated
      */
+    @Deprecated
     public abstract ValueBinding createValueBinding(String ref) throws ReferenceSyntaxException;
 
     /**
@@ -798,6 +801,7 @@ public abstract class Application
      * 
      * @deprecated
      */
+    @Deprecated
     public abstract PropertyResolver getPropertyResolver();
 
     /**
@@ -886,6 +890,7 @@ public abstract class Application
      * 
      * @deprecated
      */
+    @Deprecated
     public abstract VariableResolver getVariableResolver();
 
     /**
@@ -1081,6 +1086,7 @@ public abstract class Application
      * 
      * @deprecated
      */
+    @Deprecated
     public abstract void setPropertyResolver(PropertyResolver resolver);
 
     /**
@@ -1133,6 +1139,7 @@ public abstract class Application
      * 
      * @deprecated
      */
+    @Deprecated
     public abstract void setVariableResolver(VariableResolver resolver);
 
     /**

--- a/api/src/main/java/jakarta/faces/application/ProjectStage.java
+++ b/api/src/main/java/jakarta/faces/application/ProjectStage.java
@@ -28,7 +28,7 @@ public enum ProjectStage
     SystemTest,
     UnitTest;
     
-    public static final String PROJECT_STAGE_JNDI_NAME = "java:comp/env/jsf/ProjectStage";
+    public static final String PROJECT_STAGE_JNDI_NAME = "java:comp/env/faces/ProjectStage";
 
     /**
      * 

--- a/api/src/main/java/jakarta/faces/application/StateManager.java
+++ b/api/src/main/java/jakarta/faces/application/StateManager.java
@@ -125,6 +125,7 @@ public abstract class StateManager
      * 
      * @deprecated
      */
+    @Deprecated
     public StateManager.SerializedView saveSerializedView(FacesContext context)
     {
         Object savedView = saveView(context);
@@ -176,6 +177,7 @@ public abstract class StateManager
      * 
      * @deprecated
      */
+    @Deprecated
     protected Object getTreeStructureToSave(FacesContext context)
     {
         return null;
@@ -188,6 +190,7 @@ public abstract class StateManager
      * 
      * @deprecated
      */
+    @Deprecated
     protected Object getComponentStateToSave(FacesContext context)
     {
         return null;
@@ -210,6 +213,7 @@ public abstract class StateManager
      * 
      * @deprecated
      */
+    @Deprecated
     public void writeState(FacesContext context, StateManager.SerializedView state)
         throws IOException
     {
@@ -269,6 +273,7 @@ public abstract class StateManager
     /**
      * @deprecated
      */
+    @Deprecated
     protected UIViewRoot restoreTreeStructure(FacesContext context, String viewId, String renderKitId)
     {
         return null;
@@ -277,6 +282,7 @@ public abstract class StateManager
     /**
      * @deprecated
      */
+    @Deprecated
     protected void restoreComponentState(FacesContext context, UIViewRoot viewRoot, String renderKitId)
     {
         // default impl does nothing as per JSF 1.2 javadoc
@@ -319,6 +325,7 @@ public abstract class StateManager
     /**
      * @deprecated
      */
+    @Deprecated
     public class SerializedView
     {
         private Object _structure;

--- a/api/src/main/java/jakarta/faces/component/ActionSource.java
+++ b/api/src/main/java/jakarta/faces/component/ActionSource.java
@@ -29,18 +29,25 @@ public interface ActionSource
     /**
      * @deprecated Replaced by ActionSource2.getActionExpression
      */
+    @Deprecated
     public MethodBinding getAction();
 
     /**
      * @deprecated Replaced by ActionSource2.setActionExpression
      */
+    @Deprecated
     public void setAction(MethodBinding action);
 
     /**
      * @deprecated Replaced by getActionListeners
      */
+    @Deprecated
     public MethodBinding getActionListener();
 
+    /**
+     * @deprecated  Replaced by addActionListener
+     */
+    @Deprecated
     public void setActionListener(MethodBinding actionListener);
 
     public boolean isImmediate();

--- a/api/src/main/java/jakarta/faces/component/EditableValueHolder.java
+++ b/api/src/main/java/jakarta/faces/component/EditableValueHolder.java
@@ -134,11 +134,13 @@ public interface EditableValueHolder extends ValueHolder
      * 
      * @deprecated Use getValidators() instead.
      */
+    @Deprecated
     public MethodBinding getValidator();
 
     /**
      * @deprecated Use addValidator(MethodExpressionValidaotr) instead.
      */
+    @Deprecated
     public void setValidator(MethodBinding validatorBinding);
 
     /**
@@ -148,13 +150,15 @@ public interface EditableValueHolder extends ValueHolder
      * <p>
      * This listeners is executed after all listeners in the list.
      * 
-     * @deprecated Use getValueChangeLIsteners() instead.
+     * @deprecated Use getValueChangeListeners() instead.
      */
+    @Deprecated
     public MethodBinding getValueChangeListener();
 
     /**
      * @deprecated use addValueChangeListener(MethodExpressionValueChangeListener) instead.
      */
+    @Deprecated
     public void setValueChangeListener(MethodBinding valueChangeMethod);
 
     public void addValidator(Validator validator);

--- a/api/src/main/java/jakarta/faces/component/NamingContainer.java
+++ b/api/src/main/java/jakarta/faces/component/NamingContainer.java
@@ -61,5 +61,6 @@ public interface NamingContainer
     /**
      * @deprecated Use {@link UINamingContainer#getSeparatorChar(FacesContext)}
      */
+    @Deprecated
     public static final char SEPARATOR_CHAR = ':';
 }

--- a/api/src/main/java/jakarta/faces/component/UICommand.java
+++ b/api/src/main/java/jakarta/faces/component/UICommand.java
@@ -67,6 +67,7 @@ public class UICommand extends UIComponentBase implements ActionSource2
      * 
      * @deprecated Use getActionExpression() instead.
      */
+    @Deprecated
     public MethodBinding getAction()
     {
         MethodExpression actionExpression = getActionExpression();
@@ -85,6 +86,7 @@ public class UICommand extends UIComponentBase implements ActionSource2
     /**
      * @deprecated Use setActionExpression instead.
      */
+    @Deprecated
     public void setAction(MethodBinding action)
     {
         if (action != null)
@@ -210,6 +212,7 @@ public class UICommand extends UIComponentBase implements ActionSource2
      * 
      * @deprecated
      */
+    @Deprecated
     @JSFProperty(stateHolder=true, returnSignature = "void", methodSignature = "jakarta.faces.event.ActionEvent")
     public MethodBinding getActionListener()
     {
@@ -219,6 +222,7 @@ public class UICommand extends UIComponentBase implements ActionSource2
     /**
      * @deprecated
      */
+    @Deprecated
     @JSFProperty(returnSignature="void",methodSignature="jakarta.faces.event.ActionEvent")
     public void setActionListener(MethodBinding actionListener)
     {

--- a/api/src/main/java/jakarta/faces/component/UIComponent.java
+++ b/api/src/main/java/jakarta/faces/component/UIComponent.java
@@ -102,10 +102,13 @@ public abstract class UIComponent
 
     /**
      * Constant used to store the current component that is being processed.
-     *
+     * 
      * @see #pushComponentToEL(FacesContext, UIComponent)
      * @see #popComponentFromEL(FacesContext)
+     * 
+     * @deprecated
      */
+    @Deprecated
     public static final String CURRENT_COMPONENT = "jakarta.faces.component.CURRENT_COMPONENT";
 
     /**
@@ -113,7 +116,10 @@ public abstract class UIComponent
      *
      * @see #pushComponentToEL(FacesContext, UIComponent)
      * @see #popComponentFromEL(FacesContext)
+     * 
+     * @deprecated
      */
+    @Deprecated
     public static final String CURRENT_COMPOSITE_COMPONENT = "jakarta.faces.component.CURRENT_COMPOSITE_COMPONENT";
 
     /**
@@ -367,6 +373,7 @@ public abstract class UIComponent
     /**
      * @deprecated Replaced by setValueExpression
      */
+    @Deprecated
     public abstract void setValueBinding(String name, ValueBinding binding);
 
     public void setValueExpression(String name, ValueExpression expression)
@@ -717,6 +724,7 @@ public abstract class UIComponent
     /**
      * @deprecated Replaced by getValueExpression
      */
+    @Deprecated
     public abstract ValueBinding getValueBinding(String name);
 
     public ValueExpression getValueExpression(String name)

--- a/api/src/main/java/jakarta/faces/component/UIComponentBase.java
+++ b/api/src/main/java/jakarta/faces/component/UIComponentBase.java
@@ -147,6 +147,7 @@ public abstract class UIComponentBase extends UIComponent
      * 
      * @deprecated Replaced by setValueExpression
      */
+    @Deprecated
     @Override
     public void setValueBinding(String name, ValueBinding binding)
     {
@@ -1139,6 +1140,7 @@ public abstract class UIComponentBase extends UIComponent
      * 
      * @deprecated Replaced by getValueExpression
      */
+    @Deprecated
     @Override
     public ValueBinding getValueBinding(String name)
     {

--- a/api/src/main/java/jakarta/faces/component/UIData.java
+++ b/api/src/main/java/jakarta/faces/component/UIData.java
@@ -1614,6 +1614,7 @@ public class UIData extends UIComponentBase implements NamingContainer, UniqueId
     /**
      * @deprecated This has been replaced by {@link #setValueExpression(java.lang.String, jakarta.el.ValueExpression)}.
      */
+    @Deprecated
     @Override
     public void setValueBinding(String name, ValueBinding binding)
     {

--- a/api/src/main/java/jakarta/faces/component/UIGraphic.java
+++ b/api/src/main/java/jakarta/faces/component/UIGraphic.java
@@ -71,6 +71,7 @@ public class UIGraphic extends UIComponentBase
     /**
      * @deprecated Use getValueExpression instead
      */
+    @Deprecated
     @Override
     public ValueBinding getValueBinding(String name)
     {
@@ -87,6 +88,7 @@ public class UIGraphic extends UIComponentBase
     /**
      * @deprecated Use setValueExpression instead
      */
+    @Deprecated
     @Override
     public void setValueBinding(String name, ValueBinding binding) 
     {

--- a/api/src/main/java/jakarta/faces/component/UIInput.java
+++ b/api/src/main/java/jakarta/faces/component/UIInput.java
@@ -902,6 +902,7 @@ public class UIInput extends UIOutput implements EditableValueHolder
      * 
      * @deprecated
      */
+    @Deprecated
     @SuppressWarnings("dep-ann")
     @JSFProperty(stateHolder=true, returnSignature = "void",
             methodSignature = "jakarta.faces.context.FacesContext,jakarta.faces.component.UIComponent,java.lang.Object")
@@ -914,6 +915,7 @@ public class UIInput extends UIOutput implements EditableValueHolder
      *  
      * @deprecated 
      */
+    @Deprecated
     public void setValidator(MethodBinding validator)
     {
         getStateHelper().put(PropertyKeys.validator, validator);
@@ -1018,7 +1020,9 @@ public class UIInput extends UIOutput implements EditableValueHolder
      * </p>
      * 
      * @deprecated
+     * 
      */
+    @Deprecated
     @JSFProperty(stateHolder=true, returnSignature = "void",
                  methodSignature = "jakarta.faces.event.ValueChangeEvent", clientEvent="valueChange")
     public MethodBinding getValueChangeListener()
@@ -1028,8 +1032,6 @@ public class UIInput extends UIOutput implements EditableValueHolder
 
     /**
      * See getValueChangeListener.
-     * 
-     * @deprecated
      */
     public void setValueChangeListener(MethodBinding valueChangeListener)
     {

--- a/api/src/main/java/jakarta/faces/component/UISelectBoolean.java
+++ b/api/src/main/java/jakarta/faces/component/UISelectBoolean.java
@@ -71,6 +71,7 @@ public class UISelectBoolean extends UIInput
     /**
      * @deprecated Use getValueExpression instead
      */
+    @Deprecated
     @Override
     public ValueBinding getValueBinding(String name)
     {
@@ -91,6 +92,7 @@ public class UISelectBoolean extends UIInput
     /**
      * @deprecated Use setValueExpression instead
      */
+    @Deprecated
     @Override
     public void setValueBinding(String name, ValueBinding binding)
     {

--- a/api/src/main/java/jakarta/faces/component/UISelectMany.java
+++ b/api/src/main/java/jakarta/faces/component/UISelectMany.java
@@ -90,6 +90,7 @@ public class UISelectMany extends UIInput
     /**
      * @deprecated Use getValueExpression instead
      */
+    @Deprecated
     @Override
     public ValueBinding getValueBinding(String name)
     {
@@ -110,6 +111,7 @@ public class UISelectMany extends UIInput
     /**
      * @deprecated Use setValueExpression instead
      */
+    @Deprecated
     @Override
     public void setValueBinding(String name, ValueBinding binding)
     {

--- a/api/src/main/java/jakarta/faces/component/UIViewRoot.java
+++ b/api/src/main/java/jakarta/faces/component/UIViewRoot.java
@@ -82,7 +82,7 @@ public class UIViewRoot extends UIComponentBase implements UniqueIdVendor
 {
     public static final String COMPONENT_FAMILY = "jakarta.faces.ViewRoot";
     public static final String COMPONENT_TYPE = "jakarta.faces.ViewRoot";
-    public static final String METADATA_FACET_NAME = "UIViewRoot_faces_metadata";
+    public static final String METADATA_FACET_NAME = "jakarta_faces_metadata";
     public static final String UNIQUE_ID_PREFIX = "j_id";
     public static final String VIEW_PARAMETERS_KEY = "jakarta.faces.component.VIEW_PARAMETERS_KEY";
     

--- a/api/src/main/java/jakarta/faces/el/EvaluationException.java
+++ b/api/src/main/java/jakarta/faces/el/EvaluationException.java
@@ -25,6 +25,7 @@ import jakarta.faces.FacesException;
  * 
  * @deprecated
  */
+@Deprecated
 public class EvaluationException extends FacesException
 {
     private static final long serialVersionUID = 4668524591042216006L;

--- a/api/src/main/java/jakarta/faces/el/MethodBinding.java
+++ b/api/src/main/java/jakarta/faces/el/MethodBinding.java
@@ -25,6 +25,7 @@ import jakarta.faces.context.FacesContext;
  * 
  * @deprecated
  */
+@Deprecated
 public abstract class MethodBinding
 {
 

--- a/api/src/main/java/jakarta/faces/el/MethodNotFoundException.java
+++ b/api/src/main/java/jakarta/faces/el/MethodNotFoundException.java
@@ -23,6 +23,7 @@ package jakarta.faces.el;
  * 
  * @deprecated
  */
+@Deprecated
 public class MethodNotFoundException extends EvaluationException
 {
     private static final long serialVersionUID = 7107789255726890536L;

--- a/api/src/main/java/jakarta/faces/el/PropertyNotFoundException.java
+++ b/api/src/main/java/jakarta/faces/el/PropertyNotFoundException.java
@@ -23,6 +23,7 @@ package jakarta.faces.el;
  * 
  * @deprecated
  */
+@Deprecated
 public class PropertyNotFoundException extends EvaluationException
 {
     private static final long serialVersionUID = -7271529989175141594L;

--- a/api/src/main/java/jakarta/faces/el/PropertyResolver.java
+++ b/api/src/main/java/jakarta/faces/el/PropertyResolver.java
@@ -27,6 +27,7 @@ package jakarta.faces.el;
  * 
  * @deprecated
  */
+@Deprecated
 public abstract class PropertyResolver
 {
 

--- a/api/src/main/java/jakarta/faces/el/ReferenceSyntaxException.java
+++ b/api/src/main/java/jakarta/faces/el/ReferenceSyntaxException.java
@@ -23,6 +23,7 @@ package jakarta.faces.el;
  * 
  * @deprecated
  */
+@Deprecated
 public class ReferenceSyntaxException extends EvaluationException
 {
     private static final long serialVersionUID = -2099185257291689817L;

--- a/api/src/main/java/jakarta/faces/el/ValueBinding.java
+++ b/api/src/main/java/jakarta/faces/el/ValueBinding.java
@@ -25,6 +25,7 @@ import jakarta.faces.context.FacesContext;
  * 
  * @deprecated
  */
+@Deprecated
 public abstract class ValueBinding
 {
     /**

--- a/api/src/main/java/jakarta/faces/el/VariableResolver.java
+++ b/api/src/main/java/jakarta/faces/el/VariableResolver.java
@@ -25,6 +25,7 @@ import jakarta.faces.context.FacesContext;
  * 
  * @deprecated
  */
+@Deprecated
 public abstract class VariableResolver
 {
     // FIELDS

--- a/api/src/main/java/jakarta/faces/render/ResponseStateManager.java
+++ b/api/src/main/java/jakarta/faces/render/ResponseStateManager.java
@@ -71,6 +71,7 @@ public abstract class ResponseStateManager
      * @throws IOException 
      * @deprecated
      */
+    @Deprecated
     public void writeState(FacesContext context, StateManager.SerializedView state) throws IOException
     {
         // does nothing as per JSF 1.2 javadoc
@@ -104,6 +105,7 @@ public abstract class ResponseStateManager
     /**
      * @deprecated
      */
+    @Deprecated
     public Object getTreeStructureToRestore(FacesContext context, String viewId)
     {
         return null;
@@ -112,6 +114,7 @@ public abstract class ResponseStateManager
     /**
      * @deprecated
      */
+    @Deprecated
     public Object getComponentStateToRestore(FacesContext context)
     {
         return null;

--- a/api/src/main/java/jakarta/faces/validator/Validator.java
+++ b/api/src/main/java/jakarta/faces/validator/Validator.java
@@ -30,6 +30,7 @@ public interface Validator<T> extends EventListener
     /**
      * @deprecated
      */
+    @Deprecated
     public static final String NOT_IN_RANGE_MESSAGE_ID = "jakarta.faces.validator.NOT_IN_RANGE";
 
     public void validate(FacesContext context, UIComponent component, T value) throws ValidatorException;

--- a/api/src/main/java/jakarta/faces/webapp/AttributeTag.java
+++ b/api/src/main/java/jakarta/faces/webapp/AttributeTag.java
@@ -31,6 +31,7 @@ import jakarta.servlet.jsp.tagext.TagSupport;
  * 
  * @deprecated the implementation of this clazz is now an implementation detail.
  */
+@Deprecated
 public class AttributeTag extends TagSupport
 {
     private static final long serialVersionUID = 3147657100171678632L;

--- a/api/src/main/java/jakarta/faces/webapp/ConverterTag.java
+++ b/api/src/main/java/jakarta/faces/webapp/ConverterTag.java
@@ -34,6 +34,7 @@ import jakarta.servlet.jsp.tagext.TagSupport;
  * 
  * @deprecated replaced by {@link ConverterELTag}
  */
+@Deprecated
 public class ConverterTag extends TagSupport
 {
     private static final long serialVersionUID = -6168345066829108081L;

--- a/api/src/main/java/jakarta/faces/webapp/UIComponentBodyTag.java
+++ b/api/src/main/java/jakarta/faces/webapp/UIComponentBodyTag.java
@@ -23,6 +23,7 @@ package jakarta.faces.webapp;
  * 
  * @deprecated replaced by {@link UIComponentELTag}
  */
+@Deprecated
 public abstract class UIComponentBodyTag extends UIComponentTag
 {
 

--- a/api/src/main/java/jakarta/faces/webapp/UIComponentClassicTagBase.java
+++ b/api/src/main/java/jakarta/faces/webapp/UIComponentClassicTagBase.java
@@ -752,6 +752,7 @@ public abstract class UIComponentClassicTagBase extends UIComponentTagBase imple
     /**
      * @deprecated the ResponseWriter is now set by {@link jakarta.faces.application.ViewHandler#renderView}
      */
+    @Deprecated
     protected void setupResponseWriter()
     {
     }
@@ -759,7 +760,10 @@ public abstract class UIComponentClassicTagBase extends UIComponentTagBase imple
     /**
      * Invoke encodeBegin on the associated UIComponent. Subclasses can override this method to perform custom
      * processing before or after the UIComponent method invocation.
+     * 
+     * @deprecated
      */
+    @Deprecated
     protected void encodeBegin() throws IOException
     {
         if (log.isLoggable(Level.FINE))
@@ -777,7 +781,10 @@ public abstract class UIComponentClassicTagBase extends UIComponentTagBase imple
      * Invoke encodeChildren on the associated UIComponent. Subclasses can override this method to perform custom
      * processing before or after the UIComponent method invocation. This is only invoked for components whose
      * getRendersChildren method returns true.
+     * 
+     * @deprecated
      */
+    @Deprecated
     protected void encodeChildren() throws IOException
     {
         if (log.isLoggable(Level.FINE))
@@ -794,7 +801,10 @@ public abstract class UIComponentClassicTagBase extends UIComponentTagBase imple
     /**
      * Invoke encodeEnd on the associated UIComponent. Subclasses can override this method to perform custom processing
      * before or after the UIComponent method invocation.
+     * 
+     * @deprecated
      */
+    @Deprecated
     protected void encodeEnd() throws IOException
     {
         if (log.isLoggable(Level.FINE))

--- a/api/src/main/java/jakarta/faces/webapp/UIComponentTag.java
+++ b/api/src/main/java/jakarta/faces/webapp/UIComponentTag.java
@@ -40,6 +40,7 @@ import jakarta.servlet.jsp.tagext.Tag;
  * 
  * @deprecated replaced by {@link UIComponentELTag}
  */
+@Deprecated
 public abstract class UIComponentTag extends UIComponentClassicTagBase
 {
 

--- a/api/src/main/java/jakarta/faces/webapp/ValidatorTag.java
+++ b/api/src/main/java/jakarta/faces/webapp/ValidatorTag.java
@@ -34,6 +34,7 @@ import jakarta.servlet.jsp.tagext.TagSupport;
  * 
  * @deprecated replaced by {@link ValidatorELTag}
  */
+@Deprecated
 public class ValidatorTag extends TagSupport
 {
     private static final long serialVersionUID = 8794036166323016663L;

--- a/api/src/main/resources/META-INF/componentClass20.vm
+++ b/api/src/main/resources/META-INF/componentClass20.vm
@@ -424,6 +424,7 @@ $innersource
 #end
 
 #if ($component.className.startsWith("jakarta.faces.component.html") && $overrideSetValueExpression)
+    @Deprecated
     public void setValueBinding(String name, ValueBinding binding)
     {
         super.setValueBinding(name, binding);


### PR DESCRIPTION
Few items were were caught in our TCK testing .

* String Constants
* Deprecated Annotations 

One unique location was the _setValueBinding_ within the [api/src/main/resources/META-INF/componentClass20.vm](https://github.com/apache/myfaces/pull/124/files#diff-861505f2179ead924c6d11c51cbf707ef7d2f9e650141def73d1f07004d942bbR427-R428) file
* Used to generate the jakarta.faces.component.html.Html* classes.


**String Constants Changed:**
ProjectStage#PROJECT_STAGE_JNDI_NAME
UIViewRoot#METADATA_FACET_NAME

**Newly Added Deprecations:**
ActionSource#setActionListener
UIComponent#CURRENT_COMPONENT
UIComponent#CURRENT_COMPOSITE_COMPONENT

**Removed Deprecation Comments:** 
[UIInput#setValueChangeListener](https://github.com/apache/myfaces/pull/124/files#diff-d2e7ac349a81b8fa5b9315a29dd6a66bbfbb24342f9a1b43a40e6ac7b445be63L1032-L1034)  (See Mojarra here:https://github.com/eclipse-ee4j/mojarra/blob/3.0/impl/src/main/java/jakarta/faces/component/UIInput.java#L575-L576) 

This will also be applied master next. 