### PR TITLE
MYFACES-4493: Allow Jakarta and JCP namespaces for FacesComponent

### DIFF
--- a/api/src/main/java/jakarta/faces/component/FacesComponent.java
+++ b/api/src/main/java/jakarta/faces/component/FacesComponent.java
@@ -32,7 +32,7 @@ import java.lang.annotation.Target;
 @Inherited
 public @interface FacesComponent
 {
-    public static final String NAMESPACE = "http://xmlns.jcp.org/jsf/component";
+    public static final String NAMESPACE = "jakarta.faces.component";
         
     public String value() default "";
     

--- a/impl/src/main/java/org/apache/myfaces/config/annotation/AnnotationConfigurator.java
+++ b/impl/src/main/java/org/apache/myfaces/config/annotation/AnnotationConfigurator.java
@@ -68,6 +68,9 @@ public class AnnotationConfigurator
 {
     private static final Logger log = Logger.getLogger(AnnotationConfigurator.class.getName());
 
+    /* Added under MYFACES-4493 for Namespace Backward Compatibility */
+    private final static String JCP_NAMESPACE_FACES_COMPONENT = "http://xmlns.jcp.org/jsf/component";
+    
     public AnnotationConfigurator()
     {
     }
@@ -125,8 +128,10 @@ public class AnnotationConfigurator
                             tagName = Character.toLowerCase(tagName.charAt(0)) + tagName.substring(1);
                         }
 
-                        facesConfig.addComponentTagDeclaration(value, 
-                                new ComponentTagDeclarationImpl(value, comp.namespace(), tagName));
+                        facesConfig.addComponentTagDeclaration(
+                            new ComponentTagDeclarationImpl(value, comp.namespace(), tagName));
+                        facesConfig.addComponentTagDeclaration(
+                            new ComponentTagDeclarationImpl(value, JCP_NAMESPACE_FACES_COMPONENT, tagName));
                     }
                 }
             }

--- a/impl/src/main/java/org/apache/myfaces/config/element/FacesConfig.java
+++ b/impl/src/main/java/org/apache/myfaces/config/element/FacesConfig.java
@@ -90,12 +90,12 @@ public abstract class FacesConfig implements Serializable
     }
     
     /**
-     * @since 2.2.0
+     * @since 4.0.0
      * @return 
      */
-    public Map<String, ComponentTagDeclaration> getComponentTagDeclarations()
+    public List<ComponentTagDeclaration> getComponentTagDeclarations()
     {
-        return Collections.emptyMap();
+        return Collections.emptyList();
     }
     
     /**

--- a/impl/src/main/java/org/apache/myfaces/config/impl/FacesConfigDispenserImpl.java
+++ b/impl/src/main/java/org/apache/myfaces/config/impl/FacesConfigDispenserImpl.java
@@ -323,7 +323,7 @@ public class FacesConfigDispenserImpl extends FacesConfigDispenser
             }
         }
 
-        componentTagDeclarations.addAll(config.getComponentTagDeclarations().values());
+        componentTagDeclarations.addAll(config.getComponentTagDeclarations());
 
         faceletTagLibraries.addAll(config.getFaceletTagLibraryList());
 

--- a/impl/src/main/java/org/apache/myfaces/config/impl/element/FacesConfigImpl.java
+++ b/impl/src/main/java/org/apache/myfaces/config/impl/element/FacesConfigImpl.java
@@ -52,7 +52,7 @@ public class FacesConfigImpl extends org.apache.myfaces.config.element.FacesConf
     private List<Application> applications;
     private List<Factory> factories;
     private List<Component> components;
-    private Map<String, ComponentTagDeclaration> componentTagDeclarations;
+    private List<ComponentTagDeclaration> componentTagDeclarations;
     private List<Converter> converters;
     private List<NavigationRule> navigationRules;
     private List<RenderKit> renderKits;
@@ -69,7 +69,7 @@ public class FacesConfigImpl extends org.apache.myfaces.config.element.FacesConf
     private transient List<Application> unmodifiableApplications;
     private transient List<Factory> unmodifiableFactories;
     private transient List<Component> unmodifiableComponents;
-    private transient Map<String, ComponentTagDeclaration> unmodifiableComponentTagDeclarations;
+    private transient List<ComponentTagDeclaration> unmodifiableComponentTagDeclarations;
     private transient List<Converter> unmodifiableConverters;
     private transient List<NavigationRule> unmodifiableNavigationRules;
     private transient List<RenderKit> unmodifiableRenderKits;
@@ -119,13 +119,13 @@ public class FacesConfigImpl extends org.apache.myfaces.config.element.FacesConf
         components.add(component);
     }
     
-    public void addComponentTagDeclaration(String componentType, ComponentTagDeclaration tagDeclaration)
+    public void addComponentTagDeclaration(ComponentTagDeclaration tagDeclaration)
     {
         if (componentTagDeclarations == null)
         {
-            componentTagDeclarations = new HashMap<>();
+            componentTagDeclarations = new ArrayList<>();
         }
-        componentTagDeclarations.put(componentType, tagDeclaration);
+        componentTagDeclarations.add(tagDeclaration);
     }
 
     public void addConverter(Converter converter)
@@ -289,15 +289,15 @@ public class FacesConfigImpl extends org.apache.myfaces.config.element.FacesConf
     }
     
     @Override
-    public Map<String, ComponentTagDeclaration> getComponentTagDeclarations()
+    public List<ComponentTagDeclaration> getComponentTagDeclarations()
     {
         if (componentTagDeclarations == null)
         {
-            return Collections.emptyMap();
+            return Collections.emptyList();
         }
         if (unmodifiableComponentTagDeclarations == null)
         {
-            unmodifiableComponentTagDeclarations = Collections.unmodifiableMap(componentTagDeclarations);
+            unmodifiableComponentTagDeclarations = Collections.unmodifiableList(componentTagDeclarations);
         }
         return unmodifiableComponentTagDeclarations;
     }


### PR DESCRIPTION
I've also changed componentTagDeclarations / unmodifiableComponentTagDeclarations from a  Map to a List to avoid key conflicts and I noticed keys weren't even used (only the values).  Unless a Map was intentional to avoid duplicates, but a set should have been used instead? Nevertheless, Map changed to List and all our unit tests still pass. 

https://issues.apache.org/jira/browse/MYFACES-4493 