### PR TITLE
MYFACES-4445: websockets refactoring

### DIFF
--- a/impl/src/main/java/org/apache/myfaces/push/EndpointImpl.java
+++ b/impl/src/main/java/org/apache/myfaces/push/EndpointImpl.java
@@ -62,10 +62,23 @@ public class EndpointImpl extends Endpoint
         if (Boolean.TRUE.equals(config.getUserProperties().get(WebsocketConfigurator.WEBSOCKET_VALID)) &&
                 sessionManager.addOrUpdateSession(channelToken, session))
         {
+            // default value 0, could be reconfigured if needed
             session.setMaxIdleTimeout((Long) config.getUserProperties().getOrDefault(
-                    WebsocketConfigurator.MAX_IDLE_TIMEOUT, 300000L));
+                    WebsocketConfigurator.MAX_IDLE_TIMEOUT, 0));
 
             Serializable user = (Serializable) session.getUserProperties().get(WebsocketConfigurator.WEBSOCKET_USER);
+
+            if (LOG.isLoggable(Level.FINE))
+            {
+                LOG.log(Level.FINE, "EndPointImpl.onOpen (channel = {0}, token = {1}, user = {2})",
+                        new Object[] {channel, channelToken, user});
+            }
+
+            // register user
+            if (user != null)
+            {
+                sessionManager.registerUser(user, channel, channelToken);
+            }
 
             beanManager.get().getEvent()
                     .select(WebsocketEvent.Opened.Literal.INSTANCE)
@@ -97,6 +110,11 @@ public class EndpointImpl extends Endpoint
         String channelToken = session.getQueryString();
 
         Serializable user = (Serializable) session.getUserProperties().get(WebsocketConfigurator.WEBSOCKET_USER);
+        if (LOG.isLoggable(Level.FINE))
+        {
+            LOG.log(Level.FINE, "EndPointImpl.onClose (channel = {0}, token = {1}, user = {2})",
+                    new Object[] {channel, channelToken, user});
+        }
 
         if (!beanManager.isInitialized())
         {
@@ -115,7 +133,12 @@ public class EndpointImpl extends Endpoint
         }
 
         WebsocketSessionManager sessionManager = CDIUtils.get(beanManager.get(), WebsocketSessionManager.class);
-        sessionManager.removeSession(channelToken);
+        sessionManager.removeSession(channelToken, session);
+        // deregister user
+        if (user != null)
+        {
+            sessionManager.deregisterUser(user, channel, channelToken);
+        }
 
         beanManager.get().getEvent()
                 .select(WebsocketEvent.Closed.Literal.INSTANCE)

--- a/impl/src/main/java/org/apache/myfaces/push/cdi/WebsocketScopeManager.java
+++ b/impl/src/main/java/org/apache/myfaces/push/cdi/WebsocketScopeManager.java
@@ -103,9 +103,13 @@ public class WebsocketScopeManager
             // When current session scope is about to be destroyed, deregister all session scope channels and
             // explicitly close any open web sockets associated with it to avoid stale websockets.
             // If any, also deregister session users.
-            for (String token : tokens.keySet())
+            for (Map.Entry<String, WebsocketChannelMetadata> entry : tokens.entrySet())
             {
-                sessionManager.removeSession(token);
+                // remove channelToken - only if it is session scope
+                if (WebsocketScopeManager.SCOPE_SESSION.equals(entry.getValue().getScope()))
+                {
+                    sessionManager.removeChannelToken(entry.getKey());
+                }
             }
 
             // we dont need to destroy child sockets ("view")
@@ -172,12 +176,6 @@ public class WebsocketScopeManager
                 {
                     sessionScope.destroyChannelToken(token);
                 }
-            }
-
-            // remove sessions
-            for (String token : tokens.keySet())
-            {
-                sessionManager.removeSession(token);
             }
 
             channelTokens.clear();

--- a/impl/src/main/java/org/apache/myfaces/push/cdi/WebsocketSessionManager.java
+++ b/impl/src/main/java/org/apache/myfaces/push/cdi/WebsocketSessionManager.java
@@ -21,17 +21,30 @@ package org.apache.myfaces.push.cdi;
 
 import jakarta.annotation.PostConstruct;
 import jakarta.enterprise.context.ApplicationScoped;
+
+import java.io.IOException;
+import java.io.Serializable;
 import java.lang.ref.Reference;
 import java.lang.ref.SoftReference;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.Queue;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.Future;
+import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
+
 import jakarta.faces.context.ExternalContext;
+import jakarta.websocket.CloseReason;
 import jakarta.websocket.Session;
 import org.apache.myfaces.config.MyfacesConfig;
 import org.apache.myfaces.push.WebsocketSessionClusterSerializedRestore;
@@ -39,11 +52,19 @@ import org.apache.myfaces.push.Json;
 import org.apache.myfaces.util.lang.ConcurrentLRUCache;
 import org.apache.myfaces.util.lang.Lazy;
 
+import static jakarta.websocket.CloseReason.CloseCodes.NORMAL_CLOSURE;
+
 @ApplicationScoped
 public class WebsocketSessionManager
 {
-    private Lazy<ConcurrentLRUCache<String, Reference<Session>>> sessionMap;
+    private Lazy<ConcurrentLRUCache<String, Collection<Reference<Session>>>> sessionMap;
+
+    private Lazy<ConcurrentHashMap<UserChannelKey, Set<String>>> userMap;
     private Queue<String> restoreQueue;
+
+    private static final CloseReason REASON_EXPIRED = new CloseReason(NORMAL_CLOSURE, "Expired");
+
+    private static final Logger LOG = Logger.getLogger(WebsocketSessionManager.class.getName());
 
     @PostConstruct
     public void init()
@@ -54,17 +75,63 @@ public class WebsocketSessionManager
             return new ConcurrentLRUCache<>((size * 4 + 3) / 3, size);
         });
         restoreQueue = new ConcurrentLinkedQueue<>();
+        userMap = new Lazy<>(ConcurrentHashMap::new);
     }
 
-    public ConcurrentLRUCache<String, Reference<Session>> getSessionMap()
+    public ConcurrentLRUCache<String, Collection<Reference<Session>>> getSessionMap()
     {
         return sessionMap.get();
+    }
+
+    public ConcurrentMap<UserChannelKey, Set<String>> getUserMap()
+    {
+        return userMap.get();
+    }
+
+    public void registerSessionToken(String channelToken)
+    {
+        if (this.getSessionMap().get(channelToken) == null)
+        {
+            this.getSessionMap().put(channelToken, new ConcurrentLinkedQueue<>());
+        }
+    }
+
+    public void registerUser(Serializable user, String channel, String channelToken)
+    {
+        UserChannelKey userChannelKey = new UserChannelKey(user, channel);
+
+        Set<String> channelTokenSet = getUserMap().computeIfAbsent(userChannelKey, k -> new HashSet<>(1));
+        channelTokenSet.add(channelToken);
+    }
+
+    public void deregisterUser(Serializable user, String channel, String channelToken)
+    {
+        UserChannelKey userChannelKey = new UserChannelKey(user, channel);
+
+        synchronized (getUserMap())
+        {
+            Set<String> channelTokenSet = getUserMap().get(userChannelKey);
+            if (channelTokenSet != null)
+            {
+                channelTokenSet.remove(channelToken);
+                if (channelTokenSet.isEmpty())
+                {
+                    getUserMap().remove(userChannelKey);
+                }
+            }
+        }
+    }
+
+    public Set<String> getChannelTokensForUser(Serializable user, String channel)
+    {
+        UserChannelKey userChannelKey = new UserChannelKey(user, channel);
+        return getUserMap().get(userChannelKey);
     }
 
     public void initSessionMap(ExternalContext context)
     {
         int size = MyfacesConfig.getCurrentInstance(context).getWebsocketMaxConnections();
-        ConcurrentLRUCache<String, Reference<Session>> newSessionMap
+        ConcurrentLRUCache<String, Collection<Reference<Session>>> newSessionMap
                 = new ConcurrentLRUCache<>((size * 4 + 3) / 3, size);
         
         synchronized (sessionMap)
@@ -74,13 +141,20 @@ public class WebsocketSessionManager
                 // If a Session has been restored, it could be already a lruCache instantiated, so in this case
                 // we need to fill the new one with the old instances, but only the instances that are active
                 // at the moment.
-                Set<Map.Entry<String, Reference<Session>>> entries = sessionMap.get()
+                Set<Map.Entry<String, Collection<Reference<Session>>>> entries = sessionMap.get()
                         .getLatestAccessedItems(MyfacesConfig.WEBSOCKET_MAX_CONNECTIONS_DEFAULT).entrySet();
-                for (Map.Entry<String, Reference<Session>> entry : entries)
+                for (Map.Entry<String, Collection<Reference<Session>>> entry : entries)
                 {
-                    if (entry.getValue() != null && entry.getValue().get() != null && entry.getValue().get().isOpen())
+                    Collection<Reference<Session>> referenceCollection = entry.getValue();
+                    if (referenceCollection != null)
                     {
-                        newSessionMap.put(entry.getKey(), entry.getValue());
+                        Collection<Reference<Session>> newReferenceCollection =
+                                referenceCollection
+                                        .stream()
+                                        .filter(p -> p.get() != null && p.get().isOpen())
+                                        .distinct()
+                                        .collect(Collectors.toCollection(ConcurrentLinkedQueue::new));
+                        newSessionMap.put(entry.getKey(), newReferenceCollection);
                     }
                 }
             }
@@ -100,14 +174,22 @@ public class WebsocketSessionManager
     
     public boolean addOrUpdateSession(String channelToken, Session session)
     {
-        Reference oldInstance = getSessionMap().get(channelToken);
-        if (oldInstance == null)
+        if (LOG.isLoggable(Level.FINE))
         {
-            getSessionMap().put(channelToken, new SoftReference<>(session));
+            LOG.log (Level.FINE, "WebsocketSessionManager: addOrUpdateSession for channelToken = {0}, " +
+                    "session.id = {1}", new Object[] {channelToken ,session.getId()});
         }
-        else if (!session.equals(oldInstance.get()))
+        Collection<Reference<Session>> sessions = this.getSessionMap().get(channelToken);
+        if (sessions == null)
         {
-            getSessionMap().put(channelToken, new SoftReference<>(session));
+            registerSessionToken(channelToken);
+        }
+        Optional<Reference<Session>> referenceOptional =
+                sessions.stream().filter(p -> Objects.equals(p.get(), session)).findFirst();
+
+        if (!referenceOptional.isPresent())
+        {
+            return sessions.add(new SoftReference<>(session));
         }
         return true;
     }
@@ -121,37 +203,89 @@ public class WebsocketSessionManager
      * @param channelToken
      * @return 
      */
-    public boolean removeSession(String channelToken)
+    public void removeSession(String channelToken, Session session)
     {
-        getSessionMap().remove(channelToken);
-        return false;
+        if (LOG.isLoggable(Level.FINE))
+        {
+            LOG.log (Level.FINE, "WebsocketSessionManager: removeSession for channelToken = {0}, " +
+                    "session.id = {1}", new Object[] {channelToken ,session.getId()});
+        }
+        Collection<Reference<Session>> collection = getSessionMap().get(channelToken);
+        Optional<Reference<Session>> referenceOptional =
+                collection.stream().filter(p -> Objects.equals(p.get(), session)).findFirst();
+        referenceOptional.ifPresent(collection::remove);
     }
-    
-    
+
+    /**
+     * Remove the channelToken and close all sessions associated with it. Happens, when session scope
+     * or view scope is destroyed.
+     * @param channelToken
+     */
+    public void removeChannelToken(String channelToken)
+    {
+        // close all sessions associated with this channelToken
+        Collection<Reference<Session>> sessions = getSessionMap().get(channelToken);
+
+        if (sessions != null)
+        {
+            for (Reference<Session> sessionReference : sessions)
+            {
+                Session session = sessionReference.get();
+                if (session != null && session.isOpen())
+                {
+                    try
+                    {
+                        session.close(REASON_EXPIRED);
+                    }
+                    catch (IOException ignore)
+                    {
+                        // ignored
+                    }
+                }
+            }
+        }
+
+        getSessionMap().remove(channelToken);
+    }
+
     protected Set<Future<Void>> send(String channelToken, Object message)
     {
         // Before send, we need to check 
         synchronizeSessionInstances();
 
         Set<Future<Void>> results = new HashSet<>(1);
-        Reference<Session> sessionRef = (channelToken != null) ? getSessionMap().get(channelToken) : null;
+        Collection<Reference<Session>> sessions = (channelToken != null) ? getSessionMap().get(channelToken) : null;
 
-        if (sessionRef != null && sessionRef.get() != null)
+        if (sessions != null && !sessions.isEmpty())
         {
             String json = Json.encode(message);
-            Session session = sessionRef.get();
-            if (session.isOpen())
-            {
-                send(session, json, results, 0);
-            }
-            else
-            {
-                //If session is not open, remove the session, because a websocket session after is closed cannot
-                //be alive.
-                getSessionMap().remove(channelToken);
-            }
+
+            sessions.forEach (
+                    sessionRef ->
+                    {
+                        if (sessionRef != null && sessionRef.get() != null)
+                        {
+                            Session session = sessionRef.get();
+                            if (session.isOpen())
+                            {
+                                send(session, json, results, 0);
+                            }
+                            else
+                            {
+                                //If session is not open, remove the session, because a websocket
+                                // session after is closed cannot
+                                //be alive.
+                                removeSession(channelToken, session);
+                            }
+                        }
+                    }
+            );
+            return results;
         }
-        return results;
+        else
+        {
+            return Collections.emptySet();
+        }
     }
 
     private final String WARNING_TOMCAT_WEB_SOCKET_BOMBED =
@@ -203,7 +337,7 @@ public class WebsocketSessionManager
                 && illegalStateException.getMessage().contains("[TEXT_FULL_WRITING]");
     }
     
-    private void synchronizeSessionInstances()
+    public void synchronizeSessionInstances()
     {
         Queue<String> queue = getRestoredQueue();
         // The queue is always empty, unless a deserialization of Session instances happen. If that happens, 
@@ -213,34 +347,42 @@ public class WebsocketSessionManager
         if (!queue.isEmpty())
         {
             // It is necessary to have at least 1 registered Session instance to call getOpenSessions() and get all
-            // instances associated to jakarta.faces.push Endpoint.
-            Map<String, Reference<Session>> map = getSessionMap().getLatestAccessedItems(1);
+            // instances associated to javax.faces.push Endpoint.
+            Map<String, Collection<Reference<Session>>> map = getSessionMap().getLatestAccessedItems(1);
             if (map != null && !map.isEmpty())
             {
-                Reference<Session> ref = map.values().iterator().next();
-                if (ref != null)
-                {
-                    Session s = ref.get();
-                    if (s != null)
-                    {
-                        Set<Session> set = s.getOpenSessions();
-                        
-                        for (Iterator<Session> it = set.iterator(); it.hasNext();)
+
+                Collection<Reference<Session>> collectionRef = map.values().iterator().next();
+
+                collectionRef.forEach( ref ->
                         {
-                            Session instance = it.next();
-                            WebsocketSessionClusterSerializedRestore r = 
-                                    (WebsocketSessionClusterSerializedRestore) instance.getUserProperties().get(
-                                        WebsocketSessionClusterSerializedRestore.WEBSOCKET_SESSION_SERIALIZED_RESTORE);
-                            if (r != null && r.isDeserialized())
+                        if (ref != null)
+                        {
+                            Session s = ref.get();
+                            if (s != null)
                             {
-                                addOrUpdateSession(r.getChannelToken(), s);
+                                Set<Session> set = s.getOpenSessions();
+
+                                for (Iterator<Session> it = set.iterator(); it.hasNext(); )
+                                {
+                                    Session instance = it.next();
+                                    WebsocketSessionClusterSerializedRestore r =
+                                            (WebsocketSessionClusterSerializedRestore) instance.
+                                                    getUserProperties().get(
+                            WebsocketSessionClusterSerializedRestore.WEBSOCKET_SESSION_SERIALIZED_RESTORE
+                                                    );
+                                    if (r != null && r.isDeserialized())
+                                    {
+                                        addOrUpdateSession(r.getChannelToken(), s);
+                                    }
+                                }
+
+                                // Remove one element from the queue
+                                queue.poll();
                             }
                         }
-                        
-                        // Remove one element from the queue
-                        queue.poll();
                     }
-                }
+                );
             }
         }
     }
@@ -249,5 +391,39 @@ public class WebsocketSessionManager
     {
         return restoreQueue;
     }
-        
+
+
+    private class UserChannelKey implements Serializable
+    {
+
+        private final Serializable user;
+        private final String channel;
+        public UserChannelKey(Serializable user, String channel)
+        {
+            this.user = user;
+            this.channel = channel;
+        }
+
+        @Override
+        public boolean equals(Object o)
+        {
+            if (this == o)
+            {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass())
+            {
+                return false;
+            }
+            UserChannelKey that = (UserChannelKey) o;
+            return Objects.equals(user, that.user) && Objects.equals(channel, that.channel);
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return Objects.hash(user, channel);
+        }
+    }
+
 }


### PR DESCRIPTION
- reworked channel token generation - new token is generated only if needed (ie new session/view), just one token for application scope
- fixed usage of user-specified channel - now also works even in application scope calls
- changed default max idle timeout for websockets - according to omnifaces/mojarra spec
- specified default websocket scope - according to documentation (session scope for user-specified websocket as default)