### PR TITLE
Fix wrong translation of DoubleRangeValidator

### DIFF
--- a/api/src/main/resources/jakarta/faces/Messages_pt.properties
+++ b/api/src/main/resources/jakarta/faces/Messages_pt.properties
@@ -82,7 +82,7 @@ jakarta.faces.validator.NOT_IN_RANGE = Erro de valida\u00e7\u00e3o: O atributo e
 
 jakarta.faces.validator.DoubleRangeValidator.MAXIMUM = {1}: Erro de valida\u00e7\u00e3o: O valor \u00e9 maior que o m\u00e1ximo permitido de ''{0}''.
 jakarta.faces.validator.DoubleRangeValidator.MINIMUM = {1}: Erro de valida\u00e7\u00e3o: O valor \u00e9 menor que o m\u00ednimo permitido de ''{0}''.
-jakarta.faces.validator.DoubleRangeValidator.NOT_IN_RANGE = {2}: Erro de valida\u00e7\u00e3o: O valor especificado n\u00e3o est\u00e1 entre os valores esperados {0} e {1}.
+jakarta.faces.validator.DoubleRangeValidator.NOT_IN_RANGE = {2}: Erro de valida\u00e7\u00e3o: O atributo especificado n\u00e3o est\u00e1 entre os valores esperados {0} e {1}.
 jakarta.faces.validator.DoubleRangeValidator.TYPE = {0}: Erro de valida\u00e7\u00e3o: O valor n\u00e3o \u00e9 do tipo correto.
 
 jakarta.faces.validator.LengthValidator.MAXIMUM = {1}: Erro de valida\u00e7\u00e3o: O valor \u00e9 mais longo do que o m\u00e1ximo permitido de {0} caracteres.

--- a/api/src/main/resources/jakarta/faces/Messages_pt.properties
+++ b/api/src/main/resources/jakarta/faces/Messages_pt.properties
@@ -82,7 +82,7 @@ jakarta.faces.validator.NOT_IN_RANGE = Erro de valida\u00e7\u00e3o: O atributo e
 
 jakarta.faces.validator.DoubleRangeValidator.MAXIMUM = {1}: Erro de valida\u00e7\u00e3o: O valor \u00e9 maior que o m\u00e1ximo permitido de ''{0}''.
 jakarta.faces.validator.DoubleRangeValidator.MINIMUM = {1}: Erro de valida\u00e7\u00e3o: O valor \u00e9 menor que o m\u00ednimo permitido de ''{0}''.
-jakarta.faces.validator.DoubleRangeValidator.NOT_IN_RANGE = {2}: Erro de valida\u00e7\u00e3o: O atributo especificado n\u00e3o pode ser convertido para o tipo apropriado.
+jakarta.faces.validator.DoubleRangeValidator.NOT_IN_RANGE = {2}: Erro de valida\u00e7\u00e3o: O valor especificado n\u00e3o est\u00e1 entre os valores esperados {0} e {1}.
 jakarta.faces.validator.DoubleRangeValidator.TYPE = {0}: Erro de valida\u00e7\u00e3o: O valor n\u00e3o \u00e9 do tipo correto.
 
 jakarta.faces.validator.LengthValidator.MAXIMUM = {1}: Erro de valida\u00e7\u00e3o: O valor \u00e9 mais longo do que o m\u00e1ximo permitido de {0} caracteres.


### PR DESCRIPTION
Fix translation on jakarta.faces.validator.DoubleRangeValidator.NOT_IN_RANGE