### PR TITLE
MYFACES-4447: avoid UnsupportedOperationException

### DIFF
--- a/impl/src/main/java/org/apache/myfaces/webapp/AbstractFacesInitializer.java
+++ b/impl/src/main/java/org/apache/myfaces/webapp/AbstractFacesInitializer.java
@@ -23,7 +23,6 @@ import org.apache.myfaces.config.FacesConfigurator;
 import org.apache.myfaces.config.RuntimeConfig;
 import org.apache.myfaces.context.servlet.StartupFacesContextImpl;
 import org.apache.myfaces.context.servlet.StartupServletExternalContextImpl;
-import org.apache.myfaces.application.FacesServletMappingUtils;
 import org.apache.myfaces.context.ExceptionHandlerImpl;
 import org.apache.myfaces.application.viewstate.StateUtils;
 import org.apache.myfaces.util.WebConfigParamUtils;
@@ -58,6 +57,7 @@ import java.util.logging.Logger;
 import javax.enterprise.inject.spi.BeanManager;
 import javax.faces.application.ViewVisitOption;
 import javax.faces.push.PushContext;
+import javax.servlet.ServletRegistration;
 import javax.websocket.DeploymentException;
 import javax.websocket.server.ServerContainer;
 import javax.websocket.server.ServerEndpointConfig;
@@ -696,13 +696,15 @@ public abstract class AbstractFacesInitializer implements FacesInitializer
      */
     protected void initAutomaticExtensionlessMapping(FacesContext facesContext, ServletContext servletContext)
     {
-        FacesServletMappingUtils.ServletRegistrationInfo facesServletRegistration =
-                FacesServletMappingUtils.getFacesServletRegistration(facesContext, servletContext);
+        ServletRegistration facesServletRegistration =
+                (ServletRegistration) servletContext.getAttribute(
+                    MyFacesContainerInitializer.FACES_SERVLET_SERVLETREGISTRATION);
+
         if (facesServletRegistration != null)
         {
             facesContext.getApplication().getViewHandler().getViews(facesContext, "/", 
                     ViewVisitOption.RETURN_AS_MINIMAL_IMPLICIT_OUTCOME).forEach(s -> {
-                        facesServletRegistration.getRegistration().addMapping(s);
+                        facesServletRegistration.addMapping(s);
                     });
         }
     }

--- a/impl/src/main/java/org/apache/myfaces/webapp/MyFacesContainerInitializer.java
+++ b/impl/src/main/java/org/apache/myfaces/webapp/MyFacesContainerInitializer.java
@@ -104,6 +104,16 @@ public class MyFacesContainerInitializer implements ServletContainerInitializer
      */
     public static final String FACES_SERVLET_FOUND = "org.apache.myfaces.FACES_SERVLET_FOUND";
 
+    /**
+     * Store the FacesServlet ServletRegistration using this key in the ServletContext.
+     * The is necessary for the MyFaces Extensionless Mapping feature. This is used
+     * in AbstractFacesInitializer when configuring the Extensionless Mapping feature since
+     * an UnsupportedOperationException is thrown when calling the ServletContext.getServletRegistrations
+     * method if the StartupServletContextListener was added programmatically.
+     */
+    public static final String FACES_SERVLET_SERVLETREGISTRATION =
+                "org.apache.myfaces.FACES_SERVLET_SERVLETREGISTRATION";
+
     private static final String FACES_CONFIG_RESOURCE = "/WEB-INF/faces-config.xml";
     private static final Logger log = Logger.getLogger(MyFacesContainerInitializer.class.getName());
     private static final String[] FACES_SERVLET_MAPPINGS = { "/faces/*", "*.jsf", "*.faces" };
@@ -180,6 +190,9 @@ public class MyFacesContainerInitializer implements ServletContainerInitializer
                     // now we have to set a field in the ServletContext to indicate that we have
                     // added the mapping dynamically.
                     servletContext.setAttribute(FACES_SERVLET_ADDED_ATTRIBUTE, Boolean.TRUE);
+
+                    // Add the FacesServlet ServletRegistration as an attribute for use during initialization.
+                    servletContext.setAttribute(FACES_SERVLET_SERVLETREGISTRATION, servlet);
 
                     // add a log message
                     log.log(Level.INFO, "Added FacesServlet with mappings=" + Arrays.toString(mappings));
@@ -324,6 +337,9 @@ public class MyFacesContainerInitializer implements ServletContainerInitializer
                 // we found a FacesServlet; set an attribute for use during initialization
                 servletContext.setAttribute(FACES_SERVLET_FOUND, Boolean.TRUE);
                 isFacesServletPresent = true;
+
+                // Add the FacesServlet ServletRegistration as an attribute for use during initialization.
+                servletContext.setAttribute(FACES_SERVLET_SERVLETREGISTRATION, servletEntry.getValue());
             }
         }
         return isFacesServletPresent;


### PR DESCRIPTION
https://issues.apache.org/jira/browse/MYFACES-4447

The only difference between this PR and the changes for Faces 4.0: https://github.com/apache/myfaces/pull/329/files is I modified the comment in MyFacesContainerInitializer.java to reflect a `MyFaces` feature vs `Faces` feature as it wasn't spec'd until Faces 4.0 as well as updated the reference to `AbstractFacesInitializer` rather than `FacesInitializerImpl ` since these classes are different across the various branches. Of course imports are `javax` and not `jakarta`