### PR TITLE
[SPEC 1574 / MYFACES-4528 ] Ensure top level ul does not have border attribute

### DIFF
--- a/impl/src/main/java/org/apache/myfaces/renderkit/html/base/HtmlCheckboxRendererBase.java
+++ b/impl/src/main/java/org/apache/myfaces/renderkit/html/base/HtmlCheckboxRendererBase.java
@@ -141,7 +141,14 @@ public class HtmlCheckboxRendererBase extends HtmlRenderer
         ResponseWriter writer = facesContext.getResponseWriter();
 
         writer.startElement(usingTable != null ? HTML.TABLE_ELEM : HTML.UL_ELEM, selectMany);
-        HtmlRendererUtils.renderHTMLAttributes(writer, selectMany, HTML.SELECT_TABLE_PASSTHROUGH_ATTRIBUTES);
+        if(usingTable != null) 
+        {
+            HtmlRendererUtils.renderHTMLAttributes(writer, selectMany, HTML.SELECT_TABLE_PASSTHROUGH_ATTRIBUTES);
+        }
+        else 
+        {
+            HtmlRendererUtils.renderHTMLAttributes(writer, selectMany, HTML.UL_PASSTHROUGH_ATTRIBUTES);
+        }
         
         Map<String, List<ClientBehavior>> behaviors = null;
         if (selectMany instanceof ClientBehaviorHolder)

--- a/impl/src/main/java/org/apache/myfaces/renderkit/html/base/HtmlRadioRendererBase.java
+++ b/impl/src/main/java/org/apache/myfaces/renderkit/html/base/HtmlRadioRendererBase.java
@@ -164,8 +164,14 @@ public class HtmlRadioRendererBase extends HtmlRenderer
         {
             // Render as single component
             writer.startElement(usingTable != null ? HTML.TABLE_ELEM : HTML.UL_ELEM, selectOne);
-            HtmlRendererUtils.renderHTMLAttributes(writer, selectOne,
-                                                   HTML.SELECT_TABLE_PASSTHROUGH_ATTRIBUTES);
+            if(usingTable != null) 
+            {
+                HtmlRendererUtils.renderHTMLAttributes(writer, selectOne, HTML.SELECT_TABLE_PASSTHROUGH_ATTRIBUTES);
+            }
+            else 
+            {
+                HtmlRendererUtils.renderHTMLAttributes(writer, selectOne, HTML.UL_PASSTHROUGH_ATTRIBUTES);
+            }
 
             if (behaviors != null && !behaviors.isEmpty())
             {


### PR DESCRIPTION
Based on the SPEC issue here: https://github.com/jakartaee/faces/issues/1574

When layout="list" the border attribute should be ignored. 

When a form like this:
```xml
<h:form id="form">
	<h:selectManyCheckbox id="input" layout="list" border="5">
          ...
	</h:selectManyCheckbox>
</h:form>
```

Is rendered the current output is: 
```xml
<html>
  <head/>
  <body>
    <form id="form" name="form" method="post" action="/LayoutAttribute/selectManyCheckBox.xhtml" enctype="application/x-www-form-urlencoded">
      <ul id="form:input" border="5">
        ...
      </ul>
  </body>
</html>
```

Based on the spec we should be rendering: 
```xml
<html>
  <head/>
  <body>
    <form id="form" name="form" method="post" action="/LayoutAttribute/selectManyCheckBox.xhtml" enctype="application/x-www-form-urlencoded">
      <ul id="form:input">
        ...
      </ul>
  </body>
</html>
```

This is because we are incorrectly starting this element with table passthrough properties, instead of ul passthrough properties. 