### PR TITLE
Fix translation of DoubleRangeValidator

### DIFF
--- a/api/src/main/resources/jakarta/faces/Messages_pt.properties
+++ b/api/src/main/resources/jakarta/faces/Messages_pt.properties
@@ -82,7 +82,7 @@ jakarta.faces.validator.NOT_IN_RANGE = Erro de valida\u00E7\u00E3o: O atributo e
 
 jakarta.faces.validator.DoubleRangeValidator.MAXIMUM = {1}: Erro de valida\u00E7\u00E3o: O valor \u00E9 maior que o m\u00E1ximo permitido de ''{0}''.
 jakarta.faces.validator.DoubleRangeValidator.MINIMUM = {1}: Erro de valida\u00E7\u00E3o: O valor \u00E9 menor que o m\u00EDnimo permitido de ''{0}''.
-jakarta.faces.validator.DoubleRangeValidator.NOT_IN_RANGE = {2}: Erro de valida\u00E7\u00E3o: O atributo especificado n\u00E3o pode ser convertido para o tipo apropriado.
+jakarta.faces.validator.DoubleRangeValidator.NOT_IN_RANGE = {2}: Erro de valida\u00e7\u00e3o: O atributo especificado n\u00e3o est\u00e1 entre os valores esperados {0} e {1}.
 jakarta.faces.validator.DoubleRangeValidator.TYPE = {0}: Erro de valida\u00E7\u00E3o: O valor n\u00E3o \u00E9 do tipo correto.
 
 jakarta.faces.validator.LengthValidator.MAXIMUM = {1}: Erro de valida\u00E7\u00E3o: O valor \u00E9 mais longo do que o m\u00E1ximo permitido de {0} caracteres.

--- a/api/src/main/resources/jakarta/faces/Messages_pt_BR.properties
+++ b/api/src/main/resources/jakarta/faces/Messages_pt_BR.properties
@@ -88,7 +88,7 @@ jakarta.faces.validator.DoubleRangeValidator.MAXIMUM_detail = {1}: O valor \u00e
 jakarta.faces.validator.DoubleRangeValidator.MINIMUM        = Erro de valida\u00e7\u00e3o
 jakarta.faces.validator.DoubleRangeValidator.MINIMUM_detail = {1}: O valor \u00e9 menor que o m\u00ednimo permitido de ''{0}''.
 jakarta.faces.validator.DoubleRangeValidator.NOT_IN_RANGE        = Erro de valida\u00e7\u00e3o
-jakarta.faces.validator.DoubleRangeValidator.NOT_IN_RANGE_detail = O atributo especificado n\u00e3o pode ser convertido para o tipo apropriado.
+jakarta.faces.validator.DoubleRangeValidator.NOT_IN_RANGE_detail = {2}: Erro de valida\u00e7\u00e3o: O atributo especificado n\u00e3o est\u00e1 entre os valores esperados {0} e {1}.
 jakarta.faces.validator.DoubleRangeValidator.TYPE        = Erro de valida\u00e7\u00e3o
 jakarta.faces.validator.DoubleRangeValidator.TYPE_detail = {0}: O valor n\u00e3o \u00e9 do tipo correto.
 


### PR DESCRIPTION
Fix translation of jakarta.faces.validator.DoubleRangeValidator.NOT_IN_RANGE on api/src/main/resources/jakarta/faces/Messages_pt.properties and api/src/main/resources/jakarta/faces/Messages_pt_BR.properties 