### PR TITLE
Rollback 2.3-next-M6 assembly pom.xml

### DIFF
--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.myfaces.core</groupId>
         <artifactId>myfaces-core-project</artifactId>
-        <version>2.3-next-M6</version>
+        <version>2.3-next-SNAPSHOT</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
The release rollback didn't look to update the assembly pom.xml that was updated during the release.