### PR TITLE
Fix translation of DoubleRangeValidator

### DIFF
--- a/api/src/main/resources/javax/faces/Messages_pt.properties
+++ b/api/src/main/resources/javax/faces/Messages_pt.properties
@@ -82,7 +82,7 @@ javax.faces.validator.NOT_IN_RANGE = Erro de valida\u00E7\u00E3o: O atributo esp
 
 javax.faces.validator.DoubleRangeValidator.MAXIMUM = {1}: Erro de valida\u00E7\u00E3o: O valor \u00E9 maior que o m\u00E1ximo permitido de ''{0}''.
 javax.faces.validator.DoubleRangeValidator.MINIMUM = {1}: Erro de valida\u00E7\u00E3o: O valor \u00E9 menor que o m\u00EDnimo permitido de ''{0}''.
-javax.faces.validator.DoubleRangeValidator.NOT_IN_RANGE = {2}: Erro de valida\u00E7\u00E3o: O atributo especificado n\u00E3o pode ser convertido para o tipo apropriado.
+javax.faces.validator.DoubleRangeValidator.NOT_IN_RANGE = {2}: Erro de valida\u00e7\u00e3o: O atributo especificado n\u00e3o est\u00e1 entre os valores esperados {0} e {1}.
 javax.faces.validator.DoubleRangeValidator.TYPE = {0}: Erro de valida\u00E7\u00E3o: O valor n\u00E3o \u00E9 do tipo correto.
 
 javax.faces.validator.LengthValidator.MAXIMUM = {1}: Erro de valida\u00E7\u00E3o: O valor \u00E9 mais longo do que o m\u00E1ximo permitido de {0} caracteres.

--- a/api/src/main/resources/javax/faces/Messages_pt_BR.properties
+++ b/api/src/main/resources/javax/faces/Messages_pt_BR.properties
@@ -15,119 +15,119 @@
 # standard messages (Spec. 2.5.2.4)
 
 # components
-javax.faces.component.UIInput.CONVERSION        = Erro de convers„o
-javax.faces.component.UIInput.CONVERSION_detail = {0}: Ocorreu um erro de convers„o.
-javax.faces.component.UIInput.REQUIRED        = Erro de validaÁ„o
-javax.faces.component.UIInput.REQUIRED_detail = {0}: Um valor È requerido.
-javax.faces.component.UIInput.UPDATE = {0}: Erro ao processar a informaÁ„o apresentada.
+javax.faces.component.UIInput.CONVERSION        = Erro de convers√£o
+javax.faces.component.UIInput.CONVERSION_detail = {0}: Ocorreu um erro de convers√£o.
+javax.faces.component.UIInput.REQUIRED        = Erro de valida√ß√£o
+javax.faces.component.UIInput.REQUIRED_detail = {0}: Um valor √© requerido.
+javax.faces.component.UIInput.UPDATE = {0}: Erro ao processar a informa√ß√£o apresentada.
 
-javax.faces.component.UISelectOne.INVALID        = Erro de validaÁ„o
-javax.faces.component.UISelectOne.INVALID_detail = {0}: O valor n„o È uma opÁ„o v·lida.
-javax.faces.component.UISelectMany.INVALID        = Erro de validaÁ„o
-javax.faces.component.UISelectMany.INVALID_detail = {0}: O valor n„o È uma opÁ„o v·lida.
+javax.faces.component.UISelectOne.INVALID        = Erro de valida√ß√£o
+javax.faces.component.UISelectOne.INVALID_detail = {0}: O valor n√£o √© uma op√ß√£o v√°lida.
+javax.faces.component.UISelectMany.INVALID        = Erro de valida√ß√£o
+javax.faces.component.UISelectMany.INVALID_detail = {0}: O valor n√£o √© uma op√ß√£o v√°lida.
 
 # converters
-javax.faces.converter.BigDecimalConverter.DECIMAL        = Erro de convers„o
-javax.faces.converter.BigDecimalConverter.DECIMAL_detail = {2}: O valor especificado n„o È um n˙mero v·lido.
+javax.faces.converter.BigDecimalConverter.DECIMAL        = Erro de convers√£o
+javax.faces.converter.BigDecimalConverter.DECIMAL_detail = {2}: O valor especificado n√£o √© um n√∫mero v√°lido.
 
-javax.faces.converter.BigIntegerConverter.BIGINTEGER        = Erro de convers„o
-javax.faces.converter.BigIntegerConverter.BIGINTEGER_detail = {2}: O valor especificado n„o È um n˙mero v·lido.
+javax.faces.converter.BigIntegerConverter.BIGINTEGER        = Erro de convers√£o
+javax.faces.converter.BigIntegerConverter.BIGINTEGER_detail = {2}: O valor especificado n√£o √© um n√∫mero v√°lido.
 
-javax.faces.converter.BooleanConverter.BOOLEAN        = Erro de convers„o
-javax.faces.converter.BooleanConverter.BOOLEAN_detail = {1}: ImpossÌvel converter '{0}' para Boolean.
+javax.faces.converter.BooleanConverter.BOOLEAN        = Erro de convers√£o
+javax.faces.converter.BooleanConverter.BOOLEAN_detail = {1}: Imposs√≠vel converter '{0}' para Boolean.
 
-javax.faces.converter.ByteConverter.BYTE        = Erro de convers„o
-javax.faces.converter.ByteConverter.BYTE_detail = {2}: ImpossÌvel converter '{0}' para Byte.
+javax.faces.converter.ByteConverter.BYTE        = Erro de convers√£o
+javax.faces.converter.ByteConverter.BYTE_detail = {2}: Imposs√≠vel converter '{0}' para Byte.
 
-javax.faces.converter.CharacterConverter.CHARACTER        = Erro de convers„o
-javax.faces.converter.CharacterConverter.CHARACTER_detail = {1}: N„o foi possÌvel converter '{0}' para caracter.
+javax.faces.converter.CharacterConverter.CHARACTER        = Erro de convers√£o
+javax.faces.converter.CharacterConverter.CHARACTER_detail = {1}: N√£o foi poss√≠vel converter '{0}' para caracter.
 
-javax.faces.converter.DateTimeConverter.DATE = {2}: ''{0}'' n„o pode ser entendida como uma data.
-javax.faces.converter.DateTimeConverter.DATE_detail = {2}: ''{0}'' n„o pode ser entendida como uma data. Exemplo: {1}
-javax.faces.converter.DateTimeConverter.TIME = {2}: ''{0}'' n„o pode ser entendida como um tempo.
-javax.faces.converter.DateTimeConverter.TIME_detail = {2}: ''{0}'' n„o pode ser entendida como um tempo. Exemplo: {1}
-javax.faces.converter.DateTimeConverter.DATETIME = {2}: ''{0}'' n„o pode ser entendida como uma data e hora.
-javax.faces.converter.DateTimeConverter.DATETIME_detail = {2}: ''{0}'' n„o pode ser entendida como uma data e hora. Exemplo: {1}
+javax.faces.converter.DateTimeConverter.DATE = {2}: ''{0}'' n√£o pode ser entendida como uma data.
+javax.faces.converter.DateTimeConverter.DATE_detail = {2}: ''{0}'' n√£o pode ser entendida como uma data. Exemplo: {1}
+javax.faces.converter.DateTimeConverter.TIME = {2}: ''{0}'' n√£o pode ser entendida como um tempo.
+javax.faces.converter.DateTimeConverter.TIME_detail = {2}: ''{0}'' n√£o pode ser entendida como um tempo. Exemplo: {1}
+javax.faces.converter.DateTimeConverter.DATETIME = {2}: ''{0}'' n√£o pode ser entendida como uma data e hora.
+javax.faces.converter.DateTimeConverter.DATETIME_detail = {2}: ''{0}'' n√£o pode ser entendida como uma data e hora. Exemplo: {1}
 javax.faces.converter.DateTimeConverter.PATTERN_TYPE = {1}: 'pattern' ou 'type' atributo deve ser especificado para converter o valor ''{0}''.
 
-javax.faces.converter.DoubleConverter.DOUBLE        = Erro de convers„o
-javax.faces.converter.DoubleConverter.DOUBLE_detail = {2}: O valor especificado n„o È um n˙mero v·lido.
+javax.faces.converter.DoubleConverter.DOUBLE        = Erro de convers√£o
+javax.faces.converter.DoubleConverter.DOUBLE_detail = {2}: O valor especificado n√£o √© um n√∫mero v√°lido.
 
 javax.faces.converter.EnumConverter.ENUM = {2}: ''{0}'' deve ser convertida para um enum.
-javax.faces.converter.EnumConverter.ENUM_detail = {2}: ''{0}'' deve ser conversÌvel para um enum do enum que contÈm a constante ''{1}''.
-javax.faces.converter.EnumConverter.ENUM_NO_CLASS = {1}: ''{0}'' deve ser conversÌvel para um enum do enum, mas nenhuma classe enum prestados.
-javax.faces.converter.EnumConverter.ENUM_NO_CLASS_detail = {1}: ''{0}'' deve ser conversÌvel para um enum do enum, mas nenhuma classe enum prestados.
+javax.faces.converter.EnumConverter.ENUM_detail = {2}: ''{0}'' deve ser convers√≠vel para um enum do enum que cont√©m a constante ''{1}''.
+javax.faces.converter.EnumConverter.ENUM_NO_CLASS = {1}: ''{0}'' deve ser convers√≠vel para um enum do enum, mas nenhuma classe enum prestados.
+javax.faces.converter.EnumConverter.ENUM_NO_CLASS_detail = {1}: ''{0}'' deve ser convers√≠vel para um enum do enum, mas nenhuma classe enum prestados.
 
-javax.faces.converter.FloatConverter.FLOAT        = Erro de convers„o
-javax.faces.converter.FloatConverter.FLOAT_detail = {2}: O valor especificado n„o È um n˙mero v·lido.
+javax.faces.converter.FloatConverter.FLOAT        = Erro de convers√£o
+javax.faces.converter.FloatConverter.FLOAT_detail = {2}: O valor especificado n√£o √© um n√∫mero v√°lido.
 
-javax.faces.converter.IntegerConverter.INTEGER        = Erro de convers„o
-javax.faces.converter.IntegerConverter.INTEGER_detail = {2}: O valor especificado n„o È um n˙mero v·lido.
+javax.faces.converter.IntegerConverter.INTEGER        = Erro de convers√£o
+javax.faces.converter.IntegerConverter.INTEGER_detail = {2}: O valor especificado n√£o √© um n√∫mero v√°lido.
 
-javax.faces.converter.LongConverter.LONG        = Erro de convers„o
-javax.faces.converter.LongConverter.LONG_detail = {2}: O valor especificado n„o È um n˙mero v·lido.
+javax.faces.converter.LongConverter.LONG        = Erro de convers√£o
+javax.faces.converter.LongConverter.LONG_detail = {2}: O valor especificado n√£o √© um n√∫mero v√°lido.
 
-javax.faces.converter.NumberConverter.CURRENCY = {2}: ''{0}'' n„o pode ser entendida como um valor monet·rio.
-javax.faces.converter.NumberConverter.CURRENCY_detail = {2}: ''{0}'' n„o pode ser entendida como um valor monet·rio. Exemplo: {1}
-javax.faces.converter.NumberConverter.PERCENT = {2}: ''{0}'' n„o pode ser entendida como uma porcentagem.
-javax.faces.converter.NumberConverter.PERCENT_detail = {2}: ''{0}'' n„o pode ser entendida como uma porcentagem. Exemplo: {1}
-javax.faces.converter.NumberConverter.NUMBER = {2}: ''{0}'' n„o È um n˙mero.
-javax.faces.converter.NumberConverter.NUMBER_detail = {2}: ''{0}'' n„o È um n˙mero. Exemplo: {1}
-javax.faces.converter.NumberConverter.PATTERN = {2}: ''{0}'' n„o È um padr„o de n˙mero.
-javax.faces.converter.NumberConverter.PATTERN_detail = {2}: ''{0}'' n„o È um padr„o de n˙mero. Exemplo: {1}
+javax.faces.converter.NumberConverter.CURRENCY = {2}: ''{0}'' n√£o pode ser entendida como um valor monet√°rio.
+javax.faces.converter.NumberConverter.CURRENCY_detail = {2}: ''{0}'' n√£o pode ser entendida como um valor monet√°rio. Exemplo: {1}
+javax.faces.converter.NumberConverter.PERCENT = {2}: ''{0}'' n√£o pode ser entendida como uma porcentagem.
+javax.faces.converter.NumberConverter.PERCENT_detail = {2}: ''{0}'' n√£o pode ser entendida como uma porcentagem. Exemplo: {1}
+javax.faces.converter.NumberConverter.NUMBER = {2}: ''{0}'' n√£o √© um n√∫mero.
+javax.faces.converter.NumberConverter.NUMBER_detail = {2}: ''{0}'' n√£o √© um n√∫mero. Exemplo: {1}
+javax.faces.converter.NumberConverter.PATTERN = {2}: ''{0}'' n√£o √© um padr√£o de n√∫mero.
+javax.faces.converter.NumberConverter.PATTERN_detail = {2}: ''{0}'' n√£o √© um padr√£o de n√∫mero. Exemplo: {1}
 
-javax.faces.converter.ShortConverter.SHORT        = Erro de convers„o
-javax.faces.converter.ShortConverter.SHORT_detail = {2}: O valor especificado n„o È um n˙mero v·lido.
+javax.faces.converter.ShortConverter.SHORT        = Erro de convers√£o
+javax.faces.converter.ShortConverter.SHORT_detail = {2}: O valor especificado n√£o √© um n√∫mero v√°lido.
 
 # validators
-javax.faces.validator.NOT_IN_RANGE        = Erro de validaÁ„o
-javax.faces.validator.NOT_IN_RANGE_detail = {2}: O atributo especificador n„o est· entre os valores esperados {0} e {1}.
+javax.faces.validator.NOT_IN_RANGE        = Erro de valida√ß√£o
+javax.faces.validator.NOT_IN_RANGE_detail = {2}: O atributo especificador n√£o est√° entre os valores esperados {0} e {1}.
 
-javax.faces.validator.DoubleRangeValidator.MAXIMUM        = Erro de validaÁ„o
-javax.faces.validator.DoubleRangeValidator.MAXIMUM_detail = {1}: O valor È maior que o m·ximo permitido de ''{0}''.
-javax.faces.validator.DoubleRangeValidator.MINIMUM        = Erro de validaÁ„o
-javax.faces.validator.DoubleRangeValidator.MINIMUM_detail = {1}: O valor È menor que o mÌnimo permitido de ''{0}''.
-javax.faces.validator.DoubleRangeValidator.NOT_IN_RANGE        = Erro de validaÁ„o
-javax.faces.validator.DoubleRangeValidator.NOT_IN_RANGE_detail = O atributo especificado n„o pode ser convertido para o tipo apropriado.
-javax.faces.validator.DoubleRangeValidator.TYPE        = Erro de validaÁ„o
-javax.faces.validator.DoubleRangeValidator.TYPE_detail = {0}: O valor n„o È do tipo correto.
+javax.faces.validator.DoubleRangeValidator.MAXIMUM        = Erro de valida√ß√£o
+javax.faces.validator.DoubleRangeValidator.MAXIMUM_detail = {1}: O valor √© maior que o m√°ximo permitido de ''{0}''.
+javax.faces.validator.DoubleRangeValidator.MINIMUM        = Erro de valida√ß√£o
+javax.faces.validator.DoubleRangeValidator.MINIMUM_detail = {1}: O valor √© menor que o m√≠nimo permitido de ''{0}''.
+javax.faces.validator.DoubleRangeValidator.NOT_IN_RANGE        = Erro de valida√ß√£o
+javax.faces.validator.DoubleRangeValidator.NOT_IN_RANGE_detail = {2}: Erro de valida\u00e7\u00e3o: O atributo especificado n\u00e3o est\u00e1 entre os valores esperados {0} e {1}.
+javax.faces.validator.DoubleRangeValidator.TYPE        = Erro de valida√ß√£o
+javax.faces.validator.DoubleRangeValidator.TYPE_detail = {0}: O valor n√£o √© do tipo correto.
 
-javax.faces.validator.LengthValidator.MAXIMUM        = Erro de validaÁ„o
-javax.faces.validator.LengthValidator.MAXIMUM_detail = {1}: O valor È mais longo do que o m·ximo permitido de {0} caracteres.
-javax.faces.validator.LengthValidator.MINIMUM        = Erro de validaÁ„o
-javax.faces.validator.LengthValidator.MINIMUM_detail = {1}: O valor È mais curto do que o mÌnimo permitido de {0} caracteres.
+javax.faces.validator.LengthValidator.MAXIMUM        = Erro de valida√ß√£o
+javax.faces.validator.LengthValidator.MAXIMUM_detail = {1}: O valor √© mais longo do que o m√°ximo permitido de {0} caracteres.
+javax.faces.validator.LengthValidator.MINIMUM        = Erro de valida√ß√£o
+javax.faces.validator.LengthValidator.MINIMUM_detail = {1}: O valor √© mais curto do que o m√≠nimo permitido de {0} caracteres.
 
-javax.faces.validator.LongRangeValidator.MAXIMUM        = Erro de validaÁ„o
-javax.faces.validator.LongRangeValidator.MAXIMUM_detail = {1}: O valor È maior que o m·ximo permitido de ''{0}''.
-javax.faces.validator.LongRangeValidator.MINIMUM        = Erro de validaÁ„o
-javax.faces.validator.LongRangeValidator.MINIMUM_detail = {1}: O valor È menor que o mÌnimo permitido de ''{0}''.
-javax.faces.validator.LongRangeValidator.NOT_IN_RANGE        = Erro de validaÁ„o
-javax.faces.validator.LongRangeValidator.NOT_IN_RANGE_detail = O atributo especificado n„o pode ser convertido para o tipo apropriado.
-javax.faces.validator.LongRangeValidator.TYPE        = Erro de validaÁ„o
-javax.faces.validator.LongRangeValidator.TYPE_detail = {0}: O valor n„o È do tipo correto.
+javax.faces.validator.LongRangeValidator.MAXIMUM        = Erro de valida√ß√£o
+javax.faces.validator.LongRangeValidator.MAXIMUM_detail = {1}: O valor √© maior que o m√°ximo permitido de ''{0}''.
+javax.faces.validator.LongRangeValidator.MINIMUM        = Erro de valida√ß√£o
+javax.faces.validator.LongRangeValidator.MINIMUM_detail = {1}: O valor √© menor que o m√≠nimo permitido de ''{0}''.
+javax.faces.validator.LongRangeValidator.NOT_IN_RANGE        = Erro de valida√ß√£o
+javax.faces.validator.LongRangeValidator.NOT_IN_RANGE_detail = O atributo especificado n√£o pode ser convertido para o tipo apropriado.
+javax.faces.validator.LongRangeValidator.TYPE        = Erro de valida√ß√£o
+javax.faces.validator.LongRangeValidator.TYPE_detail = {0}: O valor n√£o √© do tipo correto.
 
-javax.faces.validator.RegexValidator.NOT_MATCHED = {1}: Erro de validaÁ„o: Valor n„o de acordo com o padr„o ''{0}''
+javax.faces.validator.RegexValidator.NOT_MATCHED = {1}: Erro de valida√ß√£o: Valor n√£o de acordo com o padr√£o ''{0}''
 
 
 # myfaces specific messages
 org.apache.myfaces.renderkit.html.HtmlMessagesRenderer.IN_FIELD = \u0020in {0}
-org.apache.myfaces.Email.INVALID = Erro de validaÁ„o
-org.apache.myfaces.Email.INVALID_detail = O valor informado ({0}) n„o È um endereÁo de e-mail v·lido.
+org.apache.myfaces.Email.INVALID = Erro de valida√ß√£o
+org.apache.myfaces.Email.INVALID_detail = O valor informado ({0}) n√£o √© um endere√ßo de e-mail v√°lido.
 
-org.apache.myfaces.Equal.INVALID = Erro de validaÁ„o
-org.apache.myfaces.Equal.INVALID_detail = O valor informado ({0}) n„o È igual ao valor de "{1}".
+org.apache.myfaces.Equal.INVALID = Erro de valida√ß√£o
+org.apache.myfaces.Equal.INVALID_detail = O valor informado ({0}) n√£o √© igual ao valor de "{1}".
 
-org.apache.myfaces.Creditcard.INVALID = Erro de validaÁ„o
-org.apache.myfaces.Creditcard.INVALID_detail = O valor informado ({0}) est· incorreto para cart„o de crÈdito
+org.apache.myfaces.Creditcard.INVALID = Erro de valida√ß√£o
+org.apache.myfaces.Creditcard.INVALID_detail = O valor informado ({0}) est√° incorreto para cart√£o de cr√©dito
 
-org.apache.myfaces.Regexpr.INVALID=Erro de validaÁ„o
-org.apache.myfaces.Regexpr.INVALID_detail= O valor informado ({0}) È inv·lido.
+org.apache.myfaces.Regexpr.INVALID=Erro de valida√ß√£o
+org.apache.myfaces.Regexpr.INVALID_detail= O valor informado ({0}) √© inv√°lido.
 
-org.apache.myfaces.Date.INVALID = Erro de validaÁ„o
-org.apache.myfaces.Date.INVALID_detail = O valor informado ({0}) n„o È uma data v·lida
+org.apache.myfaces.Date.INVALID = Erro de valida√ß√£o
+org.apache.myfaces.Date.INVALID_detail = O valor informado ({0}) n√£o √© uma data v√°lida
 
-org.apache.myfaces.ticker.NOCONNECTION = Sem conex„o: 
-org.apache.myfaces.ticker.NOCONNECTION_detail = Talvez vocÍ esteja atr·s de um firewall?
+org.apache.myfaces.ticker.NOCONNECTION = Sem conex√£o: 
+org.apache.myfaces.ticker.NOCONNECTION_detail = Talvez voc√™ esteja atr√°s de um firewall?
 
-org.apache.myfaces.ISBN.INVALID =Erro de validaÁ„o
-org.apache.myfaces.ISBN.INVALID_detail = O valor informado ({0}) n„o È um cÛdigo isbn v·lido.
+org.apache.myfaces.ISBN.INVALID =Erro de valida√ß√£o
+org.apache.myfaces.ISBN.INVALID_detail = O valor informado ({0}) n√£o √© um c√≥digo isbn v√°lido.


### PR DESCRIPTION
Fix translation of DoubleRangeValidator on files api/src/main/resources/javax/faces/Messages_pt.properties and api/src/main/resources/javax/faces/Messages_pt_BR.properties

On api/src/main/resources/javax/faces/Messages_pt_BR.properties, github forced me to update the file encoding from ISO-8859-1 to UTF-8, so that's why it changed the entire file. I couldn't get it to not force the new encoding.