### PR TITLE
MYFACES-4382: Add check if SessionScope is active.

### DIFF
--- a/impl/src/main/java/org/apache/myfaces/cdi/view/CDIViewScopeProviderImpl.java
+++ b/impl/src/main/java/org/apache/myfaces/cdi/view/CDIViewScopeProviderImpl.java
@@ -100,7 +100,8 @@ public class CDIViewScopeProviderImpl extends ViewScopeProvider
     
     private boolean isViewScopeBeanHolderCreated(FacesContext facesContext)
     {
-        if (facesContext.getExternalContext().getSession(false) == null)
+        if (facesContext.getExternalContext().getSession(false) == null ||
+                !CDIUtils.isSessionScopeActive(beanManager))
         {
             return false;
         }


### PR DESCRIPTION
This avoids "@SessionScoped does not exist within current thread" when
trying to destroy ViewScoped and FlowScoped beans.

Signed-off-by: Juri Berlanda <juri.berlanda@tuwien.ac.at>

*NOTE*: Please be aware, that this PR differs slightly from the other 3 PRs (i.e. #181,  #182, and #183).