### PR TITLE
[Draft] Testing Travis Builds in 3.0.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,5 +32,6 @@ matrix:
   allow_failures:
     - jdk: openjdk-ea
 
+
 script:
   - mvn clean test

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Apache MyFaces Core
-[![Build Status](https://travis-ci.org/apache/myfaces.svg?branch=3.0.x)](https://travis-ci.org/apache/myfaces)
+[![Build Status](https://travis-ci.com/apache/myfaces.svg?branch=3.0.x)](https://travis-ci.org/apache/myfaces)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
 Apache's implementation of the JavaServer Faces (JSF) and Jakarta Faces specification


### PR DESCRIPTION
Trying to exclude jdks in the PRs, so only openjdk8 runs

Otherwise, cron jobs should run daily and build with every jdk listed. 