### PR TITLE
MYFACES-4454

### DIFF
--- a/api/src/main/java/javax/faces/context/ExternalContextWrapper.java
+++ b/api/src/main/java/javax/faces/context/ExternalContextWrapper.java
@@ -144,7 +144,7 @@ public abstract class ExternalContextWrapper extends ExternalContext implements 
     }
 
     @Override
-    public Map<String,String> getInitParameterMap()
+    public Map getInitParameterMap()
     {
         return getWrapped().getInitParameterMap();
     }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/MYFACES-4454

https://github.com/apache/myfaces/blob/2.3-next/api/src/main/java/javax/faces/context/ExternalContextWrapper.java#L147

 

The other change for this in 4.0 doesn't look to exist in 2.3-next: https://github.com/apache/myfaces/blob/2.3-next/api/src/main/java/javax/faces/render/Renderer.java#L144 (still uses UIComponent correctly vs T)

This is just reverting the same change that was made to the API in 4.0 to cause signature test failures.