### PR TITLE
Set permissions for GitHub Actions

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -35,12 +35,18 @@ on:
     branches: [ master ]
   schedule:
     - cron: '32 16 * * 6'
-  workflow_dispatch:
+
+permissions:
+  contents: read
     
 jobs:
   analyze:
     name: Analyze
     runs-on: ubuntu-latest
+    
+    permissions:
+      # required for all workflows
+      security-events: write
 
     strategy:
       fail-fast: false

--- a/.github/workflows/myfaces-ci.yml
+++ b/.github/workflows/myfaces-ci.yml
@@ -43,6 +43,9 @@ on:
       - 'Jenkinsfile'
   workflow_dispatch:
 
+permissions:
+  contents: read
+  
 jobs:
   build:
 


### PR DESCRIPTION
Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions
https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.