### PR TITLE
MYFACES-4501 follow up: Remove writePreamble

### DIFF
--- a/impl/src/main/java/org/apache/myfaces/context/servlet/PartialViewContextImpl.java
+++ b/impl/src/main/java/org/apache/myfaces/context/servlet/PartialViewContextImpl.java
@@ -431,8 +431,7 @@ public class PartialViewContextImpl extends PartialViewContext
         try
         {
             String currentEncoding = writer.getCharacterEncoding();
-            writer.writePreamble("<?xml version=\"1.0\" encoding=\""+
-                (currentEncoding == null ? "UTF-8" : currentEncoding) +"\"?>");
+
             writer.startDocument();
             
             writer.writeAttribute("id", viewRoot.getContainerClientId(context),"id");


### PR DESCRIPTION
 Since it's now done in the startDocument call.
 
 This caused the preamble to be written twice which in turn caused some pages to fail since the JS wasn't expecting two preambles. 