### PR TITLE
Update maven-assembly-plugin to version 2.5.4

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -238,6 +238,11 @@
                 </plugin>
                 <plugin>
                   <groupId>org.apache.maven.plugins</groupId>
+                  <artifactId>>maven-assembly-plugin</artifactId>
+                  <version>2.5.4</version>
+                </plugin>
+                <plugin>
+                  <groupId>org.apache.maven.plugins</groupId>
                   <artifactId>maven-gpg-plugin</artifactId>
                   <version>1.6</version>
                 </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -91,6 +91,11 @@
               <version>2.5.3</version>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>>maven-assembly-plugin</artifactId>
+                <version>2.5.4</version>
+            </plugin>
+            <plugin>
               <groupId>org.apache.maven.plugins</groupId>
               <artifactId>maven-gpg-plugin</artifactId>
               <version>1.6</version>


### PR DESCRIPTION
As part of the last release to get the old site generation to function I had to make the following updates: https://github.com/apache/myfaces/pull/112

Now for this release I'm getting the following error:

> [INFO] [INFO] BUILD FAILURE
> [INFO] [INFO] ------------------------------------------------------------------------
> [INFO] [INFO] Total time: 03:41 min
> [INFO] [INFO] Finished at: 2021-02-03T10:55:42-05:00
> [INFO] [INFO] Final Memory: 106M/453M
> [INFO] [INFO] ------------------------------------------------------------------------
> [INFO] [ERROR] Failed to execute goal org.apache.maven.plugins:maven-assembly-plugin:2.2.1:attached (make_assembly_src) on project myfaces-core-assembly: Failed to create assembly: Error creating assembly archive coresrc: posix is not a legal value for this attribute -> [Help 1]

I had previously hit something different in the 2.3.x branch and had to make similar updates:  https://github.com/apache/myfaces/pull/44

I'd like to merge this and see if I can get any further in the release process for 2.2.14 or if additional updates are necessary.
