### PR TITLE
2.3-next: ViewScopeBeanHolder register for Quarkus native image

### DIFF
--- a/extensions/quarkus/deployment/src/main/java/org/apache/myfaces/core/extensions/quarkus/deployment/MyFacesProcessor.java
+++ b/extensions/quarkus/deployment/src/main/java/org/apache/myfaces/core/extensions/quarkus/deployment/MyFacesProcessor.java
@@ -34,6 +34,7 @@ import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBundleBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.NativeImageConfigBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.RuntimeInitializedClassBuildItem;
 import io.quarkus.runtime.LaunchMode;
@@ -542,11 +543,18 @@ class MyFacesProcessor
     
     @BuildStep
     @Record(ExecutionTime.STATIC_INIT)
-    void registerForFieldReflection(MyFacesRecorder recorder, BuildProducer<ReflectiveClassBuildItem> reflectiveClass,
+    NativeImageConfigBuildItem registerForFieldReflection(MyFacesRecorder recorder,
+                               BuildProducer<ReflectiveClassBuildItem> reflectiveClass,
                                CombinedIndexBuildItem combinedIndex)
     {     
         reflectiveClass.produce(new ReflectiveClassBuildItem(true, true, 
                 "javax.faces.context._MyFacesExternalContextHelper"));
+
+        // Register ViewScopeBeanHolder to be initialized at runtime, it uses a static random
+        NativeImageConfigBuildItem.Builder builder = NativeImageConfigBuildItem.builder();
+        builder.addRuntimeInitializedClass(ViewScopeBeanHolder.class.getName());
+
+        return builder.build();
     }
 
     @BuildStep


### PR DESCRIPTION
Because `ViewScopeBeanHolder ` has a `    private static final Random RANDOM_GENERATOR = new Random();` for creating GraalVm native images this class must be registered as a special native runtime initialization class.

```shell
Caused by: org.graalvm.compiler.java.BytecodeParser$BytecodeParserError: 
com.oracle.graal.pointsto.constraints.UnsupportedFeatureException: 
Detected an instance of Random/SplittableRandom class in the image heap. Instances created during image generation have cached seed values and don't behave as expected.  To see how this object got instantiated use --trace-object-instantiation=java.util.Random. The object was probably created by a class initializer and is reachable from a static field. You can request class initialization at image runtime by using the option --initialize-at-run-time=<class-name>. 
Or you can write your own initialization methods and call them explicitly from your main entry point.
        at parsing org.apache.myfaces.cdi.view.ViewScopeBeanHolder.generateUniqueViewScopeId(ViewScopeBeanHolder.java:222)
```