### PR TITLE
Exclude jdks & linux-ppc64le from Travis CI  PR Builds (master branch)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,15 @@ jdk:
   - openjdk-ea
 
 matrix:
+  exclude:
+    - if: type = pull_request
+      jdk: openjdk11
+    - if: type = pull_request
+      jdk: openjdk13
+    - if: type = pull_request
+      jdk: openjdk-ea
+    - if: type = pull_request
+      os: linux-ppc64le
   include:
     - os: linux-ppc64le
       jdk: openjdk8


### PR DESCRIPTION
3.0.x Travis Builds are queued and not executing. I'm not sure why, but I'm looking into it. 

For now, I'm testing the exclusions on master branch.  