### PR TITLE
MYFACES-4380 LambdaBeanELResolver: Fix PropertyNotFoundException condition

### DIFF
--- a/impl/src/main/java/org/apache/myfaces/el/resolver/LambdaBeanELResolver.java
+++ b/impl/src/main/java/org/apache/myfaces/el/resolver/LambdaBeanELResolver.java
@@ -156,7 +156,7 @@ public class LambdaBeanELResolver extends BeanELResolver
         }
 
         PropertyDescriptorWrapper pd = beanCache.get((String) property);
-        if (property == null)
+        if (pd == null)
         {
             throw new PropertyNotFoundException("Property [" + property
                     + "] not found on type [" + base.getClass().getName() + "]");


### PR DESCRIPTION
PropertyNotFoundException was thrown if the name of the poperty requested was null, but it should really be thrown when the property itself is not found.  This patch changes the nullness check accordingly.

Before:

    java.lang.NullPointerException: Cannot invoke "org.apache.myfaces.core.api.shared.lang.PropertyDescriptorWrapper.getWrapped()" because "pd" is null
	at org.apache.myfaces.el.resolver.LambdaBeanELResolver.getValue(LambdaBeanELResolver.java:78)
	at javax.el.CompositeELResolver.getValue(CompositeELResolver.java:136)

After:

    javax.el.PropertyNotFoundException: Property [x] not found on type [com.example.FooBar_ClientProxy]
	at org.apache.myfaces.el.resolver.LambdaBeanELResolver.getPropertyDescriptor(LambdaBeanELResolver.java:162)
	at org.apache.myfaces.el.resolver.LambdaBeanELResolver.getValue(LambdaBeanELResolver.java:72)
	at javax.el.CompositeELResolver.getValue(CompositeELResolver.java:136)