### PR TITLE
Only Support Faces Version 3.0  During Validations

### DIFF
--- a/impl/src/main/resources/org/apache/myfaces/resource/web-facesconfig_3_0.xsd
+++ b/impl/src/main/resources/org/apache/myfaces/resource/web-facesconfig_3_0.xsd
@@ -835,14 +835,19 @@
         <xsd:attribute name="id" type="xsd:ID"/>
     </xsd:complexType>
 
-    <xsd:simpleType name="faces-config-versionType">
-        <xsd:restriction base="xsd:token">
-            <xsd:enumeration value="1.2"/>
-            <xsd:enumeration value="2.0"/>
-            <xsd:enumeration value="2.1"/>
-            <xsd:enumeration value="2.2"/>
-            <xsd:enumeration value="2.3"/>
-        </xsd:restriction>
-    </xsd:simpleType>
-
+  <xsd:simpleType name="faces-config-versionType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> This type contains the recognized versions of
+        faces-config supported.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="3.0"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  
 </xsd:schema>


### PR DESCRIPTION
Supported Faces Versions needs an update somewhere because the current web-facesconfig_3_0.xsd doesn't support version 3.0. 

See https://issues.apache.org/jira/browse/MYFACES-4374

This fix is one option. The other is #144

Code was taken from the https://jakarta.ee/xml/ns/jakartaee/web-facesconfig_3_0.xsd 