### PR TITLE
fix: enable integration tests

### DIFF
--- a/integration-tests/ajax/src/test/java/org/apache/myfaces/core/integrationtests/ajax/IntegrationTest.java
+++ b/integration-tests/ajax/src/test/java/org/apache/myfaces/core/integrationtests/ajax/IntegrationTest.java
@@ -25,8 +25,9 @@ import org.jboss.arquillian.graphene.javascript.JavaScript;
 import org.jboss.arquillian.graphene.request.RequestGuard;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.importer.ZipImporter;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.jboss.shrinkwrap.resolver.api.maven.embedded.EmbeddedMaven;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -59,15 +60,9 @@ public class IntegrationTest {
 
     @Deployment(testable = false)
     public static WebArchive createDeployment() {
-        WebArchive webArchive = (WebArchive) EmbeddedMaven.forProject(new File("pom.xml"))
-                .useMaven3Version("3.3.9")
-                .setGoals("package")
-                .setQuiet()
-                .skipTests(true)
-                .ignoreFailure()
-                .build().getDefaultBuiltArchive();
-
-        return webArchive;
+        return ShrinkWrap.create(ZipImporter.class, "ajax.war")
+                .importFrom(new File("target/ajax.war"))
+                .as(WebArchive.class);
     }
 
     @Drone

--- a/integration-tests/ajax/src/test/resources/arquillian.xml
+++ b/integration-tests/ajax/src/test/resources/arquillian.xml
@@ -22,7 +22,7 @@
     xmlns="http://jboss.org/schema/arquillian">
 
     <extension qualifier="webdriver">
-        <property name="browser">chrome</property>
+        <property name="browser">chromeHeadless</property>
     </extension>
 
     <container qualifier="tomcat" default="true">

--- a/integration-tests/autoLookupExpressionFactoryWithoutJSP/src/test/java/org/apache/myfaces/core/integrationtests/IntegrationTest.java
+++ b/integration-tests/autoLookupExpressionFactoryWithoutJSP/src/test/java/org/apache/myfaces/core/integrationtests/IntegrationTest.java
@@ -25,8 +25,9 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.drone.api.annotation.Drone;
 import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.importer.ZipImporter;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.jboss.shrinkwrap.resolver.api.maven.embedded.EmbeddedMaven;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -41,15 +42,9 @@ public class IntegrationTest
     @Deployment(testable = false)
     public static WebArchive createDeployment()
     {
-        WebArchive webArchive = (WebArchive) EmbeddedMaven.forProject(new File("pom.xml"))
-                .useMaven3Version("3.3.9")
-                .setGoals("package")
-                .setQuiet()
-                .skipTests(true)
-                .ignoreFailure()
-                .build().getDefaultBuiltArchive();
-
-        return webArchive;
+        return ShrinkWrap.create(ZipImporter.class, "exactMapping.war")
+                .importFrom(new File("target/autoLookupExpressionFactoryWithoutJSP.war"))
+                .as(WebArchive.class);
     }
 
     @Drone

--- a/integration-tests/autoLookupExpressionFactoryWithoutJSP/src/test/resources/arquillian.xml
+++ b/integration-tests/autoLookupExpressionFactoryWithoutJSP/src/test/resources/arquillian.xml
@@ -22,7 +22,7 @@
     xmlns="http://jboss.org/schema/arquillian">
 
     <extension qualifier="webdriver">
-        <property name="browser">chrome</property>
+        <property name="browser">chromeHeadless</property>
     </extension>
 
     <container qualifier="tomcat" default="true">

--- a/integration-tests/automaticExtensionlessMapping/src/test/java/org/apache/myfaces/core/integrationtests/IntegrationTest.java
+++ b/integration-tests/automaticExtensionlessMapping/src/test/java/org/apache/myfaces/core/integrationtests/IntegrationTest.java
@@ -25,8 +25,9 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.drone.api.annotation.Drone;
 import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.importer.ZipImporter;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.jboss.shrinkwrap.resolver.api.maven.embedded.EmbeddedMaven;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -41,15 +42,9 @@ public class IntegrationTest
     @Deployment(testable = false)
     public static WebArchive createDeployment()
     {
-        WebArchive webArchive = (WebArchive) EmbeddedMaven.forProject(new File("pom.xml"))
-                .useMaven3Version("3.3.9")
-                .setGoals("package")
-                .setQuiet()
-                .skipTests(true)
-                .ignoreFailure()
-                .build().getDefaultBuiltArchive();
-
-        return webArchive;
+        return ShrinkWrap.create(ZipImporter.class, "automaticExtensionlessMapping.war")
+                .importFrom(new File("target/automaticExtensionlessMapping.war"))
+                .as(WebArchive.class);
     }
 
     @Drone

--- a/integration-tests/automaticExtensionlessMapping/src/test/resources/arquillian.xml
+++ b/integration-tests/automaticExtensionlessMapping/src/test/resources/arquillian.xml
@@ -22,7 +22,7 @@
     xmlns="http://jboss.org/schema/arquillian">
 
     <extension qualifier="webdriver">
-        <property name="browser">chrome</property>
+        <property name="browser">chromeHeadless</property>
     </extension>
 
     <container qualifier="tomcat" default="true">

--- a/integration-tests/exactMapping/src/test/java/org/apache/myfaces/core/integrationtests/IntegrationTest.java
+++ b/integration-tests/exactMapping/src/test/java/org/apache/myfaces/core/integrationtests/IntegrationTest.java
@@ -26,8 +26,9 @@ import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.drone.api.annotation.Drone;
 import org.jboss.arquillian.graphene.Graphene;
 import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.importer.ZipImporter;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.jboss.shrinkwrap.resolver.api.maven.embedded.EmbeddedMaven;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -44,15 +45,9 @@ public class IntegrationTest
     @Deployment(testable = false)
     public static WebArchive createDeployment()
     {
-        WebArchive webArchive = (WebArchive) EmbeddedMaven.forProject(new File("pom.xml"))
-                .useMaven3Version("3.3.9")
-                .setGoals("package")
-                .setQuiet()
-                .skipTests(true)
-                .ignoreFailure()
-                .build().getDefaultBuiltArchive();
-
-        return webArchive;
+        return ShrinkWrap.create(ZipImporter.class, "exactMapping.war")
+                .importFrom(new File("target/exactMapping.war"))
+                .as(WebArchive.class);
     }
 
     @Drone

--- a/integration-tests/exactMapping/src/test/resources/arquillian.xml
+++ b/integration-tests/exactMapping/src/test/resources/arquillian.xml
@@ -22,7 +22,7 @@
     xmlns="http://jboss.org/schema/arquillian">
 
     <extension qualifier="webdriver">
-        <property name="browser">chrome</property>
+        <property name="browser">chromeHeadless</property>
     </extension>
 
     <container qualifier="tomcat" default="true">

--- a/integration-tests/faceletToXhtmlMapping/src/test/java/org/apache/myfaces/core/integrationtests/IntegrationTest.java
+++ b/integration-tests/faceletToXhtmlMapping/src/test/java/org/apache/myfaces/core/integrationtests/IntegrationTest.java
@@ -25,8 +25,9 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.drone.api.annotation.Drone;
 import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.importer.ZipImporter;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.jboss.shrinkwrap.resolver.api.maven.embedded.EmbeddedMaven;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -41,15 +42,9 @@ public class IntegrationTest
     @Deployment(testable = false)
     public static WebArchive createDeployment()
     {
-        WebArchive webArchive = (WebArchive) EmbeddedMaven.forProject(new File("pom.xml"))
-                .useMaven3Version("3.8.6")
-                .setGoals("package")
-                .setQuiet(false)
-                .skipTests(true)
-                .ignoreFailure()
-                .build().getDefaultBuiltArchive();
-
-        return webArchive;
+        return ShrinkWrap.create(ZipImporter.class, "faceletToXhtmlMapping.war")
+                .importFrom(new File("target/faceletToXhtmlMapping.war"))
+                .as(WebArchive.class);
     }
 
     @Drone

--- a/integration-tests/faceletToXhtmlMapping/src/test/java/org/apache/myfaces/core/integrationtests/IntegrationTest.java
+++ b/integration-tests/faceletToXhtmlMapping/src/test/java/org/apache/myfaces/core/integrationtests/IntegrationTest.java
@@ -42,9 +42,9 @@ public class IntegrationTest
     public static WebArchive createDeployment()
     {
         WebArchive webArchive = (WebArchive) EmbeddedMaven.forProject(new File("pom.xml"))
-                .useMaven3Version("3.3.9")
+                .useMaven3Version("3.8.6")
                 .setGoals("package")
-                .setQuiet()
+                .setQuiet(false)
                 .skipTests(true)
                 .ignoreFailure()
                 .build().getDefaultBuiltArchive();

--- a/integration-tests/faceletToXhtmlMapping/src/test/resources/arquillian.xml
+++ b/integration-tests/faceletToXhtmlMapping/src/test/resources/arquillian.xml
@@ -22,7 +22,7 @@
     xmlns="http://jboss.org/schema/arquillian">
 
     <extension qualifier="webdriver">
-        <property name="browser">chrome</property>
+        <property name="browser">chromeHeadless</property>
     </extension>
 
     <container qualifier="tomcat" default="true">

--- a/integration-tests/faceletToXhtmlMappingDisabled/src/test/java/org/apache/myfaces/core/integrationtests/IntegrationTest.java
+++ b/integration-tests/faceletToXhtmlMappingDisabled/src/test/java/org/apache/myfaces/core/integrationtests/IntegrationTest.java
@@ -25,8 +25,9 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.drone.api.annotation.Drone;
 import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.importer.ZipImporter;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.jboss.shrinkwrap.resolver.api.maven.embedded.EmbeddedMaven;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -41,15 +42,9 @@ public class IntegrationTest
     @Deployment(testable = false)
     public static WebArchive createDeployment()
     {
-        WebArchive webArchive = (WebArchive) EmbeddedMaven.forProject(new File("pom.xml"))
-                .useMaven3Version("3.3.9")
-                .setGoals("package")
-                .setQuiet()
-                .skipTests(true)
-                .ignoreFailure()
-                .build().getDefaultBuiltArchive();
-
-        return webArchive;
+        return ShrinkWrap.create(ZipImporter.class, "faceletToXhtmlMappingDisabled.war")
+                .importFrom(new File("target/faceletToXhtmlMappingDisabled.war"))
+                .as(WebArchive.class);
     }
 
     @Drone

--- a/integration-tests/faceletToXhtmlMappingDisabled/src/test/resources/arquillian.xml
+++ b/integration-tests/faceletToXhtmlMappingDisabled/src/test/resources/arquillian.xml
@@ -22,7 +22,7 @@
         xmlns="http://jboss.org/schema/arquillian">
 
     <extension qualifier="webdriver">
-        <property name="browser">chrome</property>
+        <property name="browser">chromeHeadless</property>
     </extension>
 
     <container qualifier="tomcat" default="true">

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -114,7 +114,13 @@
         <dependency>
             <groupId>org.seleniumhq.selenium</groupId>
             <artifactId>selenium-java</artifactId>
-            <version>3.13.0</version>
+            <version>3.141.59</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>2.10</version>
             <scope>test</scope>
         </dependency>
 
@@ -122,7 +128,7 @@
         <dependency>
             <groupId>org.jboss.arquillian.junit</groupId>
             <artifactId>arquillian-junit-container</artifactId>
-            <version>1.7.0.Alpha10</version>
+            <version>1.7.0.Alpha13</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -192,7 +198,7 @@
                 <dependency>
                     <groupId>org.jboss.arquillian.container</groupId>
                     <artifactId>arquillian-tomcat-embedded-10</artifactId>
-                    <version>1.2.0.Alpha1</version>
+                    <version>1.2.0.Final</version>
                     <scope>test</scope>
                 </dependency>
                 <dependency>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -40,8 +40,9 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.22.2</version>
+                <version>3.0.0-M7</version>
                 <configuration>
+                    <trimStackTrace>false</trimStackTrace>
                     <systemPropertyVariables>
                         <tomcat.util.scan.StandardJarScanFilter.jarsToSkip>serializer.jar</tomcat.util.scan.StandardJarScanFilter.jarsToSkip>
                         <tomcat.util.scan.DefaultJarScanner.jarsToSkip>serializer.jar</tomcat.util.scan.DefaultJarScanner.jarsToSkip>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -28,6 +28,7 @@
     <packaging>pom</packaging>
 
     <build>
+        <finalName>${project.artifactId}</finalName>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -47,7 +48,26 @@
                         <tomcat.util.scan.StandardJarScanFilter.jarsToSkip>serializer.jar</tomcat.util.scan.StandardJarScanFilter.jarsToSkip>
                         <tomcat.util.scan.DefaultJarScanner.jarsToSkip>serializer.jar</tomcat.util.scan.DefaultJarScanner.jarsToSkip>
                     </systemPropertyVariables>
+                    <excludes>
+                        <exclude>**/*IntegrationTest</exclude>
+                    </excludes>
                 </configuration>
+                <executions>
+                    <execution>
+                        <phase>integration-test</phase>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                        <configuration>
+                            <excludes>
+                                <exclude>none</exclude>
+                            </excludes>
+                            <includes>
+                                <include>**/*IntegrationTest</include>
+                            </includes>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
 
             <plugin>

--- a/integration-tests/protectedViews/src/test/java/org/apache/myfaces/core/integrationtests/IntegrationTest.java
+++ b/integration-tests/protectedViews/src/test/java/org/apache/myfaces/core/integrationtests/IntegrationTest.java
@@ -26,8 +26,9 @@ import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.drone.api.annotation.Drone;
 import org.jboss.arquillian.graphene.Graphene;
 import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.importer.ZipImporter;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.jboss.shrinkwrap.resolver.api.maven.embedded.EmbeddedMaven;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -44,15 +45,9 @@ public class IntegrationTest
     @Deployment(testable = false)
     public static WebArchive createDeployment()
     {
-        WebArchive webArchive = (WebArchive) EmbeddedMaven.forProject(new File("pom.xml"))
-                .useMaven3Version("3.3.9")
-                .setGoals("package")
-                .setQuiet()
-                .skipTests(true)
-                .ignoreFailure()
-                .build().getDefaultBuiltArchive();
-
-        return webArchive;
+        return ShrinkWrap.create(ZipImporter.class, "protectedViews.war")
+                .importFrom(new File("target/protectedViews.war"))
+                .as(WebArchive.class);
     }
 
     @Drone

--- a/integration-tests/protectedViews/src/test/resources/arquillian.xml
+++ b/integration-tests/protectedViews/src/test/resources/arquillian.xml
@@ -22,7 +22,7 @@
     xmlns="http://jboss.org/schema/arquillian">
 
     <extension qualifier="webdriver">
-        <property name="browser">chrome</property>
+        <property name="browser">chromeHeadless</property>
     </extension>
 
     <container qualifier="tomcat" default="true">

--- a/pom.xml
+++ b/pom.xml
@@ -55,8 +55,8 @@
         <module>test</module>
         <module>impl</module>
         <module>bundle</module>
-        <!--
         <module>integration-tests</module>
+        <!--
         <module>extensions</module>
         -->
     </modules>


### PR DESCRIPTION
There are two problems with the integration tests.

- The Maven embedded build in the integration tests can't resolve the produced artifacts of myfaces because that is a new Maven build. Moving the execution of the integration tests after the package phase allows to reference the produced war with the myfaces artifacts.
- chrome should be headless 