### PR TITLE
MYFACES-4382: Add check if SessionScope is active.

### DIFF
--- a/impl/src/main/java/org/apache/myfaces/cdi/impl/CDIManagedBeanHandlerImpl.java
+++ b/impl/src/main/java/org/apache/myfaces/cdi/impl/CDIManagedBeanHandlerImpl.java
@@ -106,7 +106,8 @@ public class CDIManagedBeanHandlerImpl extends ViewScopeProvider
         FacesContext facesContext = FacesContext.getCurrentInstance();
         if (facesContext != null)
         {
-            if (facesContext.getExternalContext().getSession(false) != null)
+            if (facesContext.getExternalContext().getSession(false) != null &&
+                    CDIUtils.isSessionScopeActive(beanManager))
             {
                 if (isViewScopeBeanHolderCreated(facesContext))
                 {


### PR DESCRIPTION
This avoids "@SessionScoped does not exist within current thread" when
trying to destroy ViewScoped and FlowScoped beans.

Signed-off-by: Juri Berlanda <juri.berlanda@tuwien.ac.at>