### PR TITLE
Faces 4.0 use JDK 11

### DIFF
--- a/extensions/quarkus/showcase/pom.xml
+++ b/extensions/quarkus/showcase/pom.xml
@@ -31,9 +31,10 @@
         <surefire.version>2.22.0</surefire.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
-        <maven.compiler.release>8</maven.compiler.release>
+        <java.version>11</java.version>
+        <maven.compiler.source>${java.version}</maven.compiler.source>
+        <maven.compiler.target>${java.version}</maven.compiler.target>
+        <maven.compiler.release>${java.version}</maven.compiler.release>
     </properties>
 
     <dependencyManagement>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -66,8 +66,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.1</version>
                 <configuration>
-                    <source>8</source>
-                    <target>8</target>
+                    <source>11</source>
+                    <target>11</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -66,8 +66,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.1</version>
                 <configuration>
-                    <source>11</source>
-                    <target>11</target>
+                    <source>${java.version}</source>
+                    <target>${java.version}</target>
                 </configuration>
             </plugin>
         </plugins>
@@ -204,5 +204,6 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <java.version>11</java.version>
     </properties>
 </project>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -319,7 +319,7 @@
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <version>3.2.0</version>
                 <configuration>
-                    <source>8</source>
+                    <source>${java.version}</source>
                 </configuration>
             </plugin>
             <plugin>
@@ -332,7 +332,7 @@
                     </rulesets>
                     <linkXref>true</linkXref>
                     <minimumTokens>100</minimumTokens>
-                    <targetJdk>1.8</targetJdk>
+                    <targetJdk>${java.version}</targetJdk>
                 </configuration>
                 <reportSets>
                     <reportSet>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -198,7 +198,7 @@
                 <plugin>
                     <groupId>org.apache.felix</groupId>
                     <artifactId>maven-bundle-plugin</artifactId>
-                    <version>3.0.1</version>
+                    <version>5.1.4</version>
                 </plugin>
 
                 <plugin>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -58,8 +58,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.6.1</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>${java.version}</source>
+                    <target>${java.version}</target>
                 </configuration>
             </plugin>
 
@@ -531,6 +531,7 @@
     </distributionManagement>
 
     <properties>
+        <java.version>11</java.version>
         <siteModule.path>core40</siteModule.path>
         <site.mainDirectory>${user.home}/myfaces-site/checkout</site.mainDirectory>
         <siteContent.path>${user.home}/myfaces-site/site/${siteModule.path}</siteContent.path>

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
         <url>https://gitbox.apache.org/repos/asf?p=myfaces.git</url>
         <tag>HEAD</tag>
     </scm>
-
+  
     <modules>
         <module>parent</module>
         <module>api</module>
@@ -57,7 +57,7 @@
         <module>bundle</module>
         <!--
         <module>integration-tests</module>
-	<module>extensions</module>
+        <module>extensions</module>
         -->
     </modules>
 
@@ -245,6 +245,9 @@
     </distributionManagement>
 
     <properties>
+        <java.version>11</java.version>
+        <maven.compiler.source>${java.version}</maven.compiler.source>
+        <maven.compiler.target>${java.version}</maven.compiler.target>
         <siteModule.path>core40/module</siteModule.path>
         <site.mainDirectory>${user.home}/myfaces-site/checkout</site.mainDirectory>
         <siteContent.path>${user.home}/myfaces-site/site/${siteModule.path}</siteContent.path>


### PR DESCRIPTION
I noticed this when switching branches that Faces 4.0 is still set for JDK 8 but its using JDK 11 features.