### PR TITLE
Fix translation on Messages_pt.properties

### DIFF
--- a/api/src/main/resources/javax/faces/Messages_pt.properties
+++ b/api/src/main/resources/javax/faces/Messages_pt.properties
@@ -82,7 +82,7 @@ javax.faces.validator.NOT_IN_RANGE = Erro de valida\u00e7\u00e3o: O atributo esp
 
 javax.faces.validator.DoubleRangeValidator.MAXIMUM = {1}: Erro de valida\u00e7\u00e3o: O valor \u00e9 maior que o m\u00e1ximo permitido de ''{0}''.
 javax.faces.validator.DoubleRangeValidator.MINIMUM = {1}: Erro de valida\u00e7\u00e3o: O valor \u00e9 menor que o m\u00ednimo permitido de ''{0}''.
-javax.faces.validator.DoubleRangeValidator.NOT_IN_RANGE = {2}: Erro de valida\u00e7\u00e3o: O atributo especificado n\u00e3o pode ser convertido para o tipo apropriado.
+javax.faces.validator.DoubleRangeValidator.NOT_IN_RANGE = {2}: Erro de valida\u00e7\u00e3o: O atributo especificado n\u00e3o est\u00e1 entre os valores esperados {0} e {1}.
 javax.faces.validator.DoubleRangeValidator.TYPE = {0}: Erro de valida\u00e7\u00e3o: O valor n\u00e3o \u00e9 do tipo correto.
 
 javax.faces.validator.LengthValidator.MAXIMUM = {1}: Erro de valida\u00e7\u00e3o: O valor \u00e9 mais longo do que o m\u00e1ximo permitido de {0} caracteres.


### PR DESCRIPTION
Fix translation of javax.faces.validator.DoubleRangeValidator.NOT_IN_RANGE on Messages_pt.properties