### PR TITLE
MYFACES-4434 - HtmlTextareaRendererBase separate encode end and begin

### DIFF
--- a/impl/src/main/java/org/apache/myfaces/renderkit/html/base/HtmlTextareaRendererBase.java
+++ b/impl/src/main/java/org/apache/myfaces/renderkit/html/base/HtmlTextareaRendererBase.java
@@ -45,33 +45,33 @@ import org.apache.myfaces.renderkit.html.util.ComponentAttrs;
 public class HtmlTextareaRendererBase extends HtmlRenderer
 {
     private static final String ADD_NEW_LINE_AT_START_ATTR = "org.apache.myfaces.addNewLineAtStart";
-    
+
     @Override
-    public void encodeEnd(FacesContext facesContext, UIComponent uiComponent) throws IOException
+    public void encodeBegin(FacesContext facesContext, UIComponent uiComponent)
+            throws IOException
     {
         RendererUtils.checkParamValidity(facesContext, uiComponent, UIInput.class);
 
+        Map<String, List<ClientBehavior>> behaviors = null;
         if (uiComponent instanceof ClientBehaviorHolder)
         {
-            Map<String, List<ClientBehavior>> behaviors = ((ClientBehaviorHolder) uiComponent).getClientBehaviors();
+            behaviors = ((ClientBehaviorHolder) uiComponent).getClientBehaviors();
             if (!behaviors.isEmpty())
             {
-                ResourceUtils.renderDefaultJsfJsInlineIfNecessary(facesContext, 
+                ResourceUtils.renderDefaultJsfJsInlineIfNecessary(facesContext,
                         facesContext.getResponseWriter());
             }
         }
-        
-        encodeTextArea(facesContext, uiComponent);
 
+        renderTextAreaBegin(facesContext, uiComponent);
     }
 
-    protected void encodeTextArea(FacesContext facesContext, UIComponent uiComponent) throws IOException
+    @Override
+    public void encodeEnd(FacesContext facesContext, UIComponent uiComponent)
+            throws IOException
     {
-       //allow subclasses to render custom attributes by separating rendering begin and end
-        renderTextAreaBegin(facesContext, uiComponent);
         renderTextAreaValue(facesContext, uiComponent);
         renderTextAreaEnd(facesContext, uiComponent);
-        
     }
 
     //Subclasses can set the value of an attribute before, or can render a custom attribute after calling this method

--- a/impl/src/test/java/org/apache/myfaces/renderkit/html/HtmlTextareaRendererTest.java
+++ b/impl/src/test/java/org/apache/myfaces/renderkit/html/HtmlTextareaRendererTest.java
@@ -68,6 +68,7 @@ public class HtmlTextareaRendererTest extends AbstractJsfTestCase
 
     public void testRenderDefault() throws Exception
     {
+        inputTextarea.encodeBegin(facesContext);
         inputTextarea.encodeEnd(facesContext);
         facesContext.renderResponse();
 
@@ -79,6 +80,7 @@ public class HtmlTextareaRendererTest extends AbstractJsfTestCase
     {
         inputTextarea.setCols(5);
         inputTextarea.setRows(10);
+        inputTextarea.encodeBegin(facesContext);
         inputTextarea.encodeEnd(facesContext);
         facesContext.renderResponse();
 


### PR DESCRIPTION
… MyFaces currently performs "begin tag" and "end tag" encoding in the encodeEnd(), which breaks any vendor-neutral path for extensibility. This patch moves the "begin tag" encoding logic to the encodeBegin() function so the renderkit can be extended without needing to extend myfaces classes explicitly, but instead be called through the standard JSF api to start a tag.