### PR TITLE
MYFACES-4456: Add type to HtmlInputText

### DIFF
--- a/api/src/main/java/jakarta/faces/component/html/_HtmlInputText.java
+++ b/api/src/main/java/jakarta/faces/component/html/_HtmlInputText.java
@@ -38,7 +38,7 @@ abstract class _HtmlInputText extends UIInput implements _AccesskeyProperty,
     _AltProperty, _UniversalProperties, _DisabledReadonlyProperties,
     _FocusBlurProperties, _ChangeProperty, _SelectProperty, 
     _EventProperties, _StyleProperties, _TabindexProperty, _LabelProperty, 
-    _RoleProperty
+    _RoleProperty, _TypeProperty
 {
 
     static public final String COMPONENT_FAMILY = "jakarta.faces.Input";

--- a/api/src/main/java/jakarta/faces/component/html/_TypeProperty.java
+++ b/api/src/main/java/jakarta/faces/component/html/_TypeProperty.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package jakarta.faces.component.html;
+
+import org.apache.myfaces.buildtools.maven2.plugin.builder.annotation.JSFProperty;
+
+interface _TypeProperty
+{
+    /**
+     * HTML: How an input works varies considerably depending on the value of its type attribute, 
+     * hence the different types are covered in their own separate reference pages. If this attribute 
+     * is not specified, the default type adopted is text.
+     * 
+     */
+    @JSFProperty
+    public abstract String getType();
+
+}

--- a/impl/src/test/java/org/apache/myfaces/renderkit/html/HtmlTextRendererTest.java
+++ b/impl/src/test/java/org/apache/myfaces/renderkit/html/HtmlTextRendererTest.java
@@ -102,6 +102,31 @@ public class HtmlTextRendererTest extends AbstractJsfTestCase
         Assert.assertEquals("<span class=\"myStyleClass\">Output</span>", output);
         Assert.assertNotSame("Output", output);
     }
+
+    public void testInputDefaultTypeAttr() throws IOException
+    {
+        inputText.encodeBegin(facesContext);
+        inputText.encodeEnd(facesContext);
+        facesContext.renderResponse();
+
+        String output = writer.getWriter().toString();
+        Assert.assertEquals("<input id=\"j_id__v_0\" name=\"j_id__v_0\" type=\"text\" value=\"\"/>", output);
+        Assert.assertNotSame("Output", output);
+    }
+
+    public void testInputTypeAttr() throws IOException
+    {
+        inputText.setType("tel");
+
+        inputText.encodeBegin(facesContext);
+        inputText.encodeEnd(facesContext);
+        facesContext.renderResponse();
+
+        String output = writer.getWriter().toString();
+        Assert.assertEquals("<input id=\"j_id__v_0\" name=\"j_id__v_0\" type=\"tel\" value=\"\"/>", output);
+        Assert.assertNotSame("Output", output);
+    }
+
     
     /**
      * Don't add span over escape
@@ -121,7 +146,7 @@ public class HtmlTextRendererTest extends AbstractJsfTestCase
         Assert.assertEquals("Output", output);
     }
 
-    public void testHtmlPropertyPassTru() throws Exception
+    public void testHtmlPropertyPassThru() throws Exception
     {
         HtmlRenderedAttr[] attrs = HtmlCheckAttributesUtil.generateBasicAttrs();
         


### PR DESCRIPTION
Adds type to HtmlInputText and adds unit tests proving the default is still `type="text"` but can now be set properly on the tag like `type="tel"` etc.