### PR TITLE
Fix javadoc "bad use of '>'" errors

### DIFF
--- a/integration-tests/ajax/src/main/java/org/apache/myfaces/core/integrationtests/ajax/test1Protocol/responseWriter/PartialResponseWriterImpl.java
+++ b/integration-tests/ajax/src/main/java/org/apache/myfaces/core/integrationtests/ajax/test1Protocol/responseWriter/PartialResponseWriterImpl.java
@@ -34,14 +34,14 @@ import java.util.Map;
  * NOTE the class is a work in progress it is not finished yet
  * and therefore not combined with the rest of the codebase
  *
- * Flow UIViewRoot: insert or update -> eval  javascripts must be deferred
+ * Flow UIViewRoot: insert or update - eval  javascripts must be deferred
  * until the insert update or delete is done
  *
- * insert or update -> script src type="text/javascript"
+ * insert or update - script src type="text/javascript"
  * also must be delayed until the insert
  * or update is done!
  *
- * single elements startElement no script -> passthrough
+ * single elements startElement no script - passthrough
  * script wait for end...
  *
  * Note our evals are directly stored in a stringbuilder, we have


### PR DESCRIPTION
```
[INFO] [ERROR]                                                   ^
[INFO] [ERROR] /Users/volosied/opensource/myfaces/target/checkout/integration-tests/ajax/src/main/java/org/apache/myfaces/core/integrationtests/ajax/test1Protocol/responseWriter/PartialResponseWriterImpl.java:37: error: bad use of '>'
[INFO] [ERROR]  * Flow UIViewRoot: insert or update -> eval  javascripts must be deferred
[INFO] [ERROR]                                       ^
[INFO] [ERROR] /Users/volosied/opensource/myfaces/target/checkout/integration-tests/ajax/src/main/java/org/apache/myfaces/core/integrationtests/ajax/test1Protocol/responseWriter/PartialResponseWriterImpl.java:40: error: bad use of '>'
[INFO] [ERROR]  * insert or update -> script src type="text/javascript"
...
```
Now shows:
integration-tests % mvn javadoc:javadoc

[INFO] BUILD SUCCESS