### PR TITLE
MYFACES-4479: The jsf.js script does not read the nonce correctly in …

### DIFF
--- a/api/src/main/javascript/META-INF/resources/myfaces/_impl/_util/_Dom.js
+++ b/api/src/main/javascript/META-INF/resources/myfaces/_impl/_util/_Dom.js
@@ -63,8 +63,9 @@ _MF_SINGLTN(_PFX_UTIL + "_Dom", Object, /** @lends myfaces._impl._util._Dom.prot
 
                     newSS.setAttribute("rel", item.getAttribute("rel") || "stylesheet");
                     newSS.setAttribute("type", item.getAttribute("type") || "text/css");
-                    if(item.getAttribute("nonce")) {
-                        newSS.setAttribute("nonce", item.getAttribute("nonce"));
+                    var nonce = item.nonce || item.getAttribute("nonce") || null;
+                    if(nonce) {
+                        newSS.setAttribute("nonce", nonce);
                     }
 
                     document.getElementsByTagName("head")[0].appendChild(newSS);
@@ -136,7 +137,7 @@ _MF_SINGLTN(_PFX_UTIL + "_Dom", Object, /** @lends myfaces._impl._util._Dom.prot
                         _Lang.equalsIgnoreCase(type,"text/ecmascript") ||
                         _Lang.equalsIgnoreCase(type,"ecmascript"))) {
 
-                    var nonce = item.getAttribute("nonce") || null;
+                    var nonce = item.nonce || item.getAttribute("nonce") || null;
 
                     var src = item.getAttribute('src');
                     if ('undefined' != typeof src

--- a/api/src/main/javascript/META-INF/resources/myfaces/_impl/core/_EvalHandlers.js
+++ b/api/src/main/javascript/META-INF/resources/myfaces/_impl/core/_EvalHandlers.js
@@ -105,9 +105,9 @@ if (!myfaces._impl.core._EvalHandlers) {
             }
 
             //since our baseline atm is ie11 we cannot use document.currentScript globally
-            if(document.currentScript && document.currentScript.getAttribute("nonce")) {
+            if(document.currentScript) {
                 //fastpath for modern browsers
-                return document.currentScript.getAttribute("nonce") || null;
+                return document.currentScript.nonce || document.currentScript.getAttribute("nonce") || null;
             }
 
             var scripts = document.querySelectorAll("script[src], link[src]");
@@ -116,7 +116,7 @@ if (!myfaces._impl.core._EvalHandlers) {
             //we search all scripts
             for(var cnt = 0; scripts && cnt < scripts.length; cnt++) {
                 var scriptNode = scripts[cnt];
-                if(!scriptNode.getAttribute("nonce")) {
+                if(!scriptNode.nonce && !scriptNode.getAttribute("nonce")) {
                     continue;
                 }
                 var src = scriptNode.getAttribute("src") || "";
@@ -133,7 +133,7 @@ if (!myfaces._impl.core._EvalHandlers) {
                 nonce: null
             };
             if(jsf_js) {
-                myfaces.config.cspMeta.nonce = jsf_js.getAttribute("nonce") || null;
+                myfaces.config.cspMeta.nonce = jsf_js.nonce || jsf_js.getAttribute("nonce") || null;
             }
             return myfaces.config.cspMeta.nonce;
         };


### PR DESCRIPTION
MYFACES-4479: The jsf.js script does not read the nonce correctly in modern browsers.

In Chrome it is no longer possible to get a nonce with getAttribute("nonce").
You can only use HTMLElement.nonce (see: https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/nonce)