### PR TITLE
MYFACES-4442: Fix UnsupportedOperationException during Faces init

### DIFF
--- a/impl/src/main/java/org/apache/myfaces/spi/WebConfigProvider.java
+++ b/impl/src/main/java/org/apache/myfaces/spi/WebConfigProvider.java
@@ -18,7 +18,9 @@
  */
 package org.apache.myfaces.spi;
 
+import java.util.List;
 import jakarta.faces.context.ExternalContext;
+import org.apache.myfaces.util.ServletMapping;
 
 /**
  * SPI to provide a custom WebConfigProvider implementation.
@@ -29,11 +31,29 @@ import jakarta.faces.context.ExternalContext;
 public abstract class WebConfigProvider
 {
     /**
+     * Return the mappings configured on web.xml related to the Faces FacesServlet.
+     * <p>
+     * By default, the algorithm contemplate these three options:
+     * </p>
+     * <ol>
+     *   <li>Mappings related to registered servlet class javax.faces.webapp.FacesServlet.</li>
+     *   <li>Mappings related to registered servlet class implementing
+     *   org.apache.myfaces.webapp.DelegatedFacesServlet interface.</li>
+     *   <li>Mappings related to registered servlet class registered
+     *   using org.apache.myfaces.DELEGATE_FACES_SERVLET web config param.</li>
+     * </ol>
+     *
+     * @param externalContext
+     * @return
+     */
+    public abstract List<ServletMapping> getFacesServletMappings(ExternalContext externalContext);
+
+    /**
      * Indicate if an error page is configured on web.xml file
      * 
      * @param externalContext
      * @return
      */
     public abstract boolean isErrorPagePresent(ExternalContext externalContext);
-    
+
 }

--- a/impl/src/main/java/org/apache/myfaces/spi/impl/DefaultWebConfigProvider.java
+++ b/impl/src/main/java/org/apache/myfaces/spi/impl/DefaultWebConfigProvider.java
@@ -18,12 +18,16 @@
  */
 package org.apache.myfaces.spi.impl;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import jakarta.faces.context.ExternalContext;
 import jakarta.faces.context.FacesContext;
 
 import org.apache.myfaces.spi.WebConfigProvider;
 import org.apache.myfaces.util.WebXmlParser;
+import org.apache.myfaces.util.WebXml;
+import org.apache.myfaces.util.ServletMapping;
 
 /**
  * The default WebXmlProvider implementation.
@@ -36,6 +40,19 @@ public class DefaultWebConfigProvider extends WebConfigProvider
     {
     }
   
+    @Override
+    public List<ServletMapping> getFacesServletMappings(
+            ExternalContext externalContext)
+    {
+       WebXml webXml = WebXml.getWebXml(externalContext);
+
+        List mapping = webXml.getFacesServletMappings();
+
+        // In MyFaces 2.0, getFacesServletMappings is used only at startup
+        // time, so we don't need to cache this result.
+        return new ArrayList<ServletMapping>(mapping);
+    }
+
     @Override
     public boolean isErrorPagePresent(ExternalContext externalContext)
     {

--- a/impl/src/main/java/org/apache/myfaces/util/ServletMapping.java
+++ b/impl/src/main/java/org/apache/myfaces/util/ServletMapping.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.myfaces.util;
+
+public class ServletMapping
+{
+    private final String _servletName;
+    private final Class _servletClass;
+    private final String _urlPattern;
+    private final String _extension;
+    private final String _prefix;
+
+    public ServletMapping(String servletName, Class servletClass, String urlPattern)
+    {
+        _servletName = servletName;
+        _servletClass = servletClass;
+        _urlPattern = urlPattern;
+        _extension = _urlPattern != null && _urlPattern.startsWith("*.")
+                ? _urlPattern.substring(_urlPattern.indexOf('.'))
+                : null;
+        if (_extension == null)
+        {
+            int index = _urlPattern.indexOf("/*");
+            if (index != -1)
+            {
+                _prefix = _urlPattern.substring(0, _urlPattern.indexOf("/*"));
+            }
+            else
+            {
+                _prefix = _urlPattern;
+            }
+        }
+        else
+        {
+            _prefix = null;
+        }
+    }
+
+    public boolean isExtensionMapping()
+    {
+        return _extension != null;
+    }
+
+    public String getExtension()
+    {
+        return _extension;
+    }
+
+    public String getPrefix()
+    {
+        return _prefix;
+    }
+
+    public String getServletName()
+    {
+        return _servletName;
+    }
+
+    public Class getServletClass()
+    {
+        return _servletClass;
+    }
+
+    public String getUrlPattern()
+    {
+        return _urlPattern;
+    }
+}

--- a/impl/src/main/java/org/apache/myfaces/util/WebXml.java
+++ b/impl/src/main/java/org/apache/myfaces/util/WebXml.java
@@ -1,0 +1,250 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.myfaces.util;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import jakarta.faces.context.ExternalContext;
+import jakarta.faces.webapp.FacesServlet;
+
+import org.apache.myfaces.config.MyfacesConfig;
+import org.apache.myfaces.webapp.DelegatedFacesServlet;
+
+public class WebXml
+{
+    private static final Logger log = Logger.getLogger(WebXml.class.getName());
+
+
+    private static long refreshPeriod;
+    private long parsingTime;
+
+    private Map _servlets = new HashMap();
+    private Map _servletMappings = new HashMap();
+    private Map _filters = new HashMap();
+    private Map _filterMappings = new HashMap();
+
+    private volatile List _facesServletMappings = null;
+    
+    private String _delegateFacesServlet = null;
+    private boolean errorPagePresent = false;
+
+    void addServlet(String servletName, String servletClass)
+    {
+        if (_servlets.get(servletName) != null)
+        {
+            log.warning("Servlet " + servletName + " defined more than once, first definition will be used.");
+        }
+        else
+        {
+            _servlets.put(servletName, servletClass);
+        }
+    }
+
+    void addFilter(String filterName, String filterClass)
+    {
+        if (_filters.get(filterName) != null)
+        {
+            log.warning("Filter " + filterName + " defined more than once, first definition will be used.");
+        }
+        else
+        {
+            _filters.put(filterName, filterClass);
+        }
+    }
+
+    boolean containsServlet(String servletName)
+    {
+        return _servlets.containsKey(servletName);
+    }
+
+    boolean containsFilter(String filterName)
+    {
+        return _filters.containsKey(filterName);
+    }
+
+    void addServletMapping(String servletName, String urlPattern)
+    {
+        List mappings = (List)_servletMappings.get(servletName);
+        if (mappings == null)
+        {
+            mappings = new ArrayList();
+            _servletMappings.put(servletName, mappings);
+        }
+        mappings.add(urlPattern);
+    }
+
+    void addFilterMapping(String filterName, String urlPattern)
+    {
+        List mappings = (List)_filterMappings.get(filterName);
+        if (mappings == null)
+        {
+            mappings = new ArrayList();
+            _filterMappings.put(filterName, mappings);
+        }
+        mappings.add(urlPattern);
+    }
+
+    public List getFacesServletMappings()
+    {
+        if (_facesServletMappings != null)
+        {
+            return _facesServletMappings;
+        }
+
+        List tempFacesServletMappings = new ArrayList();
+        for (Iterator it = _servlets.entrySet().iterator(); it.hasNext(); )
+        {
+            Map.Entry entry = (Map.Entry)it.next();
+            String servletName = (String)entry.getKey();
+            if (null == entry.getValue())
+            {
+                // the value is null in the case of jsp files listed as servlets
+                // in cactus
+                // <servlet>
+                //   <servlet-name>JspRedirector</servlet-name>
+                //   <jsp-file>/jspRedirector.jsp</jsp-file>
+                // </servlet>
+                continue;
+            }
+            Class servletClass = org.apache.myfaces.util.lang.ClassUtils.simpleClassForName((String)entry.getValue());
+            if (FacesServlet.class.isAssignableFrom(servletClass) ||
+                    DelegatedFacesServlet.class.isAssignableFrom(servletClass) ||
+                    servletClass.getName().equals(_delegateFacesServlet))
+            {
+                List urlPatterns = (List)_servletMappings.get(servletName);
+                if( urlPatterns != null )
+                {
+                    for (Iterator it2 = urlPatterns.iterator(); it2.hasNext(); )
+                    {
+                        String urlpattern = (String)it2.next();
+                        tempFacesServletMappings.add(new org.apache.myfaces.util.ServletMapping(servletName,
+                                                                                           servletClass,
+                                                                                           urlpattern));
+                        if (log.isLoggable(Level.FINEST))
+                        {
+                            log.finest("adding mapping for servlet + " + servletName + " urlpattern = " + urlpattern);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                if (log.isLoggable(Level.FINEST))
+                {
+                    log.finest("ignoring servlet + " + servletName + ' ' + servletClass + " (no FacesServlet)");
+                }
+            }
+        }
+        
+        //Expose to all threads
+        _facesServletMappings = tempFacesServletMappings;
+        
+        return _facesServletMappings;
+    }
+
+    protected void setParsingTime(long parsingTime)
+    {
+        this.parsingTime = parsingTime;
+    }
+    
+    private void setDelegateFacesServlet(String delegateFacesServlet)
+    {
+        this._delegateFacesServlet = delegateFacesServlet;
+    }
+    
+    public String getDelegateFacesServlet()
+    {
+        return this._delegateFacesServlet;
+    }
+    
+    /**
+     * Sets if, the web.xml contains an error-page entry
+     * @param errorPagePresent
+     */
+    public void setErrorPagePresent(boolean errorPagePresent)
+    {
+        this.errorPagePresent = errorPagePresent;
+    }
+    
+    /**
+     * Determines, if the web.xml contains an error-page entry
+     * @return
+     */
+    public boolean isErrorPagePresent()
+    {
+        return errorPagePresent;
+    }
+
+    protected boolean isOld(ExternalContext context)
+    {
+        if (refreshPeriod > 0)
+        {
+            long ttl = this.parsingTime + refreshPeriod;
+            if (System.currentTimeMillis() > ttl)
+            {
+                long lastModified = WebXmlParser.getWebXmlLastModified(context);
+                return lastModified == 0 || lastModified > ttl;
+            }
+        }
+        return false;
+    }
+
+    private static final String WEB_XML_ATTR = WebXml.class.getName();
+    public static WebXml getWebXml(ExternalContext context)
+    {
+        WebXml webXml = (WebXml)context.getApplicationMap().get(WEB_XML_ATTR);
+        if (webXml == null)
+        {
+            init(context);
+            webXml = (WebXml)context.getApplicationMap().get(WEB_XML_ATTR);
+        }
+        return webXml;
+    }
+
+    /**
+     * should be called when initialising Servlet
+     * @param context
+     */
+    public static void init(ExternalContext context)
+    {
+        WebXmlParser parser = new WebXmlParser(context);
+        WebXml webXml = parser.parse();
+        context.getApplicationMap().put(WEB_XML_ATTR, webXml);
+        MyfacesConfig mfconfig = MyfacesConfig.getCurrentInstance(context);
+        long configRefreshPeriod = mfconfig.getConfigRefreshPeriod();
+        webXml.setParsingTime(System.currentTimeMillis());
+        webXml.setDelegateFacesServlet(mfconfig.getDelegateFacesServlet());
+        refreshPeriod = (configRefreshPeriod * 1000);
+    }
+
+    public static void update(ExternalContext context)
+    {
+        if (getWebXml(context).isOld(context))
+        {
+            WebXml.init(context);
+        }
+    }
+
+}

--- a/impl/src/main/java/org/apache/myfaces/util/WebXmlParser.java
+++ b/impl/src/main/java/org/apache/myfaces/util/WebXmlParser.java
@@ -18,7 +18,6 @@
  */
 package org.apache.myfaces.util;
 
-import org.apache.myfaces.util.lang.StringUtils;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URISyntaxException;
@@ -28,6 +27,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
+import jakarta.faces.FacesException;
 import jakarta.faces.context.ExternalContext;
 
 import javax.xml.parsers.DocumentBuilder;
@@ -35,12 +36,15 @@ import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.xpath.XPath;
 import javax.xml.xpath.XPathConstants;
 import javax.xml.xpath.XPathFactory;
+
 import org.apache.myfaces.util.lang.ClassUtils;
+import org.apache.myfaces.util.lang.StringUtils;
 
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
+import org.xml.sax.EntityResolver;
 import org.xml.sax.InputSource;
 
 public class WebXmlParser
@@ -58,9 +62,357 @@ public class WebXmlParser
             + "(*[local-name() = 'exception-type'])]/*[local-name() = 'location']";
 
     private static final String KEY_ERROR_PAGES = WebXmlParser.class.getName() + ".errorpages";
-    
+    private static final String WEB_XML_PATH = "/WEB-INF/web.xml";
+
+    private static final String WEB_APP_2_2_J2EE_SYSTEM_ID = "http://java.sun.com/j2ee/dtds/web-app_2_2.dtd";
+    private static final String WEB_APP_2_2_SYSTEM_ID = "http://java.sun.com/dtd/web-app_2_2.dtd";
+    private static final String WEB_APP_2_2_RESOURCE  = "javax/servlet/resources/web-app_2_2.dtd";
+
+    private static final String WEB_APP_2_3_SYSTEM_ID = "http://java.sun.com/dtd/web-app_2_3.dtd";
+    private static final String WEB_APP_2_3_RESOURCE  = "javax/servlet/resources/web-app_2_3.dtd";
+
+    private ExternalContext _context;
+    private WebXml _webXml;
+
     private WebXmlParser()
     {
+    }
+
+    public WebXmlParser(ExternalContext context)
+    {
+        _context = context;
+    }
+
+    public WebXml parse()
+    {
+        _webXml = new WebXml();
+
+        try
+        {
+            DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+            dbf.setIgnoringElementContentWhitespace(true);
+            dbf.setIgnoringComments(true);
+            dbf.setNamespaceAware(true);
+            dbf.setValidating(false);
+//            dbf.setAttribute(JAXP_SCHEMA_LANGUAGE, W3C_XML_SCHEMA);
+
+            DocumentBuilder db = dbf.newDocumentBuilder();
+            db.setEntityResolver(new _EntityResolver());
+            db.setErrorHandler(new WebXmlParserErrorHandler(LOGGER));
+
+            InputSource is = createContextInputSource(null, WEB_XML_PATH);
+
+            if(is==null)
+            {
+                URL url = _context.getResource(WEB_XML_PATH);
+                LOGGER.fine("No web-xml found at : "+(url==null?" null ":url.toString()));
+                return _webXml;
+            }
+
+            Document document = db.parse(is);
+
+            Element webAppElem = document.getDocumentElement();
+            if (webAppElem == null ||
+                !webAppElem.getNodeName().equals("web-app"))
+            {
+                throw new FacesException("No valid web-app root element found!");
+            }
+
+            readWebApp(webAppElem);
+
+            return _webXml;
+        }
+        catch (Exception e)
+        {
+            LOGGER.log(Level.SEVERE, "Unable to parse web.xml", e);
+            throw new FacesException(e);
+        }
+    }
+
+    public static long getWebXmlLastModified(ExternalContext context)
+    {
+        try
+        {
+            URL url = context.getResource(WEB_XML_PATH);
+            if (url != null)
+            {
+                return url.openConnection().getLastModified();
+            }
+        }
+        catch (IOException e)
+        {
+            LOGGER.log(Level.SEVERE, "Could not find web.xml in path " + WEB_XML_PATH);
+        }
+        return 0L;
+    }
+
+    private InputSource createContextInputSource(String publicId, String systemId)
+    {
+        InputStream inStream = _context.getResourceAsStream(systemId);
+        if (inStream == null)
+        {
+            // there is no such entity
+            return null;
+        }
+        InputSource is = new InputSource(inStream);
+        is.setPublicId(publicId);
+        is.setSystemId(systemId);
+        //the next line was removed - encoding should be determined automatically out of the inputStream
+        //DEFAULT_ENCODING was ISO-8859-1
+        //is.setEncoding(DEFAULT_ENCODING);
+        return is;
+    }
+
+    private InputSource createClassloaderInputSource(String publicId, String systemId)
+    {
+        InputStream inStream = ClassUtils.getResourceAsStream(systemId);
+        if (inStream == null)
+        {
+            // there is no such entity
+            return null;
+        }
+        InputSource is = new InputSource(inStream);
+        is.setPublicId(publicId);
+        is.setSystemId(systemId);
+        //the next line was removed - encoding should be determined automatically out of the inputStream
+        //encoding should be determined automatically out of the inputStream
+        //DEFAULT_ENCODING was ISO-8859-1
+        //is.setEncoding(DEFAULT_ENCODING);
+        return is;
+    }
+
+    private class _EntityResolver implements EntityResolver
+    {
+        public InputSource resolveEntity(String publicId, String systemId) throws IOException
+        {
+            if (systemId == null)
+            {
+                throw new UnsupportedOperationException("systemId must not be null");
+            }
+
+            if (systemId.equals(WebXmlParser.WEB_APP_2_2_SYSTEM_ID) ||
+                systemId.equals(WebXmlParser.WEB_APP_2_2_J2EE_SYSTEM_ID))
+            {
+                //Load DTD from servlet.jar
+                return createClassloaderInputSource(publicId, WebXmlParser.WEB_APP_2_2_RESOURCE);
+            }
+            else if (systemId.equals(WebXmlParser.WEB_APP_2_3_SYSTEM_ID))
+            {
+                //Load DTD from servlet.jar
+                return createClassloaderInputSource(publicId, WebXmlParser.WEB_APP_2_3_RESOURCE);
+            }
+            else
+            {
+                //Load additional entities from web context
+                return createContextInputSource(publicId, systemId);
+            }
+        }
+
+    }
+
+    private void readWebApp(Element webAppElem)
+    {
+        NodeList nodeList = webAppElem.getChildNodes();
+        for (int i = 0, len = nodeList.getLength(); i < len; i++)
+        {
+            Node n = nodeList.item(i);
+            if (n.getNodeType() == Node.ELEMENT_NODE)
+            {
+                if (n.getNodeName().equals("servlet"))
+                {
+                    readServlet((Element)n);
+                }
+                if (n.getNodeName().equals("servlet-mapping"))
+                {
+                    readServletMapping((Element)n);
+                }
+                if (n.getNodeName().equals("filter"))
+                {
+                    readFilter((Element)n);
+                }
+                if (n.getNodeName().equals("filter-mapping"))
+                {
+                    readFilterMapping((Element)n);
+                }
+                if (n.getNodeName().equals("error-page"))
+                {
+                    _webXml.setErrorPagePresent(true);
+                }
+            }
+            else
+            {
+                if (LOGGER.isLoggable(Level.FINE))
+                {
+                    LOGGER.fine("Ignored node '" + n.getNodeName() + "' of type " + n.getNodeType());
+                }
+            }
+        }
+    }
+
+    private void readServlet(Element servletElem)
+    {
+        String servletName = null;
+        String servletClass = null;
+        NodeList nodeList = servletElem.getChildNodes();
+        for (int i = 0, len = nodeList.getLength(); i < len; i++)
+        {
+            Node n = nodeList.item(i);
+            if (n.getNodeType() == Node.ELEMENT_NODE)
+            {
+                if (n.getNodeName().equals("servlet-name"))
+                {
+                    servletName = WebXmlParserUtils.getElementText((Element)n);
+                }
+                else if (n.getNodeName().equals("servlet-class"))
+                {
+                    servletClass = WebXmlParserUtils.getElementText((Element)n).trim();
+                }
+                else if (n.getNodeName().equals("description") || n.getNodeName().equals("load-on-startup")
+                        || n.getNodeName().equals("init-param"))
+                {
+                    //ignore
+                }
+                else
+                {
+                    if (LOGGER.isLoggable(Level.FINE))
+                    {
+                        LOGGER.fine("Ignored element '" + n.getNodeName() + "' as child of '" +
+                                servletElem.getNodeName() + "'.");
+                    }
+                }
+            }
+            else
+            {
+                if (LOGGER.isLoggable(Level.FINE))
+                {
+                    LOGGER.fine("Ignored node '" + n.getNodeName() + "' of type " + n.getNodeType());
+                }
+            }
+        }
+        _webXml.addServlet(servletName, servletClass);
+    }
+
+    private void readServletMapping(Element servletMappingElem)
+    {
+        String servletName = null;
+        String urlPattern = null;
+        NodeList nodeList = servletMappingElem.getChildNodes();
+        for (int i = 0, len = nodeList.getLength(); i < len; i++)
+        {
+            Node n = nodeList.item(i);
+            if (n.getNodeType() == Node.ELEMENT_NODE)
+            {
+                if (n.getNodeName().equals("servlet-name"))
+                {
+                    servletName = WebXmlParserUtils.getElementText((Element)n);
+                }
+                else if (n.getNodeName().equals("url-pattern"))
+                {
+                    urlPattern = WebXmlParserUtils.getElementText((Element)n).trim();
+                }
+                else
+                {
+                    if (LOGGER.isLoggable(Level.FINE))
+                    {
+                        LOGGER.fine("Ignored element '" + n.getNodeName() + "' as child of '" +
+                                servletMappingElem.getNodeName() + "'.");
+                    }
+                }
+            }
+            else
+            {
+                if (LOGGER.isLoggable(Level.FINE))
+                {
+                    LOGGER.fine("Ignored node '" + n.getNodeName() + "' of type " + n.getNodeType());
+                }
+            }
+        }
+        urlPattern = urlPattern.trim();
+        _webXml.addServletMapping(servletName, urlPattern);
+    }
+
+    private void readFilter(Element filterElem)
+    {
+        String filterName = null;
+        String filterClass = null;
+        NodeList nodeList = filterElem.getChildNodes();
+        for (int i = 0, len = nodeList.getLength(); i < len; i++)
+        {
+            Node n = nodeList.item(i);
+            if (n.getNodeType() == Node.ELEMENT_NODE)
+            {
+                if (n.getNodeName().equals("filter-name"))
+                {
+                    filterName = WebXmlParserUtils.getElementText((Element)n).trim();
+                }
+                else if (n.getNodeName().equals("filter-class"))
+                {
+                    filterClass = WebXmlParserUtils.getElementText((Element)n).trim();
+                }
+                else if (n.getNodeName().equals("description") || n.getNodeName().equals("init-param"))
+                {
+                    //ignore
+                }
+                else
+                {
+                    if (LOGGER.isLoggable(Level.FINE))
+                    {
+                        LOGGER.fine("Ignored element '" + n.getNodeName() + "' as child of '" +
+                                filterElem.getNodeName() + "'.");
+                    }
+                }
+            }
+            else
+            {
+                if (LOGGER.isLoggable(Level.FINE))
+                {
+                    LOGGER.fine("Ignored node '" + n.getNodeName() + "' of type " + n.getNodeType());
+                }
+            }
+        }
+        _webXml.addFilter(filterName, filterClass);
+    }
+
+    private void readFilterMapping(Element filterMappingElem)
+    {
+        String filterName = null;
+        String urlPattern = null;
+        NodeList nodeList = filterMappingElem.getChildNodes();
+        for (int i = 0, len = nodeList.getLength(); i < len; i++)
+        {
+            Node n = nodeList.item(i);
+            if (n.getNodeType() == Node.ELEMENT_NODE)
+            {
+                if (n.getNodeName().equals("filter-name"))
+                {
+                    filterName = WebXmlParserUtils.getElementText((Element)n).trim();
+                }
+                else if (n.getNodeName().equals("url-pattern"))
+                {
+                    urlPattern = WebXmlParserUtils.getElementText((Element)n).trim();
+                }
+                else if (n.getNodeName().equals("servlet-name"))
+                {
+                    // we are not interested in servlet-name based mapping - for now
+                }
+                else
+                {
+                    if (LOGGER.isLoggable(Level.FINE))
+                    {
+                        LOGGER.fine("Ignored element '" + n.getNodeName() + "' as child of '" +
+                                filterMappingElem.getNodeName() + "'.");
+                    }
+                }
+            }
+            else
+            {
+                if (LOGGER.isLoggable(Level.FINE))
+                {
+                    LOGGER.fine("Ignored node '" + n.getNodeName() + "' of type " + n.getNodeType());
+                }
+            }
+        }
+        _webXml.addFilterMapping(filterName, urlPattern);
     }
 
     /**
@@ -298,5 +650,5 @@ public class WebXmlParser
 
         return errorPages;
     }
-    
+
 }

--- a/impl/src/main/java/org/apache/myfaces/util/WebXmlParserErrorHandler.java
+++ b/impl/src/main/java/org/apache/myfaces/util/WebXmlParserErrorHandler.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.myfaces.util;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.xml.sax.ErrorHandler;
+import org.xml.sax.SAXParseException;
+
+/**
+ * Convenient error handler for xml sax parsing.
+ */
+public class WebXmlParserErrorHandler implements ErrorHandler
+{
+    private Logger _log;
+
+    public WebXmlParserErrorHandler(Logger log)
+    {
+        _log = log;
+    }
+
+    @Override
+    public void warning(SAXParseException exception)
+    {
+        if (_log.isLoggable(Level.WARNING))
+        {
+            _log.log(Level.WARNING, getMessage(exception), exception);
+        }
+    }
+
+    @Override
+    public void error(SAXParseException exception)
+    {
+        _log.log(Level.SEVERE, getMessage(exception), exception);
+    }
+
+    @Override
+    public void fatalError(SAXParseException exception)
+    {
+        _log.log(Level.SEVERE, getMessage(exception), exception);
+    }
+
+    private String getMessage(SAXParseException exception)
+    {
+        StringBuilder buf = new StringBuilder();
+        buf.append("SAXParseException at");
+        buf.append(" URI=");
+        buf.append(exception.getSystemId());
+        buf.append(" Line=");
+        buf.append(exception.getLineNumber());
+        buf.append(" Column=");
+        buf.append(exception.getColumnNumber());
+        return buf.toString();
+    }
+
+}

--- a/impl/src/main/java/org/apache/myfaces/util/WebXmlParserUtils.java
+++ b/impl/src/main/java/org/apache/myfaces/util/WebXmlParserUtils.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.myfaces.util;
+
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class WebXmlParserUtils
+{
+    private WebXmlParserUtils()
+    {
+        // hide from public access
+    }
+
+    public static String getElementText(Element elem)
+    {
+        StringBuilder buf = new StringBuilder();
+        NodeList nodeList = elem.getChildNodes();
+        for (int i = 0, len = nodeList.getLength(); i < len; i++)
+        {
+            Node n = nodeList.item(i);
+            if (n.getNodeType() == Node.TEXT_NODE)
+            {
+                buf.append(n.getNodeValue());
+            }
+            else
+            {
+                //TODO see jsf-samples
+                //throw new FacesException("Unexpected node type " + n.getNodeType());
+            }
+        }
+        return buf.toString();
+    }
+
+
+
+    /**
+     * Return content of child element with given tag name.
+     * If more than one children with this name are present, the content of the last
+     * element is returned.
+     *
+     * @param elem
+     * @param childTagName
+     * @return content of child element or null if no child element with this name was found
+     */
+    public static String getChildText(Element elem, String childTagName)
+    {
+        NodeList nodeList = elem.getElementsByTagName(childTagName);
+        int len = nodeList.getLength();
+        if (len == 0)
+        {
+            return null;
+        }
+
+        return getElementText((Element)nodeList.item(len - 1));
+        
+   }
+
+
+    /**
+     * Return list of content Strings of all child elements with given tag name.
+     * @param elem
+     * @param childTagName
+     * @return List 
+     */
+    public static List getChildTextList(Element elem, String childTagName)
+    {
+        NodeList nodeList = elem.getElementsByTagName(childTagName);
+        int len = nodeList.getLength();
+        if (len == 0)
+        {
+            return Collections.EMPTY_LIST;
+        }
+
+        List list = new ArrayList(len);
+        for (int i = 0; i < len; i++)
+        {
+            list.add(getElementText((Element)nodeList.item(i)));
+        }
+        return list;
+        
+   }
+
+}


### PR DESCRIPTION
This fixes MYFACES-4442: https://issues.apache.org/jira/browse/MYFACES-4442

I had to rummage around in the commit history of the current branches and find where these classes used to reside:

1. [ServletMapping](https://github.com/apache/myfaces/commit/ae3da459a80115650e81ca89d870183f0c9c434b#diff-38135243715d25b010f65297f26b41e66cc7205a2d6b9672407fc5d52c301bbb)
2. [WebXml](https://github.com/apache/myfaces/commit/115e2e3a3817e9fdf091a8672dc3bfd58a02ecdb#diff-65b3eb07dd1234eefee5b611904e4af48a2d4a53043ca72c7377e00c37d774ae) I updated this class to correct javax->jakarta, ClassUtils current package, updated import for DelegatedFacesServlet, and updated package for WebXmlParser.
3. [WebXmlParser](https://github.com/apache/myfaces/blob/3.0.x/impl/src/main/java/org/apache/myfaces/shared_impl/webapp/webxml/WebXmlParser.java) Already existed. [History of WebXmlParser](https://github.com/apache/myfaces/commits/main/impl/src/main/java/org/apache/myfaces/util/WebXmlParser.java) I added the following back to it and modified it as necessary to fit into the latest code base: [This is what it looked like before it was moved in the same commit](https://github.com/apache/myfaces/commit/ca63ed50afd5caec20f816864cbce196013e1cbd). The readWebApp method was updated to read the different mappings , which was removed [here](https://github.com/apache/myfaces/commit/ae3da459a80115650e81ca89d870183f0c9c434b).
4. [WebXmlParserErrorHandler](https://github.com/apache/myfaces/commit/ca63ed50afd5caec20f816864cbce196013e1cbd)
5. [WebXmlParserUtils](https://github.com/apache/myfaces/commit/ae3da459a80115650e81ca89d870183f0c9c434b)
