### PR TITLE
Skip integration-tests deployment

### DIFF
--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -91,6 +91,15 @@
                     <target>${java.version}</target>
                 </configuration>
             </plugin>
+            <!-- Skip deployment for this module as it's testing -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <version>3.0.0</version>
+                <configuration>
+                  <skip>true</skip>
+                </configuration>
+              </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
During the RC3 release prep, maven asked me: 
```
...
What is the release version for "Apache MyFaces Core 4.0 - Integration Tests - ajax"? (org.apache.myfaces.core.integration-tests:ajax) 4.0.0: : 4.0.0-RC3
What is the release version for "Apache MyFaces Core 4.0 - Integration Tests - automaticExtensionlessMapping"? (org.apache.myfaces.core.integration-tests:automaticExtensionlessMapping) 4.0.0: : 4.0.0-RC3
...
```

Rather not deploy this integration tests module as it's just testing, so I added the skip configuration.