### PR TITLE
MYFACES-4428 - Separate "begin tag" code from "end tag" code

### DIFF
--- a/impl/src/test/java/org/apache/myfaces/renderkit/html/HtmlSecretRendererTest.java
+++ b/impl/src/test/java/org/apache/myfaces/renderkit/html/HtmlSecretRendererTest.java
@@ -77,6 +77,7 @@ public class HtmlSecretRendererTest extends AbstractJsfTestCase
 
     public void testInputTextDefault() throws Exception
     {
+        inputText.encodeBegin(facesContext);
         inputText.encodeEnd(facesContext);
         facesContext.renderResponse();
 

--- a/impl/src/test/java/org/apache/myfaces/renderkit/html/HtmlTextRendererTest.java
+++ b/impl/src/test/java/org/apache/myfaces/renderkit/html/HtmlTextRendererTest.java
@@ -99,6 +99,7 @@ public class HtmlTextRendererTest extends AbstractJsfTestCase
         outputText.setValue("Output");
         outputText.setStyleClass("myStyleClass");
 
+        outputText.encodeBegin(facesContext);
         outputText.encodeEnd(facesContext);
         facesContext.renderResponse();
 
@@ -117,6 +118,7 @@ public class HtmlTextRendererTest extends AbstractJsfTestCase
         outputText.setValue("Output");
         outputText.setEscape(true);
 
+        outputText.encodeBegin(facesContext);
         outputText.encodeEnd(facesContext);
         facesContext.renderResponse();
 

--- a/shared/src/main/java/org/apache/myfaces/shared/renderkit/html/HtmlSecretRendererBase.java
+++ b/shared/src/main/java/org/apache/myfaces/shared/renderkit/html/HtmlSecretRendererBase.java
@@ -43,26 +43,30 @@ public class HtmlSecretRendererBase
         extends HtmlRenderer
 {
     private static final String AUTOCOMPLETE_VALUE_OFF = "off";
+    
+    @Override
+    public void encodeBegin(FacesContext facesContext, UIComponent uiComponent) throws IOException
+    {
+      RendererUtils.checkParamValidity(facesContext, uiComponent, UIInput.class);
+
+      ResponseWriter writer = facesContext.getResponseWriter();
+      
+      Map<String, List<ClientBehavior>> behaviors = null;
+      if (uiComponent instanceof ClientBehaviorHolder)
+      {
+          behaviors = ((ClientBehaviorHolder) uiComponent).getClientBehaviors();
+          if (!behaviors.isEmpty())
+          {
+              ResourceUtils.renderDefaultJsfJsInlineIfNecessary(facesContext, writer);
+          }
+      }
+      //allow subclasses to render custom attributes by separating rendering begin and end
+      renderInputBegin(facesContext, uiComponent);
+    }
 
     public void encodeEnd(FacesContext facesContext, UIComponent uiComponent)
             throws IOException
     {
-        RendererUtils.checkParamValidity(facesContext, uiComponent, UIInput.class);
-
-        ResponseWriter writer = facesContext.getResponseWriter();
-        
-        Map<String, List<ClientBehavior>> behaviors = null;
-        if (uiComponent instanceof ClientBehaviorHolder)
-        {
-            behaviors = ((ClientBehaviorHolder) uiComponent).getClientBehaviors();
-            if (!behaviors.isEmpty())
-            {
-                ResourceUtils.renderDefaultJsfJsInlineIfNecessary(facesContext, writer);
-            }
-        }
-        
-        //allow subclasses to render custom attributes by separating rendering begin and end
-        renderInputBegin(facesContext, uiComponent);
         renderInputEnd(facesContext, uiComponent);
     }
 

--- a/shared/src/main/java/org/apache/myfaces/shared/renderkit/html/HtmlTextRendererBase.java
+++ b/shared/src/main/java/org/apache/myfaces/shared/renderkit/html/HtmlTextRendererBase.java
@@ -48,25 +48,33 @@ public class HtmlTextRendererBase
     private static final Logger log = Logger.getLogger(HtmlTextRendererBase.class.getName());
 
     private static final String AUTOCOMPLETE_VALUE_OFF = "off";
+    
+    @Override
+    public void encodeBegin(FacesContext facesContext, UIComponent component) throws IOException
+    {
+      org.apache.myfaces.shared.renderkit.RendererUtils.checkParamValidity(facesContext,component,null);
+      
+      Map<String, List<ClientBehavior>> behaviors = null;
+      if (component instanceof ClientBehaviorHolder)
+      {
+          behaviors = ((ClientBehaviorHolder) component).getClientBehaviors();
+          if (!behaviors.isEmpty())
+          {
+              ResourceUtils.renderDefaultJsfJsInlineIfNecessary(facesContext, facesContext.getResponseWriter());
+          }
+      }
+      if (component instanceof UIInput)
+      {
+          renderInputBegin(facesContext, component);
+      }
+    }
 
     public void encodeEnd(FacesContext facesContext, UIComponent component)
         throws IOException
     {
-        org.apache.myfaces.shared.renderkit.RendererUtils.checkParamValidity(facesContext,component,null);
-        
-        Map<String, List<ClientBehavior>> behaviors = null;
-        if (component instanceof ClientBehaviorHolder)
-        {
-            behaviors = ((ClientBehaviorHolder) component).getClientBehaviors();
-            if (!behaviors.isEmpty())
-            {
-                ResourceUtils.renderDefaultJsfJsInlineIfNecessary(facesContext, facesContext.getResponseWriter());
-            }
-        }
-        
         if (component instanceof UIInput)
         {
-            renderInput(facesContext, component);
+            renderInputEnd(facesContext, component);
         }
         else if (component instanceof UIOutput)
         {
@@ -173,12 +181,10 @@ public class HtmlTextRendererBase
         return true;
     }
 
+    @Deprecated
     protected void renderInput(FacesContext facesContext, UIComponent component)
         throws IOException
     {
-        //allow subclasses to render custom attributes by separating rendering begin and end 
-        renderInputBegin(facesContext, component);
-        renderInputEnd(facesContext, component);
     }
 
     //Subclasses can set the value of an attribute before, or can render a custom attribute after calling this method


### PR DESCRIPTION
MYFACES-4428 - Separate "begin tag" code from "end tag" code

JSF provides a encodeBegin() and an encodeEnd() method on a Renderer. MyFaces currently performs "begin tag" and "end tag" encoding in the encodeEnd(), which breaks any vendor-netural path for extensibility. This patch moves the "begin tag" encoding logic to the encodeBegin() function so the renderkit can be extended without needed to extend myfaces classes explicitly, but instead be called through the standard JSF api to start a tag.