### PR TITLE
Support Range of Versions During Validations

### DIFF
--- a/impl/src/main/resources/org/apache/myfaces/resource/web-facesconfig_3_0.xsd
+++ b/impl/src/main/resources/org/apache/myfaces/resource/web-facesconfig_3_0.xsd
@@ -842,6 +842,7 @@
             <xsd:enumeration value="2.1"/>
             <xsd:enumeration value="2.2"/>
             <xsd:enumeration value="2.3"/>
+            <xsd:enumeration value="3.0"/>
         </xsd:restriction>
     </xsd:simpleType>
 


### PR DESCRIPTION
The supported Faces Config versions need an update because the current `web-facesconfig_3_0.xsd `doesn't specifically support version 3.0.

See https://issues.apache.org/jira/browse/MYFACES-4374

This fix is one option.  Otherwise, see #143

