### PR TITLE
Fix for https://issues.apache.org/jira/browse/MYFACES-4040

### DIFF
--- a/api/src/main/javascript/META-INF/resources/myfaces/api/faces.js
+++ b/api/src/main/javascript/META-INF/resources/myfaces/api/faces.js
@@ -474,7 +474,8 @@ if (!myfaces.ab) {
         }
 
         if (eventName) {
-            options["jakarta.faces.behavior.event"] = eventName;
+            options["params"] = options.params || {};
+            options.params["jakarta.faces.behavior.event"] = eventName;
         }
         if (execute) {
             options["execute"] = execute;

--- a/impl/src/main/java/org/apache/myfaces/renderkit/html/util/AjaxScriptBuilder.java
+++ b/impl/src/main/java/org/apache/myfaces/renderkit/html/util/AjaxScriptBuilder.java
@@ -196,8 +196,11 @@ public class AjaxScriptBuilder
             {
                 appendProperty(sb, "resetValues", resetValues, false);
             }
+
             if ((params != null && !params.isEmpty()) || (uiParams != null && !uiParams.isEmpty()))
             {
+                StringBuilder paramsBuilder = new StringBuilder();
+                paramsBuilder.append('{');
                 if (params != null && !params.isEmpty())
                 {
                     if (params instanceof RandomAccess)
@@ -206,14 +209,14 @@ public class AjaxScriptBuilder
                         for (int i = 0, size = list.size(); i < size; i++)
                         {
                             ClientBehaviorContext.Parameter param = list.get(i);
-                            appendProperty(sb, param.getName(), param.getValue(), true);
+                            appendProperty(paramsBuilder, param.getName(), param.getValue(), true);
                         }
                     }
                     else
                     {
                         for (ClientBehaviorContext.Parameter param : params)
                         {
-                            appendProperty(sb, param.getName(), param.getValue(), true);
+                            appendProperty(paramsBuilder, param.getName(), param.getValue(), true);
                         }
                     }
                 }
@@ -223,9 +226,12 @@ public class AjaxScriptBuilder
                     for (int i = 0, size = uiParams.size(); i < size; i++)
                     {
                         UIParameter param = uiParams.get(i);
-                        appendProperty(sb, param.getName(), param.getValue(), true);
+                        appendProperty(paramsBuilder, param.getName(), param.getValue(), true);
                     }
                 }
+                paramsBuilder.append('}');
+                sb.append("params: ");
+                sb.append(paramsBuilder);
             }
 
             sb.append('}');
@@ -259,6 +265,7 @@ public class AjaxScriptBuilder
         
         sb.append('\'');
     }
+
 
     public static void appendProperty(StringBuilder builder, 
                                       String name,


### PR DESCRIPTION
Fix for MYFACES-4040, in my own integration tests:


```xml
           <h:commandLink id="submitButton" value="Click here" action="#{myBean2.execute}">
                <f:ajax execute="@this" render="output" />
                <f:param name="hello2" value="Hello from f:param"/>
                <f:param name="Hello World" value="Hello from f:param2"/>
                <f:param name="render" value="output2"/>
                <f:param name="execute" value="booga"/>
           </h:commandLink>

           <h:panelGroup id="results">
                <h:outputText id="output" value="#{myBean2.helloWorld}"></h:outputText>
           </h:panelGroup>
```

Now resolves to:

```html
<a href="#" onclick="faces.util.chain(this, event,function(event){myfaces.ab(this,event,'action','submitButton','output',{params: {'hello2':'Hello from f:param','Hello World':'Hello from f:param2','render':'output2','execute':'booga'}})}); return false;" id="submitButton" name="submitButton">Click here</a>
```

and the test which searches for an updated output element passes, the render and execute f:params are now part of "param"
Also the request parameters are now as following:

```javascript
form1_SUBMIT: 1
jakarta.faces.ViewState: ZDU1NmJhYjk2NmVjZDQ5YjAwMDAwMDJk
hello2:  Hello from f:param
Hello World: Hello from f:param2
render: output2
execute: booga
jakarta.faces.behavior.event: action
jakarta.faces.partial.event: click
jakarta.faces.source: submitButton
jakarta.faces.partial.ajax: true
jakarta.faces.partial.execute: submitButton
jakarta.faces.partial.render: output
form1: form1
```
@tandraschko , @volosied:  please test I wont merge the fix until you give the ok
