### PR TITLE
MYFACES-4372 -- Fix JNDI Name & Add Deprecated Annotations (4.0 Branch)

### DIFF
--- a/api/src/main/java/jakarta/faces/application/ProjectStage.java
+++ b/api/src/main/java/jakarta/faces/application/ProjectStage.java
@@ -30,7 +30,7 @@ public enum ProjectStage
     SystemTest,
     UnitTest;
     
-    public static final String PROJECT_STAGE_JNDI_NAME = "java:comp/env/jsf/ProjectStage";
+    public static final String PROJECT_STAGE_JNDI_NAME = "java:comp/env/faces/ProjectStage";
 
     @JSFWebConfigParam(defaultValue="Production",
             expectedValues="Development, Production, SystemTest, UnitTest",

--- a/api/src/main/java/jakarta/faces/application/StateManager.java
+++ b/api/src/main/java/jakarta/faces/application/StateManager.java
@@ -266,7 +266,10 @@ public abstract class StateManager
     {
         return context.getRenderKit().getResponseStateManager().getViewState(context, saveView(context));
     }
-
+    
+    /**
+     * @deprecated
+     */
     @Deprecated
     public abstract UIViewRoot restoreView(FacesContext context, String viewId, String renderKitId);
 

--- a/api/src/main/java/jakarta/faces/application/StateManager.java
+++ b/api/src/main/java/jakarta/faces/application/StateManager.java
@@ -125,6 +125,7 @@ public abstract class StateManager
      * 
      * @deprecated
      */
+    @Deprecated
     public StateManager.SerializedView saveSerializedView(FacesContext context)
     {
         Object savedView = saveView(context);
@@ -176,6 +177,7 @@ public abstract class StateManager
      * 
      * @deprecated
      */
+    @Deprecated
     protected Object getTreeStructureToSave(FacesContext context)
     {
         return null;
@@ -188,6 +190,7 @@ public abstract class StateManager
      * 
      * @deprecated
      */
+    @Deprecated
     protected Object getComponentStateToSave(FacesContext context)
     {
         return null;
@@ -210,6 +213,7 @@ public abstract class StateManager
      * 
      * @deprecated
      */
+    @Deprecated
     public void writeState(FacesContext context, StateManager.SerializedView state)
         throws IOException
     {
@@ -269,6 +273,7 @@ public abstract class StateManager
     /**
      * @deprecated
      */
+    @Deprecated
     protected UIViewRoot restoreTreeStructure(FacesContext context, String viewId, String renderKitId)
     {
         return null;
@@ -277,6 +282,7 @@ public abstract class StateManager
     /**
      * @deprecated
      */
+    @Deprecated
     protected void restoreComponentState(FacesContext context, UIViewRoot viewRoot, String renderKitId)
     {
         // default impl does nothing as per JSF 1.2 javadoc
@@ -319,6 +325,7 @@ public abstract class StateManager
     /**
      * @deprecated
      */
+    @Deprecated
     public class SerializedView
     {
         private Object _structure;

--- a/api/src/main/java/jakarta/faces/component/NamingContainer.java
+++ b/api/src/main/java/jakarta/faces/component/NamingContainer.java
@@ -59,5 +59,6 @@ public interface NamingContainer
     /**
      * @deprecated Use {@link UINamingContainer#getSeparatorChar(jakarta.faces.context.FacesContext)}
      */
+    @Deprecated
     public static final char SEPARATOR_CHAR = ':';
 }

--- a/api/src/main/java/jakarta/faces/component/UIComponent.java
+++ b/api/src/main/java/jakarta/faces/component/UIComponent.java
@@ -102,7 +102,10 @@ public abstract class UIComponent
      *
      * @see #pushComponentToEL(FacesContext, UIComponent)
      * @see #popComponentFromEL(FacesContext)
+     * 
+     *  @deprecated
      */
+    @Deprecated
     public static final String CURRENT_COMPONENT = "jakarta.faces.component.CURRENT_COMPONENT";
 
     /**
@@ -110,7 +113,10 @@ public abstract class UIComponent
      *
      * @see #pushComponentToEL(FacesContext, UIComponent)
      * @see #popComponentFromEL(FacesContext)
+     * 
+     * @deprecated
      */
+    @Deprecated
     public static final String CURRENT_COMPOSITE_COMPONENT = "jakarta.faces.component.CURRENT_COMPOSITE_COMPONENT";
 
     /**

--- a/api/src/main/java/jakarta/faces/render/ResponseStateManager.java
+++ b/api/src/main/java/jakarta/faces/render/ResponseStateManager.java
@@ -72,6 +72,7 @@ public abstract class ResponseStateManager
      * @throws IOException 
      * @deprecated
      */
+    @Deprecated
     public void writeState(FacesContext context, StateManager.SerializedView state) throws IOException
     {
         // does nothing as per JSF 1.2 javadoc


### PR DESCRIPTION
Similar to PR #124

4.0 already has a number of deprecated functions removed, so that's why the number of annotations
 is much smaller. 

Few Notes:
- api/src/main/resources/META-INF/componentClass20.vm already had setValueBinding removed
- StateManager#restoreView was missing deprecated comment
- UIViewRoot#METADATA_FACET_NAME was already properly set

https://issues.apache.org/jira/browse/MYFACES-4372