### PR TITLE
https://issues.apache.org/jira/browse/MYFACES-4538: 3.0.x

### DIFF
--- a/api/src/assembler/jsdoc-compiler.xml
+++ b/api/src/assembler/jsdoc-compiler.xml
@@ -50,7 +50,6 @@
     <include>**/_impl/xhrCore/engine/IFrame.js</include>
 
     <include>**/_impl/xhrCore/_AjaxRequest.js</include>
-    <include>**/_impl/xhrCore/_AjaxRequestLevel2.js</include>
     <!-- not yet used in 2.0 but for development purposes it makes sense to include it here -->
     <include>**/_impl/xhrCore/_IFrameRequest.js</include>
     <include>**/_impl/xhrCore/_AjaxResponse.js</include>

--- a/api/src/assembler/jsfscripts-compiler.xml
+++ b/api/src/assembler/jsfscripts-compiler.xml
@@ -43,7 +43,7 @@
                 <include>**/_impl/core/_EvalHandlers.js</include>
 
                 <include>**/_impl/core/_Runtime.js</include>
-                <include>**/_impl/core/_RuntimeQuirks.js</include>
+                <include>**/_impl/quirks/_RuntimeQuirks.js</include>
 
                 <include>**/_impl/core/_StartImpl.js</include>
                 <include>**/_impl/i18n/Messages.js</include>
@@ -58,14 +58,15 @@
                 <include>**/_impl/i18n/Messages_zh_TW.js</include>
 
                 <include>**/_impl/_util/_Lang.js</include>
-                <include>**/_impl/_util/_LangQuirks.js</include>
+                <include>**/_impl/quirks/_LangQuirks.js</include>
                 <include>**/_impl/core/Object.js</include>
+                <include>**/_impl/quirks/ObjectQuirks.js</include>
 
                 <include>**/_impl/_util/_Queue.js</include>
                 <include>**/_impl/_util/_ListenerQueue.js</include>
                 <include>**/_impl/_util/_Dom.js</include>
                 <include>**/_impl/_util/_DomExperimental.js</include>
-                <include>**/_impl/_util/_DomQuirks.js</include>
+                <include>**/_impl/quirks/_DomQuirks.js</include>
                 <include>**/_impl/_util/_HtmlStripper.js</include>
                 <include>**/_impl/_util/_OamSubmit.js</include>
 
@@ -81,13 +82,15 @@
 
 
                 <include>**/_impl/xhrCore/_AjaxRequest.js</include>
-                <include>**/_impl/xhrCore/_ExtAjaxRequest.js</include>
-                <include>**/_impl/xhrCore/_AjaxRequestLevel2.js</include>
+                <include>**/_impl/quirks/_AjaxRequestQuirks.js</include>
+                <include>**/_impl/xhrCore/_FormDataRequest.js</include>
                 <!-- this is pure 2.2 functionality -->
                 <include>**/_impl/xhrCore/_IFrameRequest.js</include>
 
                 <include>**/_impl/xhrCore/_AjaxResponse.js</include>
+                <include>**/_impl/quirks/_AjaxResponseQuirks.js</include>
                 <include>**/_impl/xhrCore/_Transports.js</include>
+                <include>**/_impl/quirks/_TransportQuirks.js</include>
                 <include>**/_impl/xhrCore/_ExtTransport.js</include>
                 <include>**/_impl/core/Impl.js</include>
                 <include>**/_impl/core/_EndImpl.js</include>

--- a/api/src/assembler/jsfscripts-experimental.xml
+++ b/api/src/assembler/jsfscripts-experimental.xml
@@ -31,7 +31,6 @@
                 <include>**/_impl/_util/_DomExperimental.js</include>
                 <include>**/_impl/_util/_ExtDom.js</include>
                 <include>**/_impl/xhrCore/engine/IFrame.js</include>
-                <include>**/_impl/xhrCore/_ExtAjaxRequest.js</include>
                 <include>**/_impl/xhrCore/_IFrameRequest.js</include>
                 <include>**/_impl/xhrCore/_PartialSubmitUtils.js</include>
                 <include>**/_impl/xhrCore/_ExtTransports.js</include>

--- a/api/src/assembler/jsfscripts-legacy.xml
+++ b/api/src/assembler/jsfscripts-legacy.xml
@@ -41,10 +41,15 @@
         <script>
             <fileName>jsf-legacy.js</fileName>
             <includes>
-                <include>**/_impl/core/_RuntimeQuirks.js</include>
+                <include>**/_impl/quirks/_RuntimeQuirks.js</include>
                 <include>**/_impl/core/_StartImpl.js</include>
-                <include>**/_impl/_util/_LangQuirks.js</include>
-                <include>**/_impl/_util/_DomQuirks.js</include>
+                <include>**/_impl/quirks/_LangQuirks.js</include>
+                <include>**/_impl/quirks/_ObjectQuirks.js</include>
+
+                <include>**/_impl/quirks/_DomQuirks.js</include>
+                <include>**/_impl/quirks/_AjaxResponseQuirks.js</include>
+                <include>**/_impl/quirks/_AjaxRequestQuirks.js</include>
+                <include>**/_impl/quirks/_TransportQuirks.js</include>
                 <include>**/_impl/core/_EndImpl.js</include>
             </includes>
         </script>

--- a/api/src/assembler/jsfscripts-minimal-compiler.xml
+++ b/api/src/assembler/jsfscripts-minimal-compiler.xml
@@ -28,18 +28,20 @@
             <includes>
                 <include>**/_impl/core/_EvalHandlers.js</include>
                 <include>**/_impl/core/_Runtime.js</include>
-                <include>**/_impl/core/_RuntimeQuirks.js</include>
+                <include>**/_impl/quirks/_RuntimeQuirks.js</include>
                 <include>**/_impl/core/_StartImpl.js</include>
                 <include>**/_impl/i18n/Messages.js</include>
 
 
                 <include>**/_impl/_util/_Lang.js</include>
-                <include>**/_impl/_util/_LangQuirks.js</include>
+                <include>**/_impl/quirks/_LangQuirks.js</include>
                 <include>**/_impl/core/Object.js</include>
+                <include>**/_impl/quirks/ObjectQuirks.js</include>
+
                 <include>**/_impl/_util/_Queue.js</include>
                 <include>**/_impl/_util/_ListenerQueue.js</include>
                 <include>**/_impl/_util/_Dom.js</include>
-                <include>**/_impl/_util/_DomQuirks.js</include>
+                <include>**/_impl/quirks/_DomQuirks.js</include>
                 <include>**/_impl/_util/_HtmlStripper.js</include>
                 <include>**/_impl/_util/_OamSubmit.js</include>
 
@@ -54,10 +56,13 @@
                 <include>**/_impl/xhrCore/engine/IFrame.js</include>
 
                 <include>**/_impl/xhrCore/_AjaxRequest.js</include>
-                <include>**/_impl/xhrCore/_AjaxRequestLevel2.js</include>
+                <include>**/_impl/quirks/_AjaxRequestQuirks.js</include>
+                <include>**/_impl/xhrCore/_FormDataRequest.js</include>
                 <!-- not yet used in 2.0 but for development purposes it makes sense to include it here -->
                 <include>**/_impl/xhrCore/_AjaxResponse.js</include>
+                <include>**/_impl/quirks/_AjaxResponseQuirks.js</include>
                 <include>**/_impl/xhrCore/_Transports.js</include>
+                <include>**/_impl/quirks/_TransportQuirks.js</include>
                 <include>**/_impl/core/Impl.js</include>
                 <!-- optimization helper -->
                 <include>**/_impl/core/_EndImpl.js</include>

--- a/api/src/assembler/jsfscripts-minimal-modern-compiler.xml
+++ b/api/src/assembler/jsfscripts-minimal-modern-compiler.xml
@@ -56,7 +56,7 @@
                 <include>**/_impl/xhrCore/engine/BaseRequest.js</include>
 
                 <include>**/_impl/xhrCore/_AjaxRequest.js</include>
-                <include>**/_impl/xhrCore/_AjaxRequestLevel2.js</include>
+                <include>**/_impl/xhrCore/_FormDataRequest.js</include>
                 <!-- not yet used in 2.0 but for development purposes it makes sense to include it here -->
                 <include>**/_impl/xhrCore/_AjaxResponse.js</include>
                 <include>**/_impl/xhrCore/_Transports.js</include>

--- a/api/src/assembler/jsfscripts-uncompressed-compiler.xml
+++ b/api/src/assembler/jsfscripts-uncompressed-compiler.xml
@@ -23,7 +23,7 @@
             <includes>
                 <include>**/_impl/core/_EvalHandlers.js</include>
                 <include>**/_impl/core/_Runtime.js</include>
-                <include>**/_impl/core/_RuntimeQuirks.js</include>
+                <include>**/_impl/quirks/_RuntimeQuirks.js</include>
                 <include>**/_impl/core/jsf-uncompressed.js</include>
             </includes>
         </script>

--- a/api/src/assembler/jsfscripts-uncompressed-full-compiler.xml
+++ b/api/src/assembler/jsfscripts-uncompressed-full-compiler.xml
@@ -43,7 +43,7 @@
             <includes>
                 <include>**/_impl/core/_EvalHandlers.js</include>
                 <include>**/_impl/core/_Runtime.js</include>
-                <include>**/_impl/core/_RuntimeQuirks.js</include>
+                <include>**/_impl/quirks/_RuntimeQuirks.js</include>
                 <include>**/_impl/core/_StartImpl.js</include>
                 <include>**/_impl/i18n/Messages.js</include>
 
@@ -57,14 +57,15 @@
                 <include>**/_impl/i18n/Messages_zh_HK.js</include>
                 <include>**/_impl/i18n/Messages_zh_TW.js</include>
                 <include>**/_impl/_util/_Lang.js</include>
-                <include>**/_impl/_util/_LangQuirks.js</include>
+                <include>**/_impl/quirks/_LangQuirks.js</include>
                 <include>**/_impl/core/Object.js</include>
+                <include>**/_impl/quirks/ObjectQuirks.js</include>
 
                 <include>**/_impl/_util/_Queue.js</include>
                 <include>**/_impl/_util/_ListenerQueue.js</include>
                 <include>**/_impl/_util/_Dom.js</include>
                 <include>**/_impl/_util/_DomExperimental.js</include>
-                <include>**/_impl/_util/_DomQuirks.js</include>
+                <include>**/_impl/quirks/_DomQuirks.js</include>
                 <include>**/_impl/_util/_HtmlStripper.js</include>
 
                 <include>**/_impl/_util/_OamSubmit.js</include>
@@ -80,11 +81,14 @@
                 <include>**/_impl/xhrCore/engine/IFrame.js</include>
 
                 <include>**/_impl/xhrCore/_AjaxRequest.js</include>
-                <include>**/_impl/xhrCore/_AjaxRequestLevel2.js</include>
+                <include>**/_impl/quirks/_AjaxRequestQuirks.js</include>
+                <include>**/_impl/xhrCore/_FormDataRequest.js</include>
                 <!-- not yet used in 2.0 but for development purposes it makes sense to include it here -->
                 <include>**/_impl/xhrCore/_IFrameRequest.js</include>
                 <include>**/_impl/xhrCore/_AjaxResponse.js</include>
+                <include>**/_impl/quirks/_AjaxResponseQuirks.js</include>
                 <include>**/_impl/xhrCore/_Transports.js</include>
+                <include>**/_impl/quirks/_TransportQuirks.js</include>
                 <include>**/_impl/xhrCore/_ExtTransport.js</include>
                 <include>**/_impl/core/Impl.js</include>
 

--- a/api/src/main/javascript/META-INF/resources/myfaces/_impl/_util/_Dom.js
+++ b/api/src/main/javascript/META-INF/resources/myfaces/_impl/_util/_Dom.js
@@ -53,103 +53,81 @@ _MF_SINGLTN(_PFX_UTIL + "_Dom", Object, /** @lends myfaces._impl._util._Dom.prot
     constructor_: function() {
     },
 
-    runCss: function(item/*, xmlData*/) {
-
-        var  UDEF = "undefined",
-                _RT = this._RT,
-                _Lang = this._Lang,
-                applyStyle = function(item, style) {
-                    var newSS = document.createElement("style");
-
-                    newSS.setAttribute("rel", item.getAttribute("rel") || "stylesheet");
-                    newSS.setAttribute("type", item.getAttribute("type") || "text/css");
-                    document.getElementsByTagName("head")[0].appendChild(newSS);
-                    //ie merrily again goes its own way
-                    if (window.attachEvent && !_RT.isOpera && UDEF != typeof newSS.styleSheet && UDEF != newSS.styleSheet.cssText) newSS.styleSheet.cssText = style;
-                    else newSS.appendChild(document.createTextNode(style));
-                },
-
-                execCss = function(item) {
-                    var equalsIgnoreCase = _Lang.equalsIgnoreCase;
-                    var tagName = item.tagName;
-                    if (tagName && equalsIgnoreCase(tagName, "link") && equalsIgnoreCase(item.getAttribute("type"), "text/css")) {
-                        applyStyle(item, "@import url('" + item.getAttribute("href") + "');");
-                    } else if (tagName && equalsIgnoreCase(tagName, "style") && equalsIgnoreCase(item.getAttribute("type"), "text/css")) {
-                        var innerText = [];
-                        //compliant browsers know child nodes
-                        var childNodes = item.childNodes;
-                        if (childNodes) {
-                            var len = childNodes.length;
-                            for (var cnt = 0; cnt < len; cnt++) {
-                                innerText.push(childNodes[cnt].innerHTML || childNodes[cnt].data);
-                            }
-                            //non compliant ones innerHTML
-                        } else if (item.innerHTML) {
-                            innerText.push(item.innerHTML);
-                        }
-
-                        applyStyle(item, innerText.join(""));
-                    }
-                };
-
-        try {
-            var scriptElements = this.findByTagNames(item, {"link":1,"style":1}, true);
-            if (scriptElements == null) return;
-            for (var cnt = 0; cnt < scriptElements.length; cnt++) {
-                execCss(scriptElements[cnt]);
-            }
-
-        } finally {
-            //the usual ie6 fix code
-            //the IE6 garbage collector is broken
-            //nulling closures helps somewhat to reduce
-            //mem leaks, which are impossible to avoid
-            //at this browser
-            execCss = null;
-            applyStyle = null;
-        }
-    },
-
-
     /**
      * Run through the given Html item and execute the inline scripts
      * (IE doesn't do this by itself)
      * @param {Node} item
      */
     runScripts: function(item, xmlData) {
+        var _T = this;
+        var finalScripts = [];
+        var _RT = this._RT;
+
+        var evalCollectedScripts = function (scriptsToProcess) {
+            if (scriptsToProcess && scriptsToProcess.length) {
+                //script source means we have to eval the existing
+                //scripts before running the include
+                var joinedScripts = [];
+                for(var scrptCnt = 0; scrptCnt < scriptsToProcess.length; scrptCnt++) {
+                    var item = scriptsToProcess[scrptCnt];
+                    if (!item.cspMeta) {
+                        joinedScripts.push(item.text)
+                    } else {
+                        if (joinedScripts.length) {
+                            _RT.globalEval(joinedScripts.join("\n"));
+                            joinedScripts.length = 0;
+                        }
+                        _RT.globalEval(item.text, item.cspMeta);
+                    }
+                }
+
+                if (joinedScripts.length) {
+                    _RT.globalEval(joinedScripts.join("\n"));
+                    joinedScripts.length = 0;
+                }
+            }
+            return [];
+        }
+
+
         var _Lang = this._Lang,
-            _RT = this._RT,
-            finalScripts = [],
             execScrpt = function(item) {
                 var tagName = item.tagName;
                 var type = item.type || "";
                 //script type javascript has to be handled by eval, other types
                 //must be handled by the browser
                 if (tagName && _Lang.equalsIgnoreCase(tagName, "script") &&
-                        (type === "" ||
+                    (type === "" ||
                         _Lang.equalsIgnoreCase(type,"text/javascript") ||
                         _Lang.equalsIgnoreCase(type,"javascript") ||
                         _Lang.equalsIgnoreCase(type,"text/ecmascript") ||
                         _Lang.equalsIgnoreCase(type,"ecmascript"))) {
 
+                    //now given that scripts can embed nonce
+                    //we cannoit
+                    var nonce = _RT.resolveNonce(item);
+
                     var src = item.getAttribute('src');
                     if ('undefined' != typeof src
-                            && null != src
-                            && src.length > 0
-                            ) {
+                        && null != src
+                        && src.length > 0
+                    ) {
                         //we have to move this into an inner if because chrome otherwise chokes
                         //due to changing the and order instead of relying on left to right
                         //if jsf.js is already registered we do not replace it anymore
-                        if ((src.indexOf("ln=scripts") == -1 && src.indexOf("ln=jakarta.faces") == -1) || (src.indexOf("/jsf.js") == -1
-                                && src.indexOf("/jsf-uncompressed.js") == -1)) {
-                            if (finalScripts.length) {
-                                //script source means we have to eval the existing
-                                //scripts before running the include
-                                _RT.globalEval(finalScripts.join("\n"));
-
-                                finalScripts = [];
-                            }
-                            _RT.loadScriptEval(src, item.getAttribute('type'), false, "UTF-8", false);
+                        if ((
+                                src.indexOf("ln=scripts") == -1 &&
+                                src.indexOf("ln=javax.faces") == -1 &&
+                                src.indexOf("ln=jakarta.faces") == -1
+                            ) || (
+                                src.indexOf("/jsf.js") == -1 &&
+                                src.indexOf("/faces.js") == -1 &&
+                                src.indexOf("/jsf-uncompressed.js") == -1 &&
+                                src.indexOf("/jsf-development.js") == -1 &&
+                                src.indexOf("/faces-development.js") == -1
+                            )) {
+                            finalScripts = evalCollectedScripts(finalScripts);
+                            _RT.loadScriptEval(src, item.getAttribute('type'), false, "UTF-8", false, nonce ? {nonce: nonce} : null );
                         }
 
                     } else {
@@ -173,8 +151,12 @@ _MF_SINGLTN(_PFX_UTIL + "_Dom", Object, /** @lends myfaces._impl._util._Dom.prot
                         }
                         // we have to run the script under a global context
                         //we store the script for less calls to eval
-                        finalScripts.push(test);
-
+                        finalScripts.push(nonce ? {
+                            cspMeta: {nonce: nonce},
+                            text: test
+                        }: {
+                            text: test
+                        });
                     }
                 }
             };
@@ -184,9 +166,7 @@ _MF_SINGLTN(_PFX_UTIL + "_Dom", Object, /** @lends myfaces._impl._util._Dom.prot
             for (var cnt = 0; cnt < scriptElements.length; cnt++) {
                 execScrpt(scriptElements[cnt]);
             }
-            if (finalScripts.length) {
-                _RT.globalEval(finalScripts.join("\n"));
-            }
+            evalCollectedScripts(finalScripts);
         } catch (e) {
             //we are now in accordance with the rest of the system of showing errors only in development mode
             //the default error output is alert we always can override it with
@@ -332,9 +312,9 @@ _MF_SINGLTN(_PFX_UTIL + "_Dom", Object, /** @lends myfaces._impl._util._Dom.prot
         if (markup === "") return null;
 
         var evalNodes = this._buildEvalNodes(item, markup),
-                currentRef = item,
-                parentNode = item.parentNode,
-                ret = [];
+            currentRef = item,
+            parentNode = item.parentNode,
+            ret = [];
         for (var cnt = evalNodes.length - 1; cnt >= 0; cnt--) {
             currentRef = parentNode.insertBefore(evalNodes[cnt], currentRef);
             ret.push(currentRef);
@@ -356,9 +336,9 @@ _MF_SINGLTN(_PFX_UTIL + "_Dom", Object, /** @lends myfaces._impl._util._Dom.prot
         if (markup === "") return null;
 
         var evalNodes = this._buildEvalNodes(item, markup),
-                currentRef = item,
-                parentNode = item.parentNode,
-                ret = [];
+            currentRef = item,
+            parentNode = item.parentNode,
+            ret = [];
 
         for (var cnt = 0; cnt < evalNodes.length; cnt++) {
             if (currentRef.nextSibling) {
@@ -390,24 +370,15 @@ _MF_SINGLTN(_PFX_UTIL + "_Dom", Object, /** @lends myfaces._impl._util._Dom.prot
     detectAttributes: function(element) {
         //test if 'hasAttribute' method is present and its native code is intact
         //for example, Prototype can add its own implementation if missing
+        //JSF 2.4 we now can reduce the complexity here, one of the functions now
+        //is definitely implemented
         if (element.hasAttribute && this.isFunctionNative(element.hasAttribute)) {
             return function(name) {
                 return element.hasAttribute(name);
             }
         } else {
-            try {
-                //when accessing .getAttribute method without arguments does not throw an error then the method is not available
-                element.getAttribute;
-
-                var html = element.outerHTML;
-                var startTag = html.match(/^<[^>]*>/)[0];
-                return function(name) {
-                    return startTag.indexOf(name + '=') > -1;
-                }
-            } catch (ex) {
-                return function(name) {
-                    return element.getAttribute(name);
-                }
+            return function (name) {
+                return !!element.getAttribute(name);
             }
         }
     },
@@ -421,7 +392,7 @@ _MF_SINGLTN(_PFX_UTIL + "_Dom", Object, /** @lends myfaces._impl._util._Dom.prot
     cloneAttributes: function(target, source) {
 
         // enumerate core element attributes - without 'dir' as special case
-        var coreElementProperties = ['className', 'title', 'lang', 'xmllang'];
+        var coreElementProperties = ['className', 'title', 'lang', 'xmllang', "href", "rel", "src"];
         // enumerate additional input element attributes
         var inputElementProperties = [
             'name', 'value', 'size', 'maxLength', 'src', 'alt', 'useMap', 'tabIndex', 'accessKey', 'accept', 'type'
@@ -541,6 +512,26 @@ _MF_SINGLTN(_PFX_UTIL + "_Dom", Object, /** @lends myfaces._impl._util._Dom.prot
         } catch (ex) {
             //most probably dataset properties are not supported
         }
+
+        // still works in ie6
+        var attrs = source.hasAttributes() ? source.attributes: [];
+        var dataAttributes = this._Lang.arrFilter(attrs, function(attr) {
+            return attr.name && attr.name.indexOf("data-") == 0;
+        });
+        this._Lang.arrForEach(dataAttributes, function(name) {
+           if(target.setAttribute) {
+               var attrValue = source.getAttribute(name)  || source[name];
+               target.setAttribute(name, attrValue)
+           } else {
+               target[name] = attrValue;
+           }
+        });
+
+        //special nonce handling
+        var nonce = this._RT.resolveNonce(source);
+        if(!!nonce) {
+            target["nonce"] = nonce;
+        }
     },
     //from
     // http://blog.vishalon.net/index.php/javascript-getting-and-setting-caret-position-in-textarea/
@@ -601,7 +592,6 @@ _MF_SINGLTN(_PFX_UTIL + "_Dom", Object, /** @lends myfaces._impl._util._Dom.prot
      */
     outerHTML : function(item, markup, preserveFocus) {
         this._assertStdParams(item, markup, "outerHTML");
-        markup = this._Lang.trim(markup);
         // we can work on a single element in a cross browser fashion
         // regarding the focus thanks to the
         // icefaces team for providing the code
@@ -610,6 +600,7 @@ _MF_SINGLTN(_PFX_UTIL + "_Dom", Object, /** @lends myfaces._impl._util._Dom.prot
             this.cloneAttributes(item, replacingInput);
             return item;
         } else {
+            markup = this._Lang.trim(markup);
             if (markup !== "") {
                 var ret = null;
 
@@ -771,7 +762,7 @@ _MF_SINGLTN(_PFX_UTIL + "_Dom", Object, /** @lends myfaces._impl._util._Dom.prot
      */
     _buildEvalNodes: function(item, markup) {
         var evalNodes = null;
-        if (this._isTableElement(item)) {
+        if (item && this._isTableElement(item)) {
             evalNodes = this._buildTableNodes(item, markup);
         } else {
             var nonIEQuirks = (!this._RT.browser.isIE || this._RT.browser.isIE > 8);
@@ -779,9 +770,9 @@ _MF_SINGLTN(_PFX_UTIL + "_Dom", Object, /** @lends myfaces._impl._util._Dom.prot
             //elements bug, but it is mostly dom compliant so we have to give it a special
             //treatment, IE9 finally fixes that issue finally after 10 years
             evalNodes = (this.isDomCompliant() &&  nonIEQuirks) ?
-                    this._buildNodesCompliant(markup) :
-                    //ie8 or quirks mode browsers
-                    this._buildNodesNonCompliant(markup);
+                this._buildNodesCompliant(markup) :
+                //ie8 or quirks mode browsers
+                this._buildNodesNonCompliant(markup);
         }
         return evalNodes;
     },
@@ -801,9 +792,9 @@ _MF_SINGLTN(_PFX_UTIL + "_Dom", Object, /** @lends myfaces._impl._util._Dom.prot
             throw this._Lang.makeException(new Error(), null, null, this._nameSpace, "_assertStdParams",  "Caller must be set for assertion");
         }
         var _Lang = this._Lang,
-                ERR_PROV = "ERR_MUST_BE_PROVIDED1",
-                DOM = "myfaces._impl._util._Dom.",
-                finalParams = params || ["item", "markup"];
+            ERR_PROV = "ERR_MUST_BE_PROVIDED1",
+            DOM = "myfaces._impl._util._Dom.",
+            finalParams = params || ["item", "markup"];
 
         if (!item || !markup) {
             _Lang.makeException(new Error(), null, null,DOM, ""+caller,  _Lang.getMessage(ERR_PROV, null, DOM +"."+ caller, (!item) ? finalParams[0] : finalParams[1]));
@@ -859,8 +850,8 @@ _MF_SINGLTN(_PFX_UTIL + "_Dom", Object, /** @lends myfaces._impl._util._Dom.prot
 
         var parentNode = item.parentNode,
 
-                sibling = item.nextSibling,
-                resultArr = this._Lang.objToArray(evalNodes);
+            sibling = item.nextSibling,
+            resultArr = this._Lang.objToArray(evalNodes);
 
         for (var cnt = 0; cnt < resultArr.length; cnt++) {
             if (cnt == 0) {
@@ -933,7 +924,7 @@ _MF_SINGLTN(_PFX_UTIL + "_Dom", Object, /** @lends myfaces._impl._util._Dom.prot
     findByTagName : function(fragment, tagName) {
         this._assertStdParams(fragment, tagName, "findByTagName", ["fragment", "tagName"]);
         var _Lang = this._Lang,
-                nodeType = fragment.nodeType;
+            nodeType = fragment.nodeType;
         if (nodeType != 1 && nodeType != 9 && nodeType != 11) return null;
 
         //remapping to save a few bytes
@@ -1000,8 +991,8 @@ _MF_SINGLTN(_PFX_UTIL + "_Dom", Object, /** @lends myfaces._impl._util._Dom.prot
         //we use the reject mechanism to prevent a deep scan reject means any
         //child elements will be omitted from the scan
         var FILTER_ACCEPT = NodeFilter.FILTER_ACCEPT,
-                FILTER_SKIP = NodeFilter.FILTER_SKIP,
-                FILTER_REJECT = NodeFilter.FILTER_REJECT;
+            FILTER_SKIP = NodeFilter.FILTER_SKIP,
+            FILTER_REJECT = NodeFilter.FILTER_REJECT;
 
         var walkerFilter = function (node) {
             var retCode = (filter(node)) ? FILTER_ACCEPT : FILTER_SKIP;
@@ -1081,10 +1072,10 @@ _MF_SINGLTN(_PFX_UTIL + "_Dom", Object, /** @lends myfaces._impl._util._Dom.prot
             return null;
         }
 
-        // This will not work well on portlet case, because we cannot be sure
-        // the returned form is right one.
-        //we can cover that case by simply adding one of our config params
-        //the default is the weaker, but more correct portlet code
+            // This will not work well on portlet case, because we cannot be sure
+            // the returned form is right one.
+            //we can cover that case by simply adding one of our config params
+            //the default is the weaker, but more correct portlet code
         //you can override it with myfaces_config.no_portlet_env = true globally
         else if (1 == forms.length && this._RT.getGlobalConfig("no_portlet_env", false)) {
             return forms[0];
@@ -1098,7 +1089,7 @@ _MF_SINGLTN(_PFX_UTIL + "_Dom", Object, /** @lends myfaces._impl._util._Dom.prot
             //https://issues.apache.org/jira/browse/MYFACES-2793
 
             return (_Lang.equalsIgnoreCase(elem.tagName, "form")) ? elem :
-                    ( this.html5FormDetection(elem) || this.getParent(elem, "form"));
+                ( this.html5FormDetection(elem) || this.getParent(elem, "form"));
         });
 
         if (finalElem) {
@@ -1131,8 +1122,9 @@ _MF_SINGLTN(_PFX_UTIL + "_Dom", Object, /** @lends myfaces._impl._util._Dom.prot
         return (1 == foundElements.length ) ? foundElements[0] : null;
     },
 
-    html5FormDetection: function(/*item*/) {
-        return null;
+    html5FormDetection:function (item) {
+        var elemForm = this.getAttribute(item, "form");
+        return (elemForm) ? this.byId(elemForm) : null;
     },
 
 
@@ -1145,13 +1137,13 @@ _MF_SINGLTN(_PFX_UTIL + "_Dom", Object, /** @lends myfaces._impl._util._Dom.prot
 
         if (!item) {
             throw this._Lang.makeException(new Error(), null, null, this._nameSpace, "getParent",
-                    this._Lang.getMessage("ERR_MUST_BE_PROVIDED1", null, "_Dom.getParent", "item {DomNode}"));
+                this._Lang.getMessage("ERR_MUST_BE_PROVIDED1", null, "_Dom.getParent", "item {DomNode}"));
         }
 
         var _Lang = this._Lang;
         var searchClosure = function(parentItem) {
             return parentItem && parentItem.tagName
-                    && _Lang.equalsIgnoreCase(parentItem.tagName, tagName);
+                && _Lang.equalsIgnoreCase(parentItem.tagName, tagName);
         };
         try {
             return this.getFilteredParent(item, searchClosure);
@@ -1268,6 +1260,126 @@ _MF_SINGLTN(_PFX_UTIL + "_Dom", Object, /** @lends myfaces._impl._util._Dom.prot
 
     getNamedElementFromForm: function(form, elementId) {
         return form[elementId];
+    },
+
+    /**
+     * backport new faces codebase, should work from ie9 onwards
+     * (cutoff point)
+     * builds the ie nodes properly in a placeholder
+     * and bypasses a non script insert bug that way
+     * @param markup the markup code to be executed from
+     */
+    fromMarkup: function(markup) {
+
+        // https:// developer.mozilla.org/de/docs/Web/API/DOMParser license creative commons
+        var doc = document.implementation.createHTMLDocument("");
+        var lowerMarkup = markup.toLowerCase();
+        if (lowerMarkup.indexOf('<!doctype') != -1 ||
+            lowerMarkup.indexOf('<html') != -1 ||
+            lowerMarkup.indexOf('<head') != -1 ||
+            lowerMarkup.indexOf('<body') != -1) {
+            doc.documentElement.innerHTML = markup;
+            return doc.documentElement;
+        } else {
+            var dummyPlaceHolder = document.createElement("div");
+            dummyPlaceHolder.innerHTML = markup;
+            return dummyPlaceHolder;
+        }
+    },
+
+    appendToHead: function(markup) {
+
+        //we filter out only those evalNodes which do not match
+        var _RT = this._RT;
+        var _T = this;
+        var doubleExistsFilter = function(item)  {
+            switch((item.tagName || "").toLowerCase()) {
+                case "script":
+                    var src = item.getAttribute("src");
+                    var content = item.innerText;
+                    var scripts = document.head.getElementsByTagName("script");
+
+                    for(var cnt = 0; cnt < scripts.length; cnt++) {
+                        if(src && scripts[cnt].getAttribute("src") == src) {
+                            return false;
+                        } else if(!src && scripts[cnt].innerText == content) {
+                            return false;
+                        }
+                    }
+                    break;
+                case "style":
+                    var content = item.innerText;
+                    var styles = document.head.getElementsByTagName("style");
+                    for(var cnt = 0; cnt < styles.length; cnt++) {
+                        if(content && styles[cnt].innerText == content) {
+                            return false;
+                        }
+                    }
+                    break;
+                case "link":
+                    var href = item.getAttribute("href");
+                    var content = item.innerText;
+                    var links = document.head.getElementsByTagName("link");
+                    for(var cnt = 0; cnt < links.length; cnt++) {
+                        if(href && links[cnt].getAttribute("href") == href) {
+                            return false;
+                        } else if(!href && links[cnt].innerText == content) {
+                            return false;
+                        }
+                    }
+                    break;
+                default: break;
+            }
+            return true;
+        };
+
+        var appendElement = function (item) {
+            var tagName = (item.tagName || "").toLowerCase();
+            var nonce = _RT.resolveNonce(item);
+            if (tagName === "script") {
+                var newItem = document.createElement("script");
+                newItem.textContent = item.textContent;
+                _T.cloneAttributes(newItem, item);
+                item = newItem;
+            } else if (tagName === "link") {
+                var newItem = document.createElement("link");
+                newItem.textContent = item.textContent;
+                _T.cloneAttributes(newItem, item);
+                item = newItem;
+            } else if (tagName === "style") {
+                var newItem = document.createElement("style");
+                newItem.textContent = item.textContent;
+                _T.cloneAttributes(newItem, item);
+                item = newItem;
+            }
+
+            document.head.appendChild(item);
+        };
+        var evalNodes = [];
+        if(this._Lang.isString(markup)) {
+            var lastHeadChildTag = document.getElementsByTagName("head")[0].lastChild;
+            //resource requests only hav one item anyway
+            evalNodes = this._buildEvalNodes(null, markup);
+        } else {
+            evalNodes = markup.childNodes;
+        }
+
+
+        //var evalNodes = this._buildEvalNodes(lastHeadChildTag, markup);
+        var scripts = this._Lang.arrFilter(evalNodes, function(item) {
+           return (item.tagName || "").toLowerCase() == "script";
+        }, 0, this);
+        var other = this._Lang.arrFilter(evalNodes, function(item) {
+            return (item.tagName || "").toLowerCase() != "script";
+        }, 0, this);
+
+        var finalOther = this._Lang.arrFilter(other, doubleExistsFilter , 0, this);
+        var finalScripts = this._Lang.arrFilter(scripts, doubleExistsFilter , 0, this);
+        //var finalAll = this._Lang.arrFilter(evalNodes, doubleExistsFilter , 0, this);
+
+        this._Lang.arrForEach(finalOther, appendElement);
+        this._Lang.arrForEach(finalScripts, appendElement);
+        //this._Lang.arrForEach(finalAll, appendElement);
     }
 });
 

--- a/api/src/main/javascript/META-INF/resources/myfaces/_impl/_util/_Lang.js
+++ b/api/src/main/javascript/META-INF/resources/myfaces/_impl/_util/_Lang.js
@@ -336,14 +336,14 @@ _MF_SINGLTN(_PFX_UTIL + "_Lang", Object, /** @lends myfaces._impl._util._Lang.pr
      *      <li>param scope (optional) the scope to apply the closure to  </li>
      * </ul>
      */
-    arrForEach:function (arr, func /*startPos, scope*/) {
+    arrForEach:function (arr, func, startPos, scope) {
         if (!arr || !arr.length) return;
-        var startPos = Number(arguments[2]) || 0;
-        var thisObj = arguments[3];
+        var start = startPos || 0;
+        var thisObj = scope || arr;
         //check for an existing foreach mapping on array prototypes
         //IE9 still does not pass array objects as result for dom ops
         arr = this.objToArray(arr);
-        (startPos) ? arr.slice(startPos).forEach(func, thisObj) : arr.forEach(func, thisObj);
+        (start) ? arr.slice(start).forEach(func, thisObj) : arr.forEach(func, thisObj);
     },
     /**
      * foreach implementation utilizing the
@@ -360,10 +360,12 @@ _MF_SINGLTN(_PFX_UTIL + "_Lang", Object, /** @lends myfaces._impl._util._Lang.pr
      *  <li> scope (optional) the scope to apply the closure to</li>
      * </ul>
      */
-    arrFilter:function (arr, func /*startPos, scope*/) {
+    arrFilter:function (arr, func, startPos, scope) {
         if (!arr || !arr.length) return [];
+        var start = startPos || 0;
+        var thisObj = scope || arr;
         arr = this.objToArray(arr);
-        return ((startPos) ? arr.slice(startPos).filter(func, thisObj) : arr.filter(func, thisObj));
+        return ((start) ? arr.slice(start).filter(func, thisObj) : arr.filter(func, thisObj));
     },
     /**
      * adds a EcmaScript optimized indexOf to our mix,
@@ -585,12 +587,12 @@ _MF_SINGLTN(_PFX_UTIL + "_Lang", Object, /** @lends myfaces._impl._util._Lang.pr
         }
         if (!this.FormDataDecoratorOther) {
             this.FormDataDecoratorOther = function (theFormData) {
-                this._valBuf = theFormData;
+                this._valBuf = theFormData || [];
                 this._idx = {};
             };
             _newCls = this.FormDataDecoratorOther;
             _newCls.prototype.append = function (key, val) {
-                this._valBuf.append(key, val);
+                this._valBuf.push([encodeURIComponent(key), encodeURIComponent(val)]);
                 this._idx[key] = true;
             };
             _newCls.prototype.hasKey = function (key) {

--- a/api/src/main/javascript/META-INF/resources/myfaces/_impl/core/Impl.js
+++ b/api/src/main/javascript/META-INF/resources/myfaces/_impl/core/Impl.js
@@ -80,7 +80,7 @@ _MF_SINGLTN(_PFX_CORE + "Impl", _MF_OBJECT, /**  @lends myfaces._impl.core.Impl.
 
     /*blockfilter for the passthrough filtering, the attributes given here
      * will not be transmitted from the options into the passthrough*/
-    _BLOCKFILTER:{onerror:1, onevent:1, render:1, execute:1, myfaces:1, delay:1, resetValues:1},
+    _BLOCKFILTER:{onerror:1, onevent:1, render:1, execute:1, myfaces:1, delay:1, resetValues:1, params: 1},
 
     /**
      * collect and encode data for a given form element (must be of type form)
@@ -178,11 +178,19 @@ _MF_SINGLTN(_PFX_CORE + "Impl", _MF_OBJECT, /**  @lends myfaces._impl.core.Impl.
          * this copy is also the pass through parameters
          * which are sent down our request
          */
+        // this is legacy behavior which is faulty, will be removed if we decide to do it
+        // that way
         var passThrgh = _Lang.mixMaps({}, options, true, this._BLOCKFILTER);
+        // jsdoc spec everything under params must be passed through
+        if(options.params)  {
+            passThrgh = _Lang.mixMaps(passThrgh, options.params, true, {});
+        }
 
         if (event) {
             passThrgh[this.P_EVT] = event.type;
         }
+
+
 
         /**
          * ajax pass through context with the source
@@ -192,7 +200,7 @@ _MF_SINGLTN(_PFX_CORE + "Impl", _MF_OBJECT, /**  @lends myfaces._impl.core.Impl.
             source:elem,
             onevent:options.onevent,
             onerror:options.onerror,
-
+            viewId: "",
             //TODO move the myfaces part into the _mfInternal part
             myfaces:options.myfaces,
             _mfInternal:{}
@@ -211,6 +219,8 @@ _MF_SINGLTN(_PFX_CORE + "Impl", _MF_OBJECT, /**  @lends myfaces._impl.core.Impl.
         var form = (options.myfaces && options.myfaces.form) ?
                 _Lang.byId(options.myfaces.form) :
                 this._getForm(elem, event);
+
+        context.viewId = this.getViewId(form);
 
         /**
          * JSF2.2 client window must be part of the issuing form so it is encoded
@@ -268,13 +278,13 @@ _MF_SINGLTN(_PFX_CORE + "Impl", _MF_OBJECT, /**  @lends myfaces._impl.core.Impl.
              */
             options.execute = (options.execute.indexOf("@this") == -1) ? options.execute : options.execute;
 
-            this._transformList(passThrgh, this.P_EXECUTE, options.execute, form, elementId);
+            this._transformList(passThrgh, this.P_EXECUTE, options.execute, form, elementId, context.viewId);
         } else {
             passThrgh[this.P_EXECUTE] = elementId;
         }
 
         if (options.render) {
-            this._transformList(passThrgh, this.P_RENDER, options.render, form, elementId);
+            this._transformList(passThrgh, this.P_RENDER, options.render, form, elementId, context.viewId);
         }
 
         /**
@@ -299,12 +309,18 @@ _MF_SINGLTN(_PFX_CORE + "Impl", _MF_OBJECT, /**  @lends myfaces._impl.core.Impl.
         //this is not documented behavior but can be determined by running
         //mojarra under blackbox conditions
         //i assume it does the same as our formId_submit=1 so leaving it out
-        //wont hurt but for the sake of compatibility we are going to add it
+        //won´t hurt but for the sake of compatibility we are going to add it
         passThrgh[form.id] = form.id;
 
         /* jsf2.2 only: options.delay || */
         var delayTimeout = options.delay || this._RT.getLocalOrGlobalConfig(context, "delay", false);
-        if (delayTimeout) {
+
+        if (!!delayTimeout) {
+            if(!(delayTimeout >= 0)) {
+                // abbreviation which covers all cases of non positive values,
+                // including NaN and non-numeric strings, no type equality is deliberate here,
+                throw new Error("Invalid delay value: " + delayTimeout);
+            }
             if (this._delayTimeout) {
                 clearTimeout(this._delayTimeout);
             }
@@ -359,8 +375,8 @@ _MF_SINGLTN(_PFX_CORE + "Impl", _MF_OBJECT, /**  @lends myfaces._impl.core.Impl.
         //for now we turn off the transport auto selection, to enable 2.0 backwards compatibility
         //on protocol level, the file upload only can be turned on if the auto selection is set to true
         var getConfig = this._RT.getLocalOrGlobalConfig,
-                _Lang = this._Lang,
-                _Dom = this._Dom;
+            _Lang = this._Lang,
+            _Dom = this._Dom;
 
         var transportAutoSelection = getConfig(context, "transportAutoSelection", true);
         /*var isMultipart = (transportAutoSelection && _Dom.getAttribute(form, "enctype") == "multipart/form-data") ?
@@ -371,7 +387,7 @@ _MF_SINGLTN(_PFX_CORE + "Impl", _MF_OBJECT, /**  @lends myfaces._impl.core.Impl.
             return getConfig(context, "transportType", "xhrQueuedPost");
         }
         var multiPartCandidate = _Dom.isMultipartCandidate((!getConfig(context, "pps", false)) ?
-                form : passThrgh[this.P_EXECUTE]);
+            form : passThrgh[this.P_EXECUTE]);
         var multipartForm = (_Dom.getAttribute(form, "enctype") || "").toLowerCase() == "multipart/form-data";
         //spec section jsdoc, if we have a multipart candidate in our execute (aka fileupload)
         //and the form is not multipart then we have to raise an error
@@ -392,8 +408,8 @@ _MF_SINGLTN(_PFX_CORE + "Impl", _MF_OBJECT, /**  @lends myfaces._impl.core.Impl.
          *
          */
         var transportType = (!isMultipart) ?
-                getConfig(context, "transportType", "xhrQueuedPost") :
-                getConfig(context, "transportType", "multipartQueuedPost");
+            getConfig(context, "transportType", "xhrQueuedPost") :
+            getConfig(context, "transportType", "multipartQueuedPost");
         if (!this._transport[transportType]) {
             //throw new Error("Transport type " + transportType + " does not exist");
             throw new Error(_Lang.getMessage("ERR_TRANSPORT", null, transportType));
@@ -413,8 +429,9 @@ _MF_SINGLTN(_PFX_CORE + "Impl", _MF_OBJECT, /**  @lends myfaces._impl.core.Impl.
      * @param srcStr
      * @param form
      * @param elementId
+     * @param namingContainerId the naming container namingContainerId
      */
-    _transformList:function (passThrgh, target, srcStr, form, elementId) {
+    _transformList:function (passThrgh, target, srcStr, form, elementId, namingContainerId) {
         var _Lang = this._Lang;
         //this is probably the fastest transformation method
         //it uses an array and an index to position all elements correctly
@@ -422,14 +439,14 @@ _MF_SINGLTN(_PFX_CORE + "Impl", _MF_OBJECT, /**  @lends myfaces._impl.core.Impl.
         //false
         srcStr = this._Lang.trim(srcStr);
         var offset = 1,
-                vals = (srcStr) ? srcStr.split(/\s+/) : [],
-                idIdx = (vals.length) ? _Lang.arrToMap(vals, offset) : {},
+            vals = (srcStr) ? srcStr.split(/\s+/) : [],
+            idIdx = (vals.length) ? _Lang.arrToMap(vals, offset) : {},
 
-        //helpers to improve speed and compression
-                none = idIdx[this.IDENT_NONE],
-                all = idIdx[this.IDENT_ALL],
-                theThis = idIdx[this.IDENT_THIS],
-                theForm = idIdx[this.IDENT_FORM];
+            //helpers to improve speed and compression
+            none = idIdx[this.IDENT_NONE],
+            all = idIdx[this.IDENT_ALL],
+            theThis = idIdx[this.IDENT_THIS],
+            theForm = idIdx[this.IDENT_FORM];
 
         if (none) {
             //in case of none nothing is returned
@@ -455,8 +472,61 @@ _MF_SINGLTN(_PFX_CORE + "Impl", _MF_OBJECT, /**  @lends myfaces._impl.core.Impl.
         }
 
         //the final list must be blank separated
-        passThrgh[target] = vals.join(" ");
+        passThrgh[target] = this._remapNamingContainer(elementId, form, namingContainerId,vals).join(" ");
         return passThrgh;
+    },
+
+    /**
+     * in namespaced situations root naming containers must be resolved
+     * ":" absolute searches must be mapped accordingly, the same
+     * goes for absolut searches containing already the root naming container id
+     *
+     * @param issuingElementId the issuing element id
+     * @param form the hosting form of the issiung element id
+     * @param rootNamingContainerId the root naming container id
+     * @param elements a list of element client ids to be processed
+     * @returns {*} the mapped element client ids, which are resolved correctly to their naming containers
+     * @private
+     */
+    _remapNamingContainer: function(issuingElementId, form, rootNamingContainerId, elements) {
+        var SEP = jsf.separatorchar;
+        function remapViewId(toTransform) {
+            var EMPTY_STR = "";
+            var rootNamingContainerPrefix = (rootNamingContainerId.length) ? rootNamingContainerId+SEP : EMPTY_STR;
+            var formClientId = form.id;
+            // nearest parent naming container relative to the form
+            var nearestNamingContainer = formClientId.substring(0, formClientId.lastIndexOf(SEP));
+            var nearestNamingContainerPrefix = (nearestNamingContainer.length) ? nearestNamingContainer + SEP : EMPTY_STR;
+            // absolut search expression, always starts with SEP or the name of the root naming container
+            var hasLeadingSep = toTransform.indexOf(SEP) === 0;
+            var isAbsolutSearchExpr = hasLeadingSep || (rootNamingContainerId.length
+                && toTransform.indexOf(rootNamingContainerPrefix) == 0);
+            if (isAbsolutSearchExpr) {
+                //we cut off the leading sep if there is one
+                toTransform = hasLeadingSep ? toTransform.substring(1) : toTransform;
+                toTransform = toTransform.indexOf(rootNamingContainerPrefix) == 0 ? toTransform.substring(rootNamingContainerPrefix.length) : toTransform;
+                //now we prepend either the prefix or "" from the cut-off string to get the final result
+                return  [rootNamingContainerPrefix, toTransform].join(EMPTY_STR);
+            } else { //relative search according to the javadoc
+                //we cut off the root naming container id from the form
+                if (formClientId.indexOf(rootNamingContainerPrefix) == 0) {
+                    formClientId = formClientId.substring(rootNamingContainerPrefix.length);
+                }
+
+                //If prependId = true, the outer form id must be present in the id if same form
+                var hasPrependId = toTransform.indexOf(formClientId) == 0;
+
+                return hasPrependId ?
+                    [rootNamingContainerPrefix, toTransform].join(EMPTY_STR) :
+                    [nearestNamingContainerPrefix, toTransform].join(EMPTY_STR);
+            }
+        }
+
+        for(var cnt = 0; cnt < elements.length; cnt++) {
+            elements[cnt] = remapViewId(this._Lang.trim(elements[cnt]));
+        }
+
+        return elements;
     },
 
     addOnError:function (/*function*/errorListener) {
@@ -532,7 +602,7 @@ _MF_SINGLTN(_PFX_CORE + "Impl", _MF_OBJECT, /**  @lends myfaces._impl.core.Impl.
 
         if (jsf.getProjectStage() === "Development" && this._errListeners.length() == 0 && !context["onerror"]) {
             var DIVIDER = "--------------------------------------------------------",
-                    defaultErrorOutput = myfaces._impl.core._Runtime.getGlobalConfig("defaultErrorOutput", alert),
+                    defaultErrorOutput = myfaces._impl.core._Runtime.getGlobalConfig("defaultErrorOutput", (console && console.error) ? console.error : alert),
                     finalMessage = [],
             //we remap the function to achieve a better compressability
                     pushMsg = _Lang.hitch(finalMessage, finalMessage.push);
@@ -825,6 +895,26 @@ _MF_SINGLTN(_PFX_CORE + "Impl", _MF_OBJECT, /**  @lends myfaces._impl.core.Impl.
         var forms = this._Dom.findByTagName(finalNode, "form");
         var result = fetchWindowIdFromForms(forms);
         return (null != result) ? result : fetchWindowIdFromURL();
+    },
+
+    /**
+     * returns the view id from an incoming form
+     * crossport from new codebase
+     * @param form
+     */
+    getViewId: function (form) {
+        var _t = this;
+        var foundViewStates = this._Dom.findAll(form, function(node) {
+            return node.tagName === "INPUT" && node.type === "hidden" && (node.name || "").indexOf(_t.P_VIEWSTATE) !== -1
+        }, true);
+        if(!foundViewStates.length) {
+            return "";
+        }
+        var viewId =  foundViewStates[0].id.split(jsf.separatorchar, 2)[0];
+        var viewStateViewId = viewId.indexOf(this.P_VIEWSTATE) === -1 ? viewId : "";
+        // myfaces specific, we in non portlet environments prepend the viewId
+        // even without being in a naming container, the other components ignore that
+        return form.id.indexOf(viewStateViewId) === 0 ? viewStateViewId : "";
     }
 });
 

--- a/api/src/main/javascript/META-INF/resources/myfaces/_impl/core/_EvalHandlers.js
+++ b/api/src/main/javascript/META-INF/resources/myfaces/_impl/core/_EvalHandlers.js
@@ -70,114 +70,88 @@ if (!myfaces._impl.core._EvalHandlers) {
          */
         var _T = this;
 
-        /*cascaded eval methods depending upon the browser*/
-
+        // note it is safe to remove the cascaded global eval
+        // the head appendix method is the standard method and has been
+        // for over a decade even on ie6 (see file history)
         /**
-         * @function
+         * an implementation of eval which drops legacy support
+         * and allows nonce
          * @param code
-
-         *
-         * evals a script globally using exec script (ie6 fallback)
-         * @param {String} code the code which has to be evaluated
-         * @borrows myfaces._impl.core._Runtime as _T
-         *
-         * TODO eval if we cannot replace this method with the head appendix
-         * method which is faster for ie this also would reduce our code
-         * by a few bytes
+         * @param cspMeta optional csp metadata, only allowed key atm nonce
          */
-        _T._evalExecScript = function(code) {
-            //execScript definitely only for IE otherwise we might have a custom
-            //window extension with undefined behavior on our necks
-            //window.execScript does not return anything
-            //on htmlunit it return "null object"
-            //_r == ret
-            var _r = window.execScript(code);
-            if ('undefined' != typeof _r && _r == "null" /*htmlunit bug*/) {
-                return null;
+        _T.globalEval = function(code, cspMeta) {
+            //check for jsf nonce
+            var nonce = cspMeta ? cspMeta.nonce : this._currentScriptNonce();
+
+            var element = document.createElement("script");
+            element.setAttribute("type", "text/javascript");
+            element.innerHTML = code;
+            if(nonce) {
+                element.setAttribute("nonce", nonce);
             }
-            return _r;
+            //head appendix method, modern browsers use this method savely to eval scripts
+            //we did not use it up until now because there were really old legacy browsers where
+            //it did not work
+            var htmlScriptElement = document.head.appendChild(element);
+            document.head.removeChild(htmlScriptElement);
         };
 
-        /**
-         * flakey head appendix method which does not work in the correct
-         * order or at all for all modern browsers
-         * but seems to be the only method which works on blackberry correctly
-         * hence we are going to use it as fallback
-         *
-         * @param {String} code the code part to be evaled
-         * @borrows myfaces._impl.core._Runtime as _T
-         */
-        _T._evalHeadAppendix = function(code) {
-            //_l == location
-            var _l = document.getElementsByTagName("head")[0] || document.documentElement;
-            //_p == placeHolder
-            var _p = document.createElement("script");
-            _p.type = "text/javascript";
-            _p.text = code;
-            _l.insertBefore(_p, _l.firstChild);
-            _l.removeChild(_p);
-            return null;
-        };
+        _T.resolveNonce = function(item) {
+            var nonce = null;
+            if(!!(item && item.nonce)) {
+                nonce = item.nonce;
+            } else if(!!item && item.getAttribute) {
+                nonce = item.getAttribute("nonce");
+            }
+            //empty nonce means no nonce, the rest
+            //of the code treats it like null
+            return (!nonce) ? null : nonce;
+        }
+        /*
+        * determines the jsfjs nonce and adds them to the namespace
+        * this is done once and only lazily
+        */
+        _T._currentScriptNonce = function() {
+            //already processed
+            if(myfaces.config && myfaces.config.cspMeta) {
+                return myfaces.config.cspMeta.nonce;
+            }
 
-        /**
-         * @name myfaces._impl.core._Runtime._standardGlobalEval
-         * @private
-         * @param {String} code
-         */
-        _T._standardGlobalEval = function(code) {
-            //fix which works in a cross browser way
-            //we used to scope an anonymous function
-            //but I think this is better
-            //the reason is some Firefox versions
-            // apply a wrong scope
-            //if we call eval by not scoping
-            //_U == "undefined"
-            var _U = "undefined";
-            var gEval = function () {
-                //_r == retVal;
-                var _r = window.eval.call(window, code);
-                if (_U == typeof _r) return null;
-                return _r;
+            //since our baseline atm is ie11 we cannot use document.currentScript globally
+            if(_T.resolveNonce(document.currentScript)) {
+                // fastpath for modern browsers
+                return _T.resolveNonce(document.currentScript);
+            }
+
+            var _Lang = myfaces._impl._util._Lang;
+            var scripts = _Lang.objToArray(document.getElementsByTagName("script"))
+                .concat(_Lang.objToArray(document.getElementsByTagName("link")));
+
+            var jsf_js = null;
+
+            //we search all scripts
+            for(var cnt = 0; scripts && cnt < scripts.length; cnt++) {
+                var scriptNode = scripts[cnt];
+                if(!_T.resolveNonce(scriptNode)) {
+                    continue;
+                }
+                var src = scriptNode.getAttribute("src") || "";
+                if(src && !src.match(/jsf\.js\?ln\=javax\.faces/gi)) {
+                    jsf_js = scriptNode;
+                    //the first one is the one we have our code in
+                    //subsequent ones do not overwrite our code
+                    break;
+                }
+            }
+            //found
+            myfaces.config = myfaces.config || {};
+            myfaces.config.cspMeta = myfaces.config.cspMeta || {
+                nonce: null
             };
-            var _r = gEval();
-            if (_U == typeof _r) return null;
-            return _r;
-        };
-
-        /**
-         * global eval on scripts
-         * @param {String} c (code abbreviated since the compression does not work here)
-         * @name myfaces._impl.core._Runtime.globalEval
-         * @function
-         */
-        _T.globalEval = function(c) {
-            //TODO add a config param which allows to evaluate global scripts even if the call
-            //is embedded in an iframe
-            //We lazy init the eval type upon the browsers
-            //capabilities   
-            var _e = "_evalType";
-            var _w = window;
-            var _b = myfaces._impl.core._Runtime.browser;
-            //central routine to determine the eval method
-            if (!_T[_e]) {
-                //execScript supported
-                _T[_e] = _w.execScript ? "_evalExecScript" : null;
-
-                //in case of no support we go to the standard global eval  window.eval.call(window,
-                // with Firefox fixes for scoping
-                _T[_e] = _T[_e] ||(( _w.eval && (!_b.isBlackBerry ||_b.isBlackBerry >= 6)) ? "_standardGlobalEval" : null);
-
-                //this one routes into the hed appendix method
-                _T[_e] = _T[_e] ||((_w.eval ) ? "_evalHeadAppendix" : null);
+            if(jsf_js) {
+                myfaces.config.cspMeta.nonce = _T.resolveNonce(jsf_js);
             }
-            if (_T[_e]) {
-                //we now execute the eval method
-                return _T[_T[_e]](c);
-            }
-            //we probably have covered all browsers, but this is a safety net which might be triggered
-            //by some foreign browser which is not covered by the above cases
-            eval.call(window, c);
-            return null;
+            return myfaces.config.cspMeta.nonce;
         };
 
     };

--- a/api/src/main/javascript/META-INF/resources/myfaces/_impl/core/_ExtRuntime.js
+++ b/api/src/main/javascript/META-INF/resources/myfaces/_impl/core/_ExtRuntime.js
@@ -170,23 +170,23 @@
         }
     };
 
-      //internal class namespace reservation depending on the type (string or function)
-      _T._reserveClsNms = function(newCls, protoFuncs) {
-            var constr = null;
-            var UDEF = "undefined";
-            if (UDEF != typeof protoFuncs && null != protoFuncs) {
-                constr = (UDEF != typeof null != protoFuncs['constructor_'] && null != protoFuncs['constructor_']) ? protoFuncs['constructor_'] : function() {
-                };
-            } else {
-                constr = function() {
-                };
-            }
+    //internal class namespace reservation depending on the type (string or function)
+    _T._reserveClsNms = function(newCls, protoFuncs) {
+        var constr = null;
+        var UDEF = "undefined";
+        if (UDEF != typeof protoFuncs && null != protoFuncs) {
+            constr = (UDEF != typeof null != protoFuncs['constructor_'] && null != protoFuncs['constructor_']) ? protoFuncs['constructor_'] : function() {
+            };
+        } else {
+            constr = function() {
+            };
+        }
 
-            if (!_T.reserveNamespace(newCls, constr)) {
-                return null;
-            }
-            newCls = _T.fetchNamespace(newCls);
-            return newCls;
-        };
+        if (!_T.reserveNamespace(newCls, constr)) {
+            return null;
+        }
+        newCls = _T.fetchNamespace(newCls);
+        return newCls;
+    };
 
 })();

--- a/api/src/main/javascript/META-INF/resources/myfaces/_impl/core/_Runtime.js
+++ b/api/src/main/javascript/META-INF/resources/myfaces/_impl/core/_Runtime.js
@@ -73,8 +73,12 @@ if (!myfaces._impl.core._Runtime) {
          * @name myfaces._impl.core._Runtime.globalEval
          * @function
          */
-        _T.globalEval = function(code) {
-            return myfaces._impl.core._EvalHandlers.globalEval(code);
+        _T.globalEval = function(code, cspMeta) {
+            return myfaces._impl.core._EvalHandlers.globalEval(code, cspMeta);
+        };
+
+        _T.resolveNonce = function(item) {
+            return myfaces._impl.core._EvalHandlers.resolveNonce(item);
         };
 
         /**
@@ -391,9 +395,10 @@ if (!myfaces._impl.core._Runtime) {
          * @param {Boolean} defer  defer true or false, same as the javascript tag defer param
          * @param {String} charSet the charset under which the script has to be loaded
          * @param {Boolean} async tells whether the script can be asynchronously loaded or not, currently
+         * @param cspMetas csp meta data to be processed by globalEval
          * not used
          */
-        this.loadScriptEval = function(src, type, defer, charSet, async) {
+        this.loadScriptEval = function(src, type, defer, charSet, async, cspMeta) {
             var xhr = _T.getXHRObject();
             xhr.open("GET", src, false);
 
@@ -415,12 +420,12 @@ if (!myfaces._impl.core._Runtime) {
                         //we moved the sourceurl notation to # instead of @ because ie does not cover it correctly
                         //newer browsers understand # including ie since windows 8.1
                         //see http://updates.html5rocks.com/2013/06/sourceMappingURL-and-sourceURL-syntax-changed
-                        _T.globalEval(xhr.responseText.replace("\n", "\r\n") + "\r\n//# sourceURL=" + src);
+                        _T.globalEval(xhr.responseText.replace("\n", "\r\n") + "\r\n//# sourceURL=" + src, cspMeta);
                     } else {
                         //TODO not ideal we maybe ought to move to something else here
                         //but since it is not in use yet, it is ok
                         setTimeout(function() {
-                            _T.globalEval(xhr.responseText.replace("\n", "\r\n") + "\r\n//# sourceURL=" + src);
+                            _T.globalEval(xhr.responseText.replace("\n", "\r\n") + "\r\n//# sourceURL=" + src, cspMeta);
                         }, 1);
                     }
                 } else {
@@ -441,7 +446,7 @@ if (!myfaces._impl.core._Runtime) {
          * @param {Boolean} defer  defer true or false, same as the javascript tag defer param
          * @param {String} charSet the charset under which the script has to be loaded
          */
-        this.loadScriptByBrowser = function(src, type, defer, charSet, async) {
+        this.loadScriptByBrowser = function(src, type, defer, charSet, async, cspMeta) {
             //if a head is already present then it is safer to simply
             //use the body, some browsers prevent head alterations
             //after the first initial rendering
@@ -461,6 +466,9 @@ if (!myfaces._impl.core._Runtime) {
 
                 script.type = type || "text/javascript";
                 script.src = src;
+                if(cspMeta && cspMeta.nonce) {
+                    script.setAttribute("nonce", cspMeta.nonce);
+                }
                 if (charSet) {
                     script.charset = charSet;
                 }

--- a/api/src/main/javascript/META-INF/resources/myfaces/_impl/quirks/ObjectQuirks.js
+++ b/api/src/main/javascript/META-INF/resources/myfaces/_impl/quirks/ObjectQuirks.js
@@ -16,28 +16,25 @@
 /**
  Base class which provides several helper functions over all objects
  */
-_MF_CLS(_PFX_CORE+"Object", Object, {
+_MF_CLS(_PFX_CORE+"ObjectQuirks", myfaces._impl.core.Object, {
 
 
 
     constructor_: function() {
-        this._resettableContent = {};
-        //to make those singleton references
-        //overridable in the instance we have
-        //to load them into the prototype instead
-        //of the instance
-        var proto = this._mfClazz.prototype;
-        var impl = myfaces._impl;
-        if(!proto._RT) {
-            proto._RT  =  impl.core._Runtime;
-            proto._Lang = impl._util._Lang;
-            proto._Dom =  impl._util._Dom;
-        }
+       this._callSuper("constructor_");
     },
 
     /*optional functionality can be provided
      * for ie6 but is turned off by default*/
     _initDefaultFinalizableFields: function() {
+        var isIE = this._RT.browser.isIE;
+        if(!isIE || isIE > 7) return;
+        for (var key in this) {
+            //per default we reset everything which is not preinitalized
+            if (null == this[key] && key != "_resettableContent" && key.indexOf("_mf") != 0 && key.indexOf("_") == 0) {
+                this._resettableContent[key] = true;
+            }
+        }
     },
 
     /**
@@ -47,36 +44,32 @@ _MF_CLS(_PFX_CORE+"Object", Object, {
      * on other browsers this method does nothing
      */
     _finalize: function() {
-        // not needed anymore but to preserve
-        // the connection to quirks mode
-        // we keep it as empty implementation
-    },
+        try {
+            if (this._isGCed || !this._RT.browser.isIE || !this._resettableContent) {
+                //no ie, no broken garbage collector
+                return;
+            }
 
-    attr: function(name, value) {
-       return this._Lang.attr(this, name, value);
-    },
-
-    getImpl: function() {
-        this._Impl = this._Impl || this._RT.getGlobalConfig("jsfAjaxImpl", myfaces._impl.core.Impl);
-        return this._Impl;
-    },
-
-    applyArgs: function(args) {
-        this._Lang.applyArgs(this, args);
-    },
-
-    updateSingletons: function(key) {
-        var _T = this;
-        _T._RT.iterateSingletons(function(namespace) {
-            if(namespace[key]) namespace[key] = _T;
-        });
+            for (var key in this._resettableContent) {
+                if (this._RT.exists(this[key], "_finalize")) {
+                    this[key]._finalize();
+                }
+                delete this[key];
+            }
+        } finally {
+            this._isGCed = true;
+        }
     }
-
 });
 
 (function() {
     /*some mobile browsers do not have a window object*/
     var target = window ||document;
-    target._MF_OBJECT = myfaces._impl.core.Object;
+
+    // we still reuse the other namespaces for our quirks module, to avoid
+    // specific quirks code on our core code
+    // this class is a full replacement of Object, not just
+    // an extension
+    target._MF_OBJECT = myfaces._impl.core.ObjectQuirks;
 
 })();

--- a/api/src/main/javascript/META-INF/resources/myfaces/_impl/quirks/_AjaxRequestQuirks.js
+++ b/api/src/main/javascript/META-INF/resources/myfaces/_impl/quirks/_AjaxRequestQuirks.js
@@ -1,0 +1,288 @@
+/* Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * An implementation of an xhr request object
+ * with partial page submit functionality, and jsf
+ * ppr request and timeout handling capabilities
+ *
+ * Author: Werner Punz (latest modification by $Author: ganeshpuri $)
+ * Version: $Revision: 1.4 $ $Date: 2009/05/31 09:16:44 $
+ */
+
+_MF_CLS(_PFX_XHR + "_AjaxRequestQuirks", myfaces._impl.xhrCore._AjaxRequest, /** @lends myfaces._impl.xhrCore._AjaxRequest.prototype */ {
+    constructor_: function (args) {
+        this._callSuper("constructor_", args);
+    },
+    /**
+     * Sends an Ajax request
+     */
+    send:function () {
+
+        var _Lang = this._Lang;
+        var _RT = this._RT;
+        var _Dom = this._Dom;
+        try {
+
+            var scopeThis = _Lang.hitch(this, function (functionName) {
+                return _Lang.hitch(this, this[functionName]);
+            });
+            this._xhr = _Lang.mixMaps(this._getTransport(), {
+                onprogress:scopeThis("onprogress"),
+                ontimeout:scopeThis("ontimeout"),
+                //remove for xhr level2 support (chrome has problems with it)
+                //for chrome we have to emulate the onloadend by calling it explicitely
+                //and leave the onload out
+                //onloadend:  scopeThis("ondone"),
+                onload:scopeThis("onsuccess"),
+                onerror:scopeThis("onerror")
+
+            }, true);
+
+            this._applyClientWindowId();
+            var xhr = this._xhr,
+                sourceForm = this._sourceForm,
+                targetURL = (typeof sourceForm.elements[this.ENCODED_URL] == 'undefined') ?
+                    sourceForm.action :
+                    sourceForm.elements[this.ENCODED_URL].value,
+                formData = this.getFormData();
+
+            for (var key in this._passThrough) {
+                if (!this._passThrough.hasOwnProperty(key)) continue;
+                formData.append(key, this._passThrough[key]);
+            }
+
+            xhr.open(this._ajaxType, targetURL +
+                ((this._ajaxType == "GET") ? "?" + this._formDataToURI(formData) : "")
+                , true);
+
+            xhr.timeout = this._timeout || 0;
+
+            this._applyContentType(xhr);
+            xhr.setRequestHeader(this._HEAD_FACES_REQ, this._VAL_AJAX);
+
+            //some webkit based mobile browsers do not follow the w3c spec of
+            // setting the accept headers automatically
+            if (this._RT.browser.isWebKit) {
+                xhr.setRequestHeader("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8");
+            }
+            this._sendEvent("BEGIN");
+            //Check if it is a custom form data object
+            //if yes we use makefinal for the final handling
+            if (formData && formData.makeFinal) {
+                formData = formData.makeFinal()
+            }
+            xhr.send((this._ajaxType != "GET") ? formData : null);
+
+        } catch (e) {
+            //_onError//_onError
+            e = (e._mfInternal) ? e : this._Lang.makeException(new Error(), "sendError", "sendError", this._nameSpace, "send", e.message);
+            this._stdErrorHandler(this._xhr, this._context, e);
+        } finally {
+            //no finally possible since the iframe uses real asynchronousity
+        }
+    },
+
+    _applyClientWindowId:function () {
+        var _Impl = this.attr("impl");
+        var clientWindow = this._Dom.getNamedElementFromForm(this._sourceForm, _Impl.P_CLIENTWINDOW);
+        //pass through if exists already set by _Impl
+        if ('undefined' != typeof this._context._mfInternal._clientWindow) {
+            this._context._mfInternal._clientWindowOld = clientWindow.value;
+            clientWindow.value = this._context._mfInternal._clientWindow;
+        } else {
+            if(clientWindow) {
+                this._context._mfInternal._clientWindowDisabled = !! clientWindow.disabled;
+                clientWindow.disabled = true;
+            }
+        }
+    },
+
+    _restoreClientWindowId:function () {
+        //we have to reset the client window back to its original state
+        var _Impl = this.attr("impl");
+        var clientWindow = this._Dom.getNamedElementFromForm(this._sourceForm, _Impl.P_CLIENTWINDOW);
+        if(!clientWindow) {
+            return;
+        }
+        if ('undefined' != typeof this._context._mfInternal._clientWindowOld) {
+            clientWindow.value =  this._context._mfInternal._clientWindow;
+        }
+        if('undefined' != typeof this._context._mfInternal._clientWindowDisabled) {
+            //we reset it to the old value
+            clientWindow.disabled = this._context._mfInternal._clientWindowDisabled;
+        }
+    },
+
+
+
+    onsuccess:function (/*evt*/) {
+        this._restoreClientWindowId();
+        var context = this._context;
+        var xhr = this._xhr;
+        try {
+            this._sendEvent("COMPLETE");
+            //now we have to reroute into our official api
+            //because users might want to decorate it, we will split it apart afterwards
+
+            context._mfInternal = context._mfInternal || {};
+            jsf.ajax.response((xhr.getXHRObject) ? xhr.getXHRObject() : xhr, context);
+
+        } catch (e) {
+            this._stdErrorHandler(this._xhr, this._context, e);
+
+            //add for xhr level2 support
+        } finally {
+            //W3C spec onloadend must be called no matter if success or not
+            this.ondone();
+        }
+    },
+
+    onerror:function (/*evt*/) {
+        this._restoreClientWindowId();
+        //TODO improve the error code detection here regarding server errors etc...
+        //and push it into our general error handling subframework
+        var context = this._context;
+        var xhr = this._xhr;
+        var _Lang = this._Lang;
+
+        var errorText = "";
+        this._sendEvent("COMPLETE");
+        try {
+            var UNKNOWN = _Lang.getMessage("UNKNOWN");
+            //status can be 0 and statusText can be ""
+            var status = ('undefined' != xhr.status && null != xhr.status) ? xhr.status : UNKNOWN;
+            var statusText = ('undefined' != xhr.statusText && null != xhr.statusText) ? xhr.statusText : UNKNOWN;
+            errorText = _Lang.getMessage("ERR_REQU_FAILED", null, status, statusText);
+
+        } catch (e) {
+            errorText = _Lang.getMessage("ERR_REQ_FAILED_UNKNOWN", null);
+        } finally {
+            try {
+                var _Impl = this.attr("impl");
+                _Impl.sendError(xhr, context, _Impl.HTTPERROR,
+                    _Impl.HTTPERROR, errorText, "", "myfaces._impl.xhrCore._AjaxRequest", "onerror");
+            } finally {
+                //add for xhr level2 support
+                //since chrome does not call properly the onloadend we have to do it manually
+                //to eliminate xhr level1 for the compile profile modern
+                //W3C spec onloadend must be called no matter if success or not
+                this.ondone();
+            }
+        }
+        //_onError
+    },
+
+
+    ontimeout:function (/*evt*/) {
+        try {
+            this._restoreClientWindowId();
+            //we issue an event not an error here before killing the xhr process
+            this._sendEvent("TIMEOUT_EVENT");
+            //timeout done we process the next in the queue
+        } finally {
+            this._requestDone();
+        }
+    },
+
+    _formDataToURI:function (formData) {
+        if (formData && formData.makeFinal) {
+            formData = formData.makeFinal()
+        }
+        return formData;
+    },
+
+    _getTransport:function () {
+
+        var xhr = this._RT.getXHRObject();
+        //the current xhr level2 timeout w3c spec is not implemented by the browsers yet
+        //we have to do a fallback to our custom routines
+
+        //add for xhr level2 support
+        //Chrome fails in the current builds, on our loadend, we disable the xhr
+        //level2 optimisations for now
+        if (/*('undefined' == typeof this._timeout || null == this._timeout) &&*/ this._RT.getXHRLvl() >= 2) {
+            //no timeout we can skip the emulation layer
+            return xhr;
+        }
+        return new myfaces._impl.xhrCore.engine.Xhr1({xhrObject:xhr});
+    },
+
+    //----------------- backported from the base request --------------------------------
+    //non abstract ones
+    /**
+     * Spec. 13.3.1
+     * Collect and encode input elements.
+     * Additionally the hidden element jakarta/javax.faces.ViewState
+     *
+     *
+     * @return  an element of formDataWrapper
+     * which keeps the final Send Representation of the
+     */
+    getFormData:function () {
+        var _AJAXUTIL = this._AJAXUTIL, myfacesOptions = this._context.myfaces;
+        return this._Lang.createFormDataDecorator(jsf.getViewState(this._sourceForm));
+    },
+
+    /**
+     * Client error handlers which also in the long run route into our error queue
+     * but also are able to deliver more meaningful messages
+     * note, in case of an error all subsequent xhr requests are dropped
+     * to get a clean state on things
+     *
+     * @param request the xhr request object
+     * @param context the context holding all values for further processing
+     * @param exception the embedded exception
+     */
+    _stdErrorHandler:function (request, context, exception) {
+        var xhrQueue = this._xhrQueue;
+        try {
+            this.attr("impl").stdErrorHandler(request, context, exception);
+        } finally {
+            if (xhrQueue) {
+                xhrQueue.cleanup();
+            }
+        }
+    },
+
+    _sendEvent:function (evtType) {
+        var _Impl = this.attr("impl");
+        _Impl.sendEvent(this._xhr, this._context, _Impl[evtType]);
+    },
+
+    _requestDone:function () {
+        var queue = this._xhrQueue;
+        if (queue) {
+            queue.processQueue();
+        }
+        //ie6 helper cleanup
+        delete this._context.source;
+        this._finalize();
+    },
+
+    //cleanup
+    _finalize:function () {
+        if (this._xhr.readyState == this._XHR_CONST.READY_STATE_DONE) {
+            this._callSuper("_finalize");
+        }
+    }
+
+});
+
+(function() {
+    /*some mobile browsers do not have a window object*/
+    myfaces._impl.xhrCore._AjaxRequest = myfaces._impl.xhrCore._AjaxRequestQuirks;
+})();

--- a/api/src/main/javascript/META-INF/resources/myfaces/_impl/quirks/_AjaxResponseQuirks.js
+++ b/api/src/main/javascript/META-INF/resources/myfaces/_impl/quirks/_AjaxResponseQuirks.js
@@ -1,0 +1,171 @@
+/* Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @class
+ * @name _AjaxResponse
+ * @memberOf myfaces._impl.xhrCore
+ * @extends myfaces._impl.core.Object
+ * @description
+ * This singleton is responsible for handling the standardized xml ajax response
+ * Note: since the semantic processing can be handled about 90% in a functional
+ * style we make this class stateless. Every state information is stored
+ * temporarily in the context.
+ *
+ * Ajax Response overrides for IE quirks mode
+ *
+ */
+_MF_SINGLTN(_PFX_XHR + "_AjaxResponseQuirks", myfaces._impl.xhrCore._AjaxResponse, /** @lends myfaces._impl.xhrCore._AjaxResponse.prototype */ {
+    constructor_: function() {
+        this._callSuper("constructor_");
+        myfaces._impl.xhrCore._AjaxResponse = this;
+    },
+
+    /**
+     * replaces a current head theoretically,
+     * pratically only the scripts are evaled anew since nothing else
+     * can be changed.
+     *
+     * @param request the current request
+     * @param context the ajax context
+     * @param newData the data to be processed
+     *
+     * @return an xml representation of the page for further processing if possible
+     */
+    _replaceHead: function (request, context, newData) {
+        var _Lang = this._Lang,
+            _Dom = this._Dom,
+            _RT = this._RT,
+            isWebkit = this._RT.browser.isWebKit,
+            //we have to work around an xml parsing bug in Webkit
+            //see https://issues.apache.org/jira/browse/MYFACES-3061
+            doc = (!isWebkit) ? _Lang.parseXML(newData) : null,
+            newHead = null;
+
+        if (!isWebkit && _Lang.isXMLParseError(doc)) {
+            doc = _Lang.parseXML(newData.replace(/<!\-\-[\s\n]*<!\-\-/g, "<!--").replace(/\/\/-->[\s\n]*\/\/-->/g, "//-->"));
+        }
+
+        if (isWebkit || _Lang.isXMLParseError(doc)) {
+            //the standard xml parser failed we retry with the stripper
+            var parser = new (this._RT.getGlobalConfig("updateParser", myfaces._impl._util._HtmlStripper))();
+            var headData = parser.parse(newData, "head");
+            //We cannot avoid it here, but we have reduced the parsing now down to the bare minimum
+            //for further processing
+            newHead = _Lang.parseXML("<head>" + headData + "</head>");
+            //last and slowest option create a new head element and let the browser
+            //do its slow job
+            if (_Lang.isXMLParseError(newHead)) {
+                try {
+                    newHead = _Dom.createElement("head");
+                    newHead.innerHTML = headData;
+                } catch (e) {
+                    //we give up no further fallbacks
+                    throw this._raiseError(new Error(), "Error head replacement failed reason:" + e.toString(), "_replaceHead");
+                }
+            }
+            newHead = newHead.childNodes[0];
+        } else {
+            //parser worked we go on
+            newHead = doc.getElementsByTagName("head")[0];
+        }
+
+        var oldTags = _Lang.objToArray(document.head.childNodes);
+
+
+        _Dom.deleteItems(_Lang.objToArray(oldTags));
+        _Dom.appendToHead(newHead);
+
+
+        return document.head;
+    },
+
+    /**
+     * special method to handle the body dom manipulation,
+     * replacing the entire body does not work fully by simply adding a second body
+     * and by creating a range instead we have to work around that by dom creating a second
+     * body and then filling it properly!
+     *
+     * @param {Object} request our request object
+     * @param {Object} context (Map) the response context
+     * @param {String} newData the markup which replaces the old dom node!
+     * @param {Node} parsedData (optional) preparsed XML representation data of the current document
+     */
+    _replaceBody: function (request, context, newData /*varargs*/) {
+        var _RT = this._RT,
+            _Dom = this._Dom,
+            _Lang = this._Lang,
+
+            oldBody = document.getElementsByTagName("body")[0],
+            placeHolder = document.createElement("div"),
+            isWebkit = _RT.browser.isWebKit;
+
+        placeHolder.id = "myfaces_bodyplaceholder";
+
+        _Dom._removeChildNodes(oldBody);
+        oldBody.innerHTML = "";
+        oldBody.appendChild(placeHolder);
+
+        var bodyData, doc = null, parser;
+
+        //we have to work around an xml parsing bug in Webkit
+        //see https://issues.apache.org/jira/browse/MYFACES-3061
+        if (!isWebkit) {
+            doc = (arguments.length > 3) ? arguments[3] : _Lang.parseXML(newData);
+        }
+
+        if (!isWebkit && _Lang.isXMLParseError(doc)) {
+            doc = _Lang.parseXML(newData.replace(/<!\-\-[\s\n]*<!\-\-/g, "<!--").replace(/\/\/-->[\s\n]*\/\/-->/g, "//-->"));
+        }
+
+        if (isWebkit || _Lang.isXMLParseError(doc)) {
+            //the standard xml parser failed we retry with the stripper
+
+            parser = new (_RT.getGlobalConfig("updateParser", myfaces._impl._util._HtmlStripper))();
+
+            bodyData = parser.parse(newData, "body");
+        } else {
+            //parser worked we go on
+            var newBodyData = doc.getElementsByTagName("body")[0];
+
+            //speedwise we serialize back into the code
+            //for code reduction, speedwise we will take a small hit
+            //there which we will clean up in the future, but for now
+            //this is ok, I guess, since replace body only is a small subcase
+            //bodyData = _Lang.serializeChilds(newBodyData);
+            var browser = _RT.browser;
+            if (!browser.isIEMobile || browser.isIEMobile >= 7) {
+                //TODO check what is failing there
+                for (var cnt = 0; cnt < newBodyData.attributes.length; cnt++) {
+                    var value = newBodyData.attributes[cnt].value;
+                    if (value)
+                        _Dom.setAttribute(oldBody, newBodyData.attributes[cnt].name, value);
+                }
+            }
+        }
+        //we cannot serialize here, due to escape problems
+        //we must parse, this is somewhat unsafe but should be safe enough
+        parser = new (_RT.getGlobalConfig("updateParser", myfaces._impl._util._HtmlStripper))();
+        bodyData = parser.parse(newData, "body");
+
+        var returnedElement = this.replaceHtmlItem(request, context, placeHolder, bodyData);
+
+        if (returnedElement) {
+            this._pushOperationResult(context, returnedElement);
+        }
+        return returnedElement;
+    },
+});

--- a/api/src/main/javascript/META-INF/resources/myfaces/_impl/quirks/_DomQuirks.js
+++ b/api/src/main/javascript/META-INF/resources/myfaces/_impl/quirks/_DomQuirks.js
@@ -1,0 +1,629 @@
+/* Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+if (_MF_SINGLTN) {
+    /***
+     Dom.js version for non html5 browsers
+     */
+    _MF_SINGLTN(_PFX_UTIL + "DomQuirks", myfaces._impl._util._Dom, /** @lends myfaces._impl._util._DomQuirks.prototype */ {
+
+        IE_QUIRKS_EVENTS:{
+            "onabort":true,
+            "onload":true,
+            "onunload":true,
+            "onchange":true,
+            "onsubmit":true,
+            "onreset":true,
+            "onselect":true,
+            "onblur":true,
+            "onfocus":true,
+            "onkeydown":true,
+            "onkeypress":true,
+            "onkeyup":true,
+            "onclick":true,
+            "ondblclick":true,
+            "onmousedown":true,
+            "onmousemove":true,
+            "onmouseout":true,
+            "onmouseover":true,
+            "onmouseup":true
+        },
+
+        constructor_:function () {
+
+            var b = myfaces._impl.core._Runtime.browser;
+
+            if (b.isIEMobile && b.isIE <= 6) {
+                //winmobile hates add onLoad, and checks on the construct
+                //it does not eval scripts anyway
+                myfaces.config = myfaces.config || {};
+                myfaces.config._autoeval = false;
+                return;
+            } else {
+                //for whatever reason autoeval is set here on Firefox 3.5 only
+                // could be a firebug problem, by setting setters
+                //and getters no assignment was revealed.
+                if ('undefined' != typeof myfaces.config && 'undefined' != typeof myfaces.config._autoeval) {
+                    delete myfaces.config._autoeval;
+                }
+            }
+            this._callSuper("constructor_");
+            myfaces._impl._util._Dom = this;
+
+            var _Lang = this._Lang;
+            //by w3c spec the script eval is turned off it is only
+            //on on legacy browsers
+            var scriptEval = _Lang.hitch(this, this.isManualScriptEval);
+
+            if (window) {
+                this._RT.addOnLoad(window, scriptEval);
+            }
+            //safety fallback if the window onload handler is overwritten and not chained
+            if (document.body) {
+                this._RT.addOnLoad(document.body, scriptEval);
+            }
+
+            //we register ourselves into the existing classes lazily
+            var _T = this;
+            if (myfaces._impl.core.Impl) {
+                this._RT.iterateClasses(function (proto) {
+                    if (proto._Dom) proto._Dom = _T;
+                });
+            }
+        },
+
+        /**
+         * Checks whether the browser is dom compliant.
+         * Dom compliant means that it performs the basic dom operations safely
+         * without leaking and also is able to perform a native setAttribute
+         * operation without freaking out
+         *
+         *
+         * Not dom compliant browsers are all microsoft browsers in quirks mode
+         * and ie6 and ie7 to some degree in standards mode
+         * and pretty much every browser who cannot create ranges
+         * (older mobile browsers etc...)
+         *
+         * We dont do a full browser detection here because it probably is safer
+         * to test for existing features to make an assumption about the
+         * browsers capabilities
+         */
+        isDomCompliant:function () {
+            if ('undefined' == typeof this._isCompliantBrowser) {
+                this._isCompliantBrowser = !!((window.Range
+                        && typeof Range.prototype.createContextualFragment == 'function')
+                                                            //createContextualFragment hints to a no quirks browser but we need more fallbacks
+                        || document.querySelectoryAll       //query selector all hints to html5 capabilities
+                        || document.createTreeWalker);      //treewalker is either firefox 3.5+ or ie9 standards mode
+            }
+            return this._isCompliantBrowser;
+        },
+
+        /**
+         * now to the evil browsers
+         * of what we are dealing with is various bugs
+         * first a simple replaceElement leaks memory
+         * secondly embedded scripts can be swallowed upon
+         * innerHTML, we probably could also use direct outerHTML
+         * but then we would run into the script swallow bug
+         *
+         * the entire mess is called IE6 and IE7
+         *
+         * @param item
+         * @param markup
+         */
+        _outerHTMLNonCompliant:function (item, markup) {
+
+            var b = this._RT.browser;
+
+            try {
+                //check for a subtable rendering case
+
+                var evalNodes = this._buildEvalNodes(item, markup);
+
+                if (evalNodes.length == 1) {
+                    var ret = evalNodes[0];
+                    this.replaceElement(item, evalNodes[0]);
+                    return ret;
+                } else {
+                    return this.replaceElements(item, evalNodes);
+                }
+
+            } finally {
+
+                var dummyPlaceHolder = this.getDummyPlaceHolder();
+                //now that Microsoft has finally given
+                //ie a working gc in 8 we can skip the costly operation
+                if (b.isIE && b.isIE < 8) {
+                    this._removeChildNodes(dummyPlaceHolder, false);
+                }
+                dummyPlaceHolder.innerHTML = "";
+            }
+
+        },
+
+        replaceElement:function (item, evalNode) {
+
+            var _Browser = this._RT.browser;
+            if (!_Browser.isIE || _Browser.isIE >= 8) {
+                //standards conform no leaking browser
+                item.parentNode.replaceChild(evalNode, item);
+            } else {
+                this._callSuper("replaceElement", item, evalNode);
+            }
+        },
+
+        /**
+         * builds the ie nodes properly in a placeholder
+         * and bypasses a non script insert bug that way
+         * @param markup the marku code
+         */
+        _buildNodesNonCompliant:function (markup) {
+
+            //now to the non w3c compliant browsers
+            //http://blogs.perl.org/users/clinton_gormley/2010/02/forcing-ie-to-accept-script-tags-in-innerhtml.html
+            //we have to cope with deficiencies between ie and its simulations in this case
+            var probe = this.getDummyPlaceHolder();//document.createElement("div");
+
+            probe.innerHTML = "<table><tbody><tr><td><div></div></td></tr></tbody></table>";
+
+            //we have customers using html unit, this has a bug in the table resolution
+            //hence we determine the depth dynamically
+            var depth = this._determineDepth(probe);
+
+            this._removeChildNodes(probe, false);
+            probe.innerHTML = "";
+
+            var dummyPlaceHolder = this.getDummyPlaceHolder();//document.createElement("div");
+
+            //fortunately a table element also works which is less critical than form elements regarding
+            //the inner content
+            dummyPlaceHolder.innerHTML = "<table><tbody><tr><td>" + markup + "</td></tr></tbody></table>";
+            var evalNodes = dummyPlaceHolder;
+
+            for (var cnt = 0; cnt < depth; cnt++) {
+                evalNodes = evalNodes.childNodes[0];
+            }
+            var ret = (evalNodes.parentNode) ? this.detach(evalNodes.parentNode.childNodes) : null;
+
+            if ('undefined' == typeof evalNodes || null == evalNodes) {
+                //fallback for htmlunit which should be good enough
+                //to run the tests, maybe we have to wrap it as well
+                dummyPlaceHolder.innerHTML = "<div>" + markup + "</div>";
+                //note this is triggered only in htmlunit no other browser
+                //so we are save here
+                //TODO Fix this (probaby ret is needed here, check the history)
+                evalNodes = this.detach(dummyPlaceHolder.childNodes[0].childNodes);
+            }
+
+            this._removeChildNodes(dummyPlaceHolder, false);
+            //ie fix any version, ie does not return true javascript arrays so we have to perform
+            //a cross conversion
+            return ret;
+
+        },
+
+        _determineDepth:function (probe) {
+            var depth = 0;
+            var newProbe = probe;
+            for (; newProbe &&
+                           newProbe.childNodes &&
+                           newProbe.childNodes.length &&
+                           newProbe.nodeType == 1; depth++) {
+                newProbe = newProbe.childNodes[0];
+            }
+            return depth;
+        },
+
+        //now to another nasty issue:
+        //for ie we have to walk recursively over all nodes:
+        //http://msdn.microsoft.com/en-us/library/bb250448%28VS.85%29.aspx
+        //http://weblogs.java.net/blog/driscoll/archive/2009/11/13/ie-memory-management-and-you
+        //http://home.orange.nl/jsrosman/
+        //http://www.quirksmode.org/blog/archives/2005/10/memory_leaks_li.html
+        //http://www.josh-davis.org/node/7
+        _removeNode:function (node, breakEventsOpen) {
+            if (!node) return;
+            var b = this._RT.browser;
+            if (this.isDomCompliant()) {
+                //recursive descension only needed for old ie versions
+                //all newer browsers cleanup the garbage just fine without it
+                //thank you
+                if ('undefined' != typeof node.parentNode && null != node.parentNode) //if the node has a parent
+                    node.parentNode.removeChild(node);
+                return;
+            }
+
+            //now to the browsers with non working garbage collection
+            this._removeChildNodes(node, breakEventsOpen);
+
+            try {
+                //outer HTML setting is only possible in earlier IE versions all modern browsers throw an exception here
+                //again to speed things up we precheck first
+                if (!this._isTableElement(node)) {
+                    //we do not do a table structure innnerhtml on table elements except td
+                    //htmlunit rightfully complains that we should not do it
+                    node.innerHTML = "";
+                }
+                if (b.isIE && 'undefined' != typeof node.outerHTML) {//ie8+ check done earlier we skip it here
+                    node.outerHTML = '';
+                } else {
+                    node = this.detach(node)[0];
+                }
+                if (!b.isIEMobile) {
+                    delete node;
+                }
+            } catch (e) {
+                //on some elements we might not have covered by our table check on the outerHTML
+                // can fail we skip those in favor of stability
+                try {
+                    // both innerHTML and outerHTML fails when <tr> is the node, but in that case
+                    // we need to force node removal, otherwise it will be on the tree (IE 7 IE 6)
+                    this.detach(node);
+                    if (!b.isIEMobile) {
+                        delete node;
+                    }
+                } catch (e1) {
+                }
+            }
+        },
+
+        /**
+         * recursive delete child nodes
+         * node, this method only makes sense in the context of IE6 + 7 hence
+         * it is not exposed to the public API, modern browsers
+         * can garbage collect the nodes just fine by doing the standard removeNode method
+         * from the dom API!
+         *
+         * @param node  the node from which the childnodes have to be deletd
+         * @param breakEventsOpen if set to true a standard events breaking is performed
+         */
+        _removeChildNodes:function (node, breakEventsOpen) {
+            if (!node) return;
+
+            //node types which cannot be cleared up by normal means
+            var disallowedNodes = this.TABLE_ELEMS;
+
+            //for now we do not enable it due to speed reasons
+            //normally the framework has to do some event detection
+            //which we cannot do yet, I will dig for options
+            //to enable it in a speedly manner
+            //ie7 fixes this area anyway
+            //this.breakEvents(node);
+
+            var b = this._RT.browser;
+            if (breakEventsOpen) {
+                this.breakEvents(node);
+            }
+
+            for (var cnt = node.childNodes.length - 1; cnt >= 0; cnt -= 1) {
+                var childNode = node.childNodes[cnt];
+                //we cannot use our generic recursive tree walking due to the needed head recursion
+                //to clean it up bottom up, the tail recursion we were using in the search either would use more time
+                //because we had to walk and then clean bottom up, so we are going for a direct head recusion here
+                if ('undefined' != typeof childNode.childNodes && node.childNodes.length)
+                    this._removeChildNodes(childNode);
+                try {
+                    var nodeName = (childNode.nodeName || childNode.tagName) ? (childNode.nodeName || childNode.tagName).toLowerCase() : null;
+                    //ie chokes on clearing out table inner elements, this is also covered by our empty
+                    //catch block, but to speed things up it makes more sense to precheck that
+                    if (!disallowedNodes[nodeName]) {
+                        //outer HTML setting is only possible in earlier IE versions all modern browsers throw an exception here
+                        //again to speed things up we precheck first
+                        if (!this._isTableElement(childNode)) {    //table elements cannot be deleted
+                            childNode.innerHTML = "";
+                        }
+                        if (b.isIE && b.isIE < 8 && 'undefined' != typeof childNode.outerHTML) {
+                            childNode.outerHTML = '';
+                        } else {
+                            node.removeChild(childNode);
+                        }
+                        if (!b.isIEMobile) {
+                            delete childNode;
+                        }
+                    }
+                } catch (e) {
+                    //on some elements the outerHTML can fail we skip those in favor
+                    //of stability
+
+                }
+            }
+        },
+        /**
+         * cross ported from dojo
+         * fetches an attribute from a node
+         *
+         * @param {String} node the node
+         * @param {String} attr the attribute
+         * @return the attributes value or null
+         */
+        getAttribute:function (/* HTMLElement */node, /* string */attr) {
+            //	summary
+            //	Returns the value of attribute attr from node.
+            node = this.byId(node);
+            // FIXME: need to add support for attr-specific accessors
+            if ((!node) || (!node.getAttribute)) {
+                // if(attr !== 'nwType'){
+                //	alert("getAttr of '" + attr + "' with bad node");
+                // }
+                return null;
+            }
+            var ta = typeof attr == 'string' ? attr : new String(attr);
+
+            // first try the approach most likely to succeed
+            var v = node.getAttribute(ta.toUpperCase());
+            if ((v) && (typeof v == 'string') && (v != "")) {
+                return v;	//	string
+            }
+
+            // try returning the attributes value, if we couldn't get it as a string
+            if (v && v.value) {
+                return v.value;	//	string
+            }
+
+
+
+            if (node.getAttribute(ta)) {
+                return node.getAttribute(ta);	//	string
+            } else if (node.getAttribute(ta.toLowerCase())) {
+                return node.getAttribute(ta.toLowerCase());	//	string
+
+            }
+            //there used to be a getAttributeNode check here for really old
+            //browsers, I had to remove it because of a firefox warning
+            //which uses a regexp scan for this method to be deprecated
+
+            return null;	//	string
+        },
+
+        /**
+         * bugfixing for ie6 which does not cope properly with setAttribute
+         */
+        setAttribute:function (node, attr, val) {
+
+            this._assertStdParams(node, attr, "setAttribute");
+
+            //quirks mode and ie7 mode has the attributes problems ie8 standards mode behaves like
+            //a good citizen
+            var _Browser = this._RT.browser;
+            //in case of ie > ie7 we have to check for a quirks mode setting
+            if (!_Browser.isIE || _Browser.isIE > 7 && this.isDomCompliant()) {
+                this._callSuper("setAttribute", node, attr, val);
+                return;
+            }
+
+            /*
+             Now to the broken browsers IE6+.... ie7 and ie8 quirks mode
+
+             we deal mainly with three problems here
+             class and for are not handled correctly
+             styles are arrays and cannot be set directly
+             and javascript events cannot be set via setAttribute as well!
+
+             or in original words of quirksmode.org ... this is a mess!
+
+             Btw. thank you Microsoft for providing all necessary tools for free
+             for being able to debug this entire mess in the ie rendering engine out
+             (which is the Microsoft ie vms, developers toolbar, Visual Web Developer 2008 express
+             and the ie8 8 developers toolset!)
+
+             also thank you http://www.quirksmode.org/
+             dojotoolkit.org and   //http://delete.me.uk/2004/09/ieproto.html
+             for additional information on this mess!
+
+             The lowest common denominator tested within this code
+             is IE6, older browsers for now are legacy!
+             */
+            attr = attr.toLowerCase();
+
+            if (attr === "class") {
+                //setAttribute does not work for winmobile browsers
+                //firect calls work
+                node.className = val;
+            } else if (attr === "name") {
+                //the ie debugger fails to assign the name via setAttr
+                //in quirks mode
+                node[attr] = val;
+            } else if (attr === "for") {
+                if (!_Browser.isIEMobile || _Browser.isIEMobile >= 7) {
+                    node.setAttribute("htmlFor", val);
+                } else {
+                    node.htmlFor = val;
+                }
+            } else if (attr === "style") {
+                node.style.cssText = val;
+            } else {
+                //check if the attribute is an event, since this applies only
+                //to quirks mode of ie anyway we can live with the standard html4/xhtml
+                //ie supported events
+                if (this.IE_QUIRKS_EVENTS[attr]) {
+                    if (this._Lang.isString(attr)) {
+                        var c = document.body.appendChild(document.createElement('span'));
+                        try {
+                            c.innerHTML = '<span ' + attr + '="' + val + '"/>';
+                            node[attr] = c.firstChild[attr];
+                        } finally {
+                            document.body.removeChild(c);
+                        }
+                    }
+                } else {
+                    //unknown cases we try to catch them via standard setAttributes
+                    if (!_Browser.isIEMobile || _Browser.isIEMobile >= 7) {
+                        node.setAttribute(attr, val);
+                    } else {
+                        node[attr] = val;
+                    }
+                }
+            }
+        },
+
+        getDummyPlaceHolder:function () {
+            this._callSuper("getDummyPlaceHolder");
+
+            //ieMobile in its 6.1-- incarnation cannot handle innerHTML detached objects so we have
+            //to attach the dummy placeholder, we try to avoid it for
+            //better browsers so that we do not have unecessary dom operations
+            if (this._RT.browser.isIEMobile && created) {
+                this.insertFirst(this._dummyPlaceHolder);
+
+                this.setAttribute(this._dummyPlaceHolder, "style", "display: none");
+
+            }
+
+            return this._dummyPlaceHolder;
+        },
+
+        /**
+         * classical recursive way which definitely will work on all browsers
+         * including the IE6
+         *
+         * @param rootNode the root node
+         * @param filter the filter to be applied to
+         * @param deepScan if set to true a deep scan is performed
+         */
+        _recursionSearchAll:function (rootNode, filter, deepScan) {
+            var ret = [];
+            //fix the value to prevent undefined errors
+
+            if (filter(rootNode)) {
+                ret.push(rootNode);
+                if (!deepScan) return ret;
+            }
+
+            //
+            if (!rootNode.childNodes) {
+                return ret;
+            }
+
+            //subfragment usecases
+
+            var retLen = ret.length;
+            var childLen = rootNode.childNodes.length;
+            for (var cnt = 0; (deepScan || retLen == 0) && cnt < childLen; cnt++) {
+                ret = ret.concat(this._recursionSearchAll(rootNode.childNodes[cnt], filter, deepScan));
+            }
+            return ret;
+        },
+
+        /**
+         * break the standard events from an existing dom node
+         * (note this method is not yet used, but can be used
+         * by framework authors to get rid of ie circular event references)
+         *
+         * another way probably would be to check all attributes of a node
+         * for a function and if one is present break it by nulling it
+         * I have to do some further investigation on this.
+         *
+         * The final fix is to move away from ie6 at all which is the root cause of
+         * this.
+         *
+         * @param node the node which has to be broken off its events
+         */
+        breakEvents:function (node) {
+            if (!node) return;
+            var evtArr = this.IE_QUIRKS_EVENTS;
+            for (var key in evtArr) {
+                if (!evtArr.hasOwnProperty(key)) continue;
+                if (key != "onunload" && node[key]) {
+                    node[key] = null;
+                }
+            }
+        },
+
+        isManualScriptEval:function () {
+
+            if (!this._Lang.exists(myfaces, "config._autoeval")) {
+
+                //now we rely on the document being processed if called for the first time
+                var evalDiv = document.createElement("div");
+                this._Lang.reserveNamespace("myfaces.config._autoeval");
+                //null not swallowed
+                myfaces.config._autoeval = false;
+
+                var markup = "<script type='text/javascript'> myfaces.config._autoeval = true; </script>";
+                //now we rely on the same replacement mechanisms as outerhtml because
+                //some browsers have different behavior of embedded scripts in the contextualfragment
+                //or innerhtml case (opera for instance), this way we make sure the
+                //eval detection is covered correctly
+                this.setAttribute(evalDiv, "style", "display:none");
+
+                //it is less critical in some browsers (old ie versions)
+                //to append as first element than as last
+                //it should not make any difference layoutwise since we are on display none anyway.
+                this.insertFirst(evalDiv);
+
+                //we remap it into a real boolean value
+                if (this.isDomCompliant()) {
+                    this._outerHTMLCompliant(evalDiv, markup);
+                } else {
+                    //will not be called placeholder for quirks class
+                    this._outerHTMLNonCompliant(evalDiv, markup);
+                }
+
+
+            }
+
+            return  !myfaces.config._autoeval;
+        },
+
+        getNamedElementFromForm:function (form, elementName) {
+			var browser = this._RT.browser;
+            if(browser.isIE && browser.isIE < 8) {
+                if(!form.elements) return null;
+                for(var cnt = 0, l = form.elements.length; cnt < l; cnt ++) {
+                    var element = form.elements[cnt];
+                    if(element.name == elementName) {
+                        return element;
+                    }
+                }
+                return null;
+            } else {
+                return form[elementName];
+            }
+        },
+
+        detectAttributes: function(element) {
+            //test if 'hasAttribute' method is present and its native code is intact
+            //for example, Prototype can add its own implementation if missing
+            //JSF 2.4 we now can reduce the complexity here, one of the functions now
+            //is definitely implemented
+            if (element.hasAttribute && this.isFunctionNative(element.hasAttribute)) {
+                return function(name) {
+                    return element.hasAttribute(name);
+                }
+            } else {
+                try {
+                    //when accessing .getAttribute method without arguments does not throw an error then the method is not available
+                    element.getAttribute;
+
+                    var html = element.outerHTML;
+                    var startTag = html.match(/^<[^>]*>/)[0];
+                    return function(name) {
+                        return startTag.indexOf(name + '=') > -1;
+                    }
+                } catch (ex) {
+                    return function(name) {
+                        return element.getAttribute(name);
+                    }
+                }
+            }
+        },
+        html5FormDetection: function(/*item*/) {
+            return null;
+        }
+
+    });
+
+}

--- a/api/src/main/javascript/META-INF/resources/myfaces/_impl/quirks/_LangQuirks.js
+++ b/api/src/main/javascript/META-INF/resources/myfaces/_impl/quirks/_LangQuirks.js
@@ -1,0 +1,234 @@
+/* Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+/*
+ theoretically we could save some code
+ by
+ defining the parent object as
+ var parent = new Object();
+ parent.prototype = new myfaces._impl.core._Runtime();
+ extendClass(function () {
+ }, parent , {
+ But for now we are not doing it the little bit of saved
+ space is not worth the loss of readability
+ */
+
+//html5 ecmascript 3 compliant browser, no quirks mode needed
+if(!Array.prototype.forEach  && _MF_SINGLTN) {
+/**
+ * @memberOf myfaces._impl
+ * @namespace
+ * @name _util
+ */
+
+/**
+ * @class
+ * @name _Lang
+ * @memberOf myfaces._impl._util
+ * @extends myfaces._impl.core._Runtime
+ * @namespace
+ * @description Object singleton for Language related methods, this object singleton
+ * decorates the namespace myfaces._impl.core._Runtime and adds a bunch of new methods to
+ * what _Runtime provided
+ * <p>This class provides the proper fallbacks for ie8- and Firefox 3.6-</p>
+ * */
+_MF_SINGLTN(_PFX_UTIL+"_LangQuirks", myfaces._impl._util._Lang, {
+
+    constructor_: function() {
+        this._callSuper("constructor_");
+        var _RT = this._RT;
+        var _T = this;
+        //we only apply lazy if the jsf part is loaded already
+        //otherwise we are at the correct position
+        if(myfaces._impl.core.Impl) {
+            _RT.iterateClasses(function(proto) {
+                if(proto._Lang) proto._Lang = _T;
+            });
+        }
+
+        myfaces._impl._util._Lang = _T;
+    },
+
+    /**
+     * foreach implementation utilizing the
+     * ECMAScript wherever possible
+     * with added functionality
+     *
+     * @param arr the array to filter
+     * @param func the closure to apply the function to, with the syntax defined by the ecmascript functionality
+     * function (element<,key, array>)
+     * <p />
+     * optional params
+     * <p />
+     * <ul>
+     *      <li>param startPos (optional) the starting position </li>
+     *      <li>param scope (optional) the scope to apply the closure to  </li>
+     * </ul>
+     */
+    arrForEach: function(arr, func /*startPos, scope*/) {
+        if (!arr || !arr.length) return;
+        try {
+            var startPos = Number(arguments[2]) || 0;
+            var thisObj = arguments[3];
+
+            //check for an existing foreach mapping on array prototypes
+            //IE9 still does not pass array objects as result for dom ops
+            if (Array.prototype.forEach && arr.forEach) {
+                (startPos) ? arr.slice(startPos).forEach(func, thisObj) : arr.forEach(func, thisObj);
+            } else {
+                startPos = (startPos < 0) ? Math.ceil(startPos) : Math.floor(startPos);
+                if (typeof func != "function") {
+                    throw new TypeError();
+                }
+                for (var cnt = 0; cnt < arr.length; cnt++) {
+                    if (thisObj) {
+                        func.call(thisObj, arr[cnt], cnt, arr);
+                    } else {
+                        func(arr[cnt], cnt, arr);
+                    }
+                }
+            }
+        } finally {
+            func = null;
+        }
+    },
+
+    /**
+     * foreach implementation utilizing the
+     * ECMAScript wherever possible
+     * with added functionality
+     *
+     * @param arr the array to filter
+     * @param func the closure to apply the function to, with the syntax defined by the ecmascript functionality
+     * function (element<,key, array>)
+     * <p />
+     * additional params
+     * <ul>
+     *  <li> startPos (optional) the starting position</li>
+     *  <li> scope (optional) the scope to apply the closure to</li>
+     * </ul>
+     */
+    arrFilter: function(arr, func /*startPos, scope*/) {
+        if (!arr || !arr.length) return [];
+        try {
+            var startPos = Number(arguments[2]) || 0;
+            var thisObj = arguments[3];
+
+            //check for an existing foreach mapping on array prototypes
+            if (Array.prototype.filter) {
+                return ((startPos) ? arr.slice(startPos).filter(func, thisObj) : arr.filter(func, thisObj));
+            } else {
+                if (typeof func != "function") {
+                    throw new TypeError();
+                }
+                var ret = [];
+                startPos = (startPos < 0) ? Math.ceil(startPos) : Math.floor(startPos);
+
+                for (var cnt = startPos; cnt < arr.length; cnt++) {
+                    var elem = null;
+                    if (thisObj) {
+                        elem = arr[cnt];
+                        if (func.call(thisObj, elem, cnt, arr)) ret.push(elem);
+                    } else {
+                        elem = arr[cnt];
+                        if (func(arr[cnt], cnt, arr)) ret.push(elem);
+                    }
+                }
+            }
+        } finally {
+            func = null;
+        }
+    },
+
+    /**
+     * adds a EcmaScript optimized indexOf to our mix,
+     * checks for the presence of an indexOf functionality
+     * and applies it, otherwise uses a fallback to the hold
+     * loop method to determine the index
+     *
+     * @param arr the array
+     * @param element the index to search for
+     */
+    arrIndexOf: function(arr, element /*fromIndex*/) {
+        if (!arr || !arr.length) return -1;
+        var pos = Number(arguments[2]) || 0;
+
+        if (Array.prototype.indexOf) {
+            return arr.indexOf(element, pos);
+        }
+        //var cnt = this._space;
+        var len = arr.length;
+        pos = (pos < 0) ? Math.ceil(pos) : Math.floor(pos);
+
+        //if negative then it is taken from as offset from the length of the array
+        if (pos < 0) {
+            pos += len;
+        }
+        while (pos < len && arr[pos] !== element) {
+            pos++;
+        }
+        return (pos < len) ? pos : -1;
+    },
+
+    parseXML: function(txt) {
+        try {
+            var xmlDoc = null;
+            if (window.DOMParser) {
+                xmlDoc = this._callSuper("parseXML", txt);
+            }
+            else // Internet Explorer
+            {
+                xmlDoc = new ActiveXObject("Microsoft.XMLDOM");
+                xmlDoc.async = "false";
+                xmlDoc.loadXML(txt);
+            }
+            return xmlDoc;
+        } catch (e) {
+            //undefined internal parser error
+            return null;
+        }
+    },
+
+    serializeXML: function(xmlNode, escape) {
+        if (xmlNode.xml) return xmlNode.xml; //IE
+        return this._callSuper("serializeXML", xmlNode, escape);
+    },
+
+     /**
+     * Concatenates an array to a string
+     * @param {Array} arr the array to be concatenated
+     * @param {String} delimiter the concatenation delimiter if none is set \n is used
+     *
+     * @return the concatenated array, one special behavior to enable j4fry compatibility has been added
+     * if no delimiter is used the [entryNumber]+entry is generated for a single entry
+     * TODO check if this is still needed it is somewhat outside of the scope of the function
+     * and functionality wise dirty
+     */
+    arrToString : function(/*String or array*/ arr, /*string*/ delimiter) {
+        if (!arr) {
+            throw this._Lang.makeException(new Error(), null, null, this._nameSpace,"arrToString",  this.getMessage("ERR_MUST_BE_PROVIDED1",null, "arr {array}"));
+        }
+        if (this.isString(arr)) {
+            return arr;
+        }
+
+        delimiter = delimiter || "\n";
+        return arr.join(delimiter);
+    }
+});
+
+}

--- a/api/src/main/javascript/META-INF/resources/myfaces/_impl/quirks/_RuntimeQuirks.js
+++ b/api/src/main/javascript/META-INF/resources/myfaces/_impl/quirks/_RuntimeQuirks.js
@@ -1,0 +1,51 @@
+/* Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+if (!document.querySelectorAll || !window.XMLHttpRequest) {
+
+    //initial browser detection, we encapsule it in a closure
+    //to drop all temporary variables from ram as soon as possible
+    //we run into the quirks fallback if XMLHttpRequest is not enabled
+    (function() {
+        var _T  = myfaces._impl.core._Runtime;
+
+        _T.getXHRObject = function() {
+            //since this is a global object ie hates it if we do not check for undefined
+            if (window.XMLHttpRequest) {
+                var _ret = new XMLHttpRequest();
+                //we now check the xhr level
+                //sendAsBinary = 1.5 which means mozilla only
+                //upload attribute present == level2
+
+                if (!_T.XHR_LEVEL) {
+                    var _e = _T.exists;
+                    _T.XHR_LEVEL = (_e(_ret, "sendAsBinary")) ? 1.5 : 1;
+                    _T.XHR_LEVEL = (_e(_ret, "upload") && 'undefined' != typeof FormData) ? 2 : _T.XHR_LEVEL;
+                }
+                return _ret;
+            }
+            //IE
+            try {
+                _T.XHR_LEVEL = 1;
+                return new ActiveXObject("Msxml2.XMLHTTP");
+            } catch (e) {
+
+            }
+            return new ActiveXObject('Microsoft.XMLHTTP');
+        };
+
+
+    })();
+}

--- a/api/src/main/javascript/META-INF/resources/myfaces/_impl/quirks/_TransportQuirks.js
+++ b/api/src/main/javascript/META-INF/resources/myfaces/_impl/quirks/_TransportQuirks.js
@@ -1,0 +1,36 @@
+/* Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+_MF_SINGLTN(_PFX_XHR + "_TransportsQuirks", myfaces._impl.xhrCore._Transports,
+    /** @lends myfaces._impl.xhrCore._Transports.prototype */ {
+        constructor_: function () {
+            this._callSuper("constructor_");
+            myfaces._impl.xhrCore._Transports = this;
+        },
+        /**
+         * centralized transport switching helper
+         * for the multipart submit case
+         *
+         * @param context the context which is passed down
+         */
+        _getMultipartReqClass: function (context) {
+            if (this._RT.getXHRLvl() >= 2) {
+                return myfaces._impl.xhrCore._FormDataRequest;
+            } else {
+                return myfaces._impl.xhrCore._IFrameRequest;
+            }
+        }
+    });

--- a/api/src/main/javascript/META-INF/resources/myfaces/_impl/quirks/readme.txt
+++ b/api/src/main/javascript/META-INF/resources/myfaces/_impl/quirks/readme.txt
@@ -1,0 +1,4 @@
+Quirks overrides for legacy browsers (mostly internet explorer)
+
+if you do not have to support any of those browsers
+you can drop the entire package from the build

--- a/api/src/main/javascript/META-INF/resources/myfaces/_impl/xhrCore/_AjaxRequest.js
+++ b/api/src/main/javascript/META-INF/resources/myfaces/_impl/xhrCore/_AjaxRequest.js
@@ -31,18 +31,18 @@
  */
 _MF_CLS(_PFX_XHR + "_AjaxRequest", _MF_OBJECT, /** @lends myfaces._impl.xhrCore._AjaxRequest.prototype */ {
 
-    _contentType:"application/x-www-form-urlencoded",
+    _contentType: "application/x-www-form-urlencoded",
     /** source element issuing the request */
-    _source:null,
+    _source: null,
     /** context passed down from the caller */
     _context:null,
     /** source form issuing the request */
-    _sourceForm:null,
+    _sourceForm: null,
     /** passthrough parameters */
-    _passThrough:null,
+    _passThrough: null,
 
     /** queue control */
-    _timeout:null,
+    _timeout: null,
     /** enqueuing delay */
     //_delay:null,
     /** queue size */
@@ -52,13 +52,13 @@ _MF_CLS(_PFX_XHR + "_AjaxRequest", _MF_OBJECT, /** @lends myfaces._impl.xhrCore.
      back reference to the xhr queue,
      only set if the object really is queued
      */
-    _xhrQueue:null,
+    _xhrQueue: null,
 
     /** pps an array of identifiers which should be part of the submit, the form is ignored */
-    _partialIdsArray:null,
+    _partialIdsArray : null,
 
     /** xhr object, internal param */
-    _xhr:null,
+    _xhr: null,
 
     /** predefined method */
     _ajaxType:"POST",
@@ -70,8 +70,8 @@ _MF_CLS(_PFX_XHR + "_AjaxRequest", _MF_OBJECT, /** @lends myfaces._impl.xhrCore.
      */
     _CONTENT_TYPE:"Content-Type",
     _HEAD_FACES_REQ:"Faces-Request",
-    _VAL_AJAX:"partial/ajax",
-    _XHR_CONST:myfaces._impl.xhrCore.engine.XhrConst,
+    _VAL_AJAX: "partial/ajax",
+    _XHR_CONST: myfaces._impl.xhrCore.engine.XhrConst,
 
     // _exception: null,
     // _requestParameters: null,
@@ -85,7 +85,7 @@ _MF_CLS(_PFX_XHR + "_AjaxRequest", _MF_OBJECT, /** @lends myfaces._impl.xhrCore.
      * @param {Object} args an arguments map which an override any of the given protected
      * instance variables, by a simple name value pair combination
      */
-    constructor_:function (args) {
+    constructor_: function(args) {
 
         try {
             this._callSuper("constructor_", args);
@@ -111,44 +111,40 @@ _MF_CLS(_PFX_XHR + "_AjaxRequest", _MF_OBJECT, /** @lends myfaces._impl.xhrCore.
     /**
      * Sends an Ajax request
      */
-    send:function () {
+    send : function() {
 
         var _Lang = this._Lang;
         var _RT = this._RT;
-        var _Dom = this._Dom;
+
         try {
 
-            var scopeThis = _Lang.hitch(this, function (functionName) {
+            var scopeThis = _Lang.hitch(this, function(functionName) {
                 return _Lang.hitch(this, this[functionName]);
             });
             this._xhr = _Lang.mixMaps(this._getTransport(), {
-                onprogress:scopeThis("onprogress"),
-                ontimeout:scopeThis("ontimeout"),
-                //remove for xhr level2 support (chrome has problems with it)
-                //for chrome we have to emulate the onloadend by calling it explicitely
-                //and leave the onload out
-                //onloadend:  scopeThis("ondone"),
-                onload:scopeThis("onsuccess"),
-                onerror:scopeThis("onerror")
+                onprogress: scopeThis("onprogress"),
+                ontimeout:  scopeThis("ontimeout"),
+				//remove for xhr level2 support (chrome has problems with it)
+                onloadend:  scopeThis("ondone"),
+                onload:     scopeThis("onsuccess"),
+                onerror:    scopeThis("onerror")
 
             }, true);
-
-            this._applyClientWindowId();
             var xhr = this._xhr,
-                    sourceForm = this._sourceForm,
-                    targetURL = (typeof sourceForm.elements[this.ENCODED_URL] == 'undefined') ?
-                            sourceForm.action :
-                            sourceForm.elements[this.ENCODED_URL].value,
-                    formData = this.getFormData();
+                sourceForm = this._sourceForm,
+                targetURL = (typeof sourceForm.elements[this.ENCODED_URL] == 'undefined') ?
+                    sourceForm.action :
+                    sourceForm.elements[this.ENCODED_URL].value,
+                formData = this.getFormData();
 
             for (var key in this._passThrough) {
-                if (!this._passThrough.hasOwnProperty(key)) continue;
+                if(!this._passThrough.hasOwnProperty(key)) continue;
                 formData.append(key, this._passThrough[key]);
             }
 
             xhr.open(this._ajaxType, targetURL +
-                    ((this._ajaxType == "GET") ? "?" + this._formDataToURI(formData) : "")
-                    , true);
+                ((this._ajaxType == "GET") ? "?" + this._formDataToURI(formData) : "")
+                , true);
 
             xhr.timeout = this._timeout || 0;
 
@@ -157,8 +153,8 @@ _MF_CLS(_PFX_XHR + "_AjaxRequest", _MF_OBJECT, /** @lends myfaces._impl.xhrCore.
 
             //some webkit based mobile browsers do not follow the w3c spec of
             // setting the accept headers automatically
-            if (this._RT.browser.isWebKit) {
-                xhr.setRequestHeader("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8");
+            if(this._RT.browser.isWebKit) {
+                xhr.setRequestHeader("Accept","text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8");
             }
             this._sendEvent("BEGIN");
             //Check if it is a custom form data object
@@ -170,60 +166,28 @@ _MF_CLS(_PFX_XHR + "_AjaxRequest", _MF_OBJECT, /** @lends myfaces._impl.xhrCore.
 
         } catch (e) {
             //_onError//_onError
-            e = (e._mfInternal) ? e : this._Lang.makeException(new Error(), "sendError", "sendError", this._nameSpace, "send", e.message);
+            e = (e._mfInternal)? e: this._Lang.makeException(new Error(), "sendError","sendError", this._nameSpace, "send", e.message);
             this._stdErrorHandler(this._xhr, this._context, e);
-        } finally {
-            //no finally possible since the iframe uses real asynchronousity
-        }
-    },
-
-    _applyClientWindowId:function () {
-        var clientWindow = this._Dom.getNamedElementFromForm(this._sourceForm, "jakarta.faces.ClientWindow");
-        //pass through if exists already set by _Impl
-        if ('undefined' != typeof this._context._mfInternal._clientWindow) {
-            this._context._mfInternal._clientWindowOld = clientWindow.value;
-            clientWindow.value = this._context._mfInternal._clientWindow;
-        } else {
-            if(clientWindow) {
-                this._context._mfInternal._clientWindowDisabled = !! clientWindow.disabled;
-                clientWindow.disabled = true;
-            }
-        }
-    },
-
-    _restoreClientWindowId:function () {
-        //we have to reset the client window back to its original state
-
-        var clientWindow = this._Dom.getNamedElementFromForm(this._sourceForm, "jakarta.faces.ClientWindow");
-        if(!clientWindow) {
-            return;
-        }
-        if ('undefined' != typeof this._context._mfInternal._clientWindowOld) {
-            clientWindow.value =  this._context._mfInternal._clientWindow;
-        }
-        if('undefined' != typeof this._context._mfInternal._clientWindowDisabled) {
-            //we reset it to the old value
-            clientWindow.disabled = this._context._mfInternal._clientWindowDisabled;
         }
     },
 
     /**
-     * applies the content type, this needs to be done only for xhr
-     * level1
-     * @param xhr
-     * @private
+     * helper, in multipart situations we might alter the content type
+     * from the urlencoded one
      */
-    _applyContentType:function (xhr) {
-        var contentType = this._contentType + "; charset=utf-8";
+    _applyContentType: function(xhr) {
+        var contentType = this._contentType+"; charset=utf-8";
+
         xhr.setRequestHeader(this._CONTENT_TYPE, contentType);
     },
 
-    ondone:function () {
+    ondone: function() {
         this._requestDone();
     },
 
-    onsuccess:function (/*evt*/) {
-        this._restoreClientWindowId();
+
+    onsuccess: function(/*evt*/) {
+
         var context = this._context;
         var xhr = this._xhr;
         try {
@@ -234,18 +198,19 @@ _MF_CLS(_PFX_XHR + "_AjaxRequest", _MF_OBJECT, /** @lends myfaces._impl.xhrCore.
             context._mfInternal = context._mfInternal || {};
             jsf.ajax.response((xhr.getXHRObject) ? xhr.getXHRObject() : xhr, context);
 
+
+
         } catch (e) {
             this._stdErrorHandler(this._xhr, this._context, e);
-
-            //add for xhr level2 support
-        } finally {
-            //W3C spec onloadend must be called no matter if success or not
-            this.ondone();
         }
+        //add for xhr level2 support
+        //}  finally {
+        //W3C spec onloadend must be called no matter if success or not
+        //    this.ondone();
+        //}
     },
 
-    onerror:function (/*evt*/) {
-        this._restoreClientWindowId();
+    onerror: function(/*evt*/) {
         //TODO improve the error code detection here regarding server errors etc...
         //and push it into our general error handling subframework
         var context = this._context;
@@ -257,35 +222,31 @@ _MF_CLS(_PFX_XHR + "_AjaxRequest", _MF_OBJECT, /** @lends myfaces._impl.xhrCore.
         try {
             var UNKNOWN = _Lang.getMessage("UNKNOWN");
             //status can be 0 and statusText can be ""
-            var status = ('undefined' != xhr.status && null != xhr.status) ? xhr.status : UNKNOWN;
-            var statusText = ('undefined' != xhr.statusText && null != xhr.statusText) ? xhr.statusText : UNKNOWN;
-            errorText = _Lang.getMessage("ERR_REQU_FAILED", null, status, statusText);
+            var status = ('undefined' != xhr.status  && null != xhr.status)? xhr.status : UNKNOWN;
+            var statusText = ('undefined' != xhr.statusText  && null != xhr.statusText)? xhr.statusText : UNKNOWN;
+            errorText = _Lang.getMessage("ERR_REQU_FAILED", null,status,statusText);
 
         } catch (e) {
             errorText = _Lang.getMessage("ERR_REQ_FAILED_UNKNOWN", null);
         } finally {
-            try {
-                var _Impl = this.attr("impl");
+            var _Impl = this.attr("impl");
                 _Impl.sendError(xhr, context, _Impl.HTTPERROR,
-                        _Impl.HTTPERROR, errorText, "", "myfaces._impl.xhrCore._AjaxRequest", "onerror");
-            } finally {
-                //add for xhr level2 support
-                //since chrome does not call properly the onloadend we have to do it manually
-                //to eliminate xhr level1 for the compile profile modern
-                //W3C spec onloadend must be called no matter if success or not
-                this.ondone();
-            }
+                _Impl.HTTPERROR, errorText,"","myfaces._impl.xhrCore._AjaxRequest","onerror");
+            //add for xhr level2 support
+            //since chrome does not call properly the onloadend we have to do it manually
+            //to eliminate xhr level1 for the compile profile modern
+            //W3C spec onloadend must be called no matter if success or not
+            //this.ondone();
         }
         //_onError
     },
 
-    onprogress:function (/*evt*/) {
+    onprogress: function(/*evt*/) {
         //do nothing for now
     },
 
-    ontimeout:function (/*evt*/) {
+    ontimeout: function(/*evt*/) {
         try {
-            this._restoreClientWindowId();
             //we issue an event not an error here before killing the xhr process
             this._sendEvent("TIMEOUT_EVENT");
             //timeout done we process the next in the queue
@@ -294,44 +255,58 @@ _MF_CLS(_PFX_XHR + "_AjaxRequest", _MF_OBJECT, /** @lends myfaces._impl.xhrCore.
         }
     },
 
-    _formDataToURI:function (formData) {
+    _formDataToURI: function(formData) {
         if (formData && formData.makeFinal) {
             formData = formData.makeFinal()
         }
         return formData;
     },
 
-    _getTransport:function () {
-
-        var xhr = this._RT.getXHRObject();
-        //the current xhr level2 timeout w3c spec is not implemented by the browsers yet
-        //we have to do a fallback to our custom routines
-
-        //add for xhr level2 support
-        //Chrome fails in the current builds, on our loadend, we disable the xhr
-        //level2 optimisations for now
-        if (/*('undefined' == typeof this._timeout || null == this._timeout) &&*/ this._RT.getXHRLvl() >= 2) {
-            //no timeout we can skip the emulation layer
-            return xhr;
-        }
-        return new myfaces._impl.xhrCore.engine.Xhr1({xhrObject:xhr});
+    /**
+     * change for jsf 2.3 since we drop legacy browser support
+     * there is no need anymore to support xhr level 1.
+     * @returns {XMLHttpRequest} the transport object
+     * @private
+     */
+    _getTransport: function() {
+        return new XMLHttpRequest();
     },
+
 
     //----------------- backported from the base request --------------------------------
     //non abstract ones
+
+
     /**
      * Spec. 13.3.1
      * Collect and encode input elements.
-     * Additionally the hidden element jakarta.faces.ViewState
-     *
+     * Additionally the hidden element jakarta/javax.faces.ViewState
+     * Enhancement partial page submit
      *
      * @return  an element of formDataWrapper
      * which keeps the final Send Representation of the
      */
-    getFormData:function () {
-        var _AJAXUTIL = this._AJAXUTIL, myfacesOptions = this._context.myfaces;
-        return this._Lang.createFormDataDecorator(jsf.getViewState(this._sourceForm));
+    getFormData : function() {
+        var _AJAXUTIL = this._AJAXUTIL, myfacesOptions = this._context.myfaces, ret = null;
+
+
+
+        if (!this._partialIdsArray || !this._partialIdsArray.length) {
+            var _AJAXUTIL = this._AJAXUTIL, myfacesOptions = this._context.myfaces;
+            return this._Lang.createFormDataDecorator(jsf.getViewState(this._sourceForm));
+        } else {
+            //now this is less performant but we have to call it to allow viewstate decoration
+            ret = this._Lang.createFormDataDecorator(new Array());
+            _AJAXUTIL.encodeSubmittableFields(ret, this._sourceForm, this._partialIdsArray);
+            if (this._source && myfacesOptions && myfacesOptions.form)
+                _AJAXUTIL.appendIssuingItem(this._source, ret);
+
+        }
+        return ret;
+
     },
+
+
 
     /**
      * Client error handlers which also in the long run route into our error queue
@@ -343,7 +318,7 @@ _MF_CLS(_PFX_XHR + "_AjaxRequest", _MF_OBJECT, /** @lends myfaces._impl.xhrCore.
      * @param context the context holding all values for further processing
      * @param exception the embedded exception
      */
-    _stdErrorHandler:function (request, context, exception) {
+    _stdErrorHandler: function(request, context, exception) {
         var xhrQueue = this._xhrQueue;
         try {
             this.attr("impl").stdErrorHandler(request, context, exception);
@@ -354,26 +329,19 @@ _MF_CLS(_PFX_XHR + "_AjaxRequest", _MF_OBJECT, /** @lends myfaces._impl.xhrCore.
         }
     },
 
-    _sendEvent:function (evtType) {
+    _sendEvent: function(evtType) {
         var _Impl = this.attr("impl");
         _Impl.sendEvent(this._xhr, this._context, _Impl[evtType]);
     },
 
-    _requestDone:function () {
+    _requestDone: function() {
         var queue = this._xhrQueue;
         if (queue) {
             queue.processQueue();
         }
         //ie6 helper cleanup
         delete this._context.source;
-        this._finalize();
-    },
 
-    //cleanup
-    _finalize:function () {
-        if (this._xhr.readyState == this._XHR_CONST.READY_STATE_DONE) {
-            this._callSuper("_finalize");
-        }
     }
 });
 

--- a/api/src/main/javascript/META-INF/resources/myfaces/_impl/xhrCore/_Transports.js
+++ b/api/src/main/javascript/META-INF/resources/myfaces/_impl/xhrCore/_Transports.js
@@ -40,150 +40,257 @@
  * corresponding protected attributes on class level in the transports themselves)
  */
 _MF_SINGLTN(_PFX_XHR + "_Transports", _MF_OBJECT,
-        /** @lends myfaces._impl.xhrCore._Transports.prototype */ {
+    /** @lends myfaces._impl.xhrCore._Transports.prototype */ {
 
-    _PAR_ERRORLEVEL:"errorlevel",
-    _PAR_QUEUESIZE:"queuesize",
-    _PAR_PPS:"pps",
-    _PAR_TIMEOUT:"timeout",
-    _PAR_DELAY:"delay",
+        _PAR_ERRORLEVEL: "errorlevel",
+        _PAR_QUEUESIZE: "queuesize",
+        _PAR_PPS: "pps",
+        _PAR_TIMEOUT: "timeout",
+        _PAR_DELAY: "delay",
 
 
-    /**
-     * a singleton queue
-     * note the structure of our inheritance
-     * is that that _queue is attached to prototype
-     * and hence the pointer to the request qeue
-     * is shared over all instances
-     *
-     * if you need to have it per instance for complex objects
-     * you have to initialize in the constructor
-     *
-     * (This is the same limitation dojo class inheritance
-     * where our inheritance pattern is derived from has)
-     */
-    _q: new myfaces._impl.xhrCore._AjaxRequestQueue(),
+        /**
+         * a singleton queue
+         * note the structure of our inheritance
+         * is that that _queue is attached to prototype
+         * and hence the pointer to the request qeue
+         * is shared over all instances
+         *
+         * if you need to have it per instance for complex objects
+         * you have to initialize in the constructor
+         *
+         * (This is the same limitation dojo class inheritance
+         * where our inheritance pattern is derived from has)
+         */
+        _q: new myfaces._impl.xhrCore._AjaxRequestQueue(),
 
-    /**
-     * xhr post with enqueuing as defined by the jsf 2.0 specification
-     *
-     * mapped options already have the exec and view properly in place
-     * myfaces specifics can be found under mappedOptions.myFaces
-     * @param {Node} source the source of this call
-     * @param {Node} sourceForm the html form which is the source of this call
-     * @param {Object} context (Map) the internal pass through context
-     * @param {Object} passThrgh (Map) values to be passed through
-     **/
-    xhrQueuedPost : function(source, sourceForm, context, passThrgh) {
-        context._mfInternal.xhrOp = "xhrQueuedPost";
-        this._q.enqueue(
+        /**
+         * xhr post with enqueuing as defined by the jsf 2.0 specification
+         *
+         * mapped options already have the exec and view properly in place
+         * myfaces specifics can be found under mappedOptions.myFaces
+         * @param {Node} source the source of this call
+         * @param {Node} sourceForm the html form which is the source of this call
+         * @param {Object} context (Map) the internal pass through context
+         * @param {Object} passThrgh (Map) values to be passed through
+         **/
+        xhrQueuedPost: function (source, sourceForm, context, passThrgh) {
+            this._q.enqueue(
                 new (this._getAjaxReqClass(context))(this._getArguments(source, sourceForm, context, passThrgh)));
-    },
-
-    /**
-      * iframe queued post
-      *
-      * mapped options already have the exec and view properly in place
-      * myfaces specifics can be found under mappedOptions.myFaces
-      * @param {Node} source the source of this call
-      * @param {Node} sourceForm the html form which is the source of this call
-      * @param {Object} context (Map) the internal pass through context
-      * @param {Object} passThrgh (Map) values to be passed through
-      **/
-     multipartQueuedPost : function(source, sourceForm, context, passThrgh) {
-         context._mfInternal.xhrOp = "multipartQueuedPost";
-         var args = this._getArguments(source, sourceForm, context, passThrgh);
-         // note in get the timeout is not working delay however is and queue size as well
-         // since there are no cross browser ways to resolve a timeout on xhr level
-         this._q.enqueue(
-                 new (this._getMultipartReqClass(context))(args));
-     },
+        },
 
 
-    /**
-     * creates the arguments map and
-     * fetches the config params in a proper way in to
-     * deal with them in a flat way (from the nested context way)
-     *
-     * @param source the source of the request
-     * @param sourceForm the sourceform
-     * @param context   the context holding all values
-     * @param passThrgh the passThrough values to be blended into the response
-     */
-    _getArguments: function(source, sourceForm, context, passThrgh) {
-        var _RT = myfaces._impl.core._Runtime,
-        /** @ignore */
-             _Lang = myfaces._impl._util._Lang,
-             applyCfg = _Lang.hitch(this, this._applyConfig),
-            //RT does not have this references, hence no hitch needed
-             getCfg = _RT.getLocalOrGlobalConfig,
+        /**
+         * a simple not enqueued xhr post
+         *
+         * mapped options already have the exec and view properly in place
+         * myfaces specifics can be found under mappedOptions.myFaces
+         * @param {Node} source the source of this call
+         * @param {Node} sourceForm the html form which is the source of this call
+         * @param {Object} context (Map) the internal pass through context
+         * @param {Object} passThrgh (Map) values to be passed through
+         **/
+        xhrPost: function (source, sourceForm, context, passThrgh) {
+            var args = this._getArguments(source, sourceForm, context, passThrgh);
+            delete args.xhrQueue;
+            (new (this._getAjaxReqClass(context))(args)).send();
+        },
 
 
-            ret = {
-                "source": source,
-                "sourceForm": sourceForm,
-                "context": context,
-                "passThrough": passThrgh,
-                "xhrQueue": this._q
-            };
+        /**
+         * xhr get without enqueuing
+         *
+         * mapped options already have the exec and view properly in place
+         * myfaces specifics can be found under mappedOptions.myFaces
+         * @param {Node} source the source of this call
+         * @param {Node} sourceForm the html form which is the source of this call
+         * @param {Object} context (Map) the internal pass through context
+         * @param {Object} passThrgh (Map) values to be passed through
+         **/
+        xhrGet: function (source, sourceForm, context, passThrgh) {
+            var args = this._getArguments(source, sourceForm, context, passThrgh);
+            // note in get the timeout is not working delay however is and queue size as well
+            // since there are no cross browser ways to resolve a timeout on xhr level
+            // we have to live with it
+            args.ajaxType = "GET";
+            delete args.xhrQueue;
+            (new (this._getAjaxReqClass(context))(args)).send();
+        },
 
-        //we now mix in the config settings which might either be set globally
-        //or pushed in under the context myfaces.<contextValue> into the current request
-        applyCfg(ret, context, "alarmThreshold", this._PAR_ERRORLEVEL);
-        applyCfg(ret, context, "queueSize", this._PAR_QUEUESIZE);
-        //TODO timeout probably not needed anymore
-        applyCfg(ret, context, "timeout", this._PAR_TIMEOUT);
-        //applyCfg(ret, context, "delay", this._PAR_DELAY);
+        /**
+         * xhr get which takes the existing queue into consideration to by synchronized
+         * to previous queued post requests
+         *
+         * mapped options already have the exec and view properly in place
+         * myfaces specifics can be found under mappedOptions.myFaces
+         * @param {Node} source the source of this call
+         * @param {Node} sourceForm the html form which is the source of this call
+         * @param {Object} context (Map) the internal pass through context
+         * @param {Object} passThrgh (Map) values to be passed through
+         **/
+        xhrQueuedGet: function (source, sourceForm, context, passThrgh) {
+            var args = this._getArguments(source, sourceForm, context, passThrgh);
+            // note in get the timeout is not working delay however is and queue size as well
+            // since there are no cross browser ways to resolve a timeout on xhr level
+            // we have to live with it
+            args.ajaxType = "GET";
+            this._q.enqueue(
+                new (this._getAjaxReqClass(context))(args));
+        },
 
-        //now partial page submit needs a different treatment
-        //since pps == execute strings
-        if (getCfg(context, this._PAR_PPS, false)
+
+        /**
+         * multipart post without queueing
+         *
+         * mapped options already have the exec and view properly in place
+         * myfaces specifics can be found under mappedOptions.myFaces
+         * @param {Node} source the source of this call
+         * @param {Node} sourceForm the html form which is the source of this call
+         * @param {Object} context (Map) the internal pass through context
+         * @param {Object} passThrgh (Map) values to be passed through
+         **/
+        multipartPost: function (source, sourceForm, context, passThrgh) {
+            var args = this._getArguments(source, sourceForm, context, passThrgh);
+            // note in get the timeout is not working delay however is and queue size as well
+            // since there are no cross browser ways to resolve a timeout on xhr level
+            // we have to live with it
+            delete args.xhrQueue;
+            (new (this._getMultipartReqClass(context))(args)).send();
+        },
+
+        /**
+         * multipart queued post
+         *
+         * mapped options already have the exec and view properly in place
+         * myfaces specifics can be found under mappedOptions.myFaces
+         * @param {Node} source the source of this call
+         * @param {Node} sourceForm the html form which is the source of this call
+         * @param {Object} context (Map) the internal pass through context
+         * @param {Object} passThrgh (Map) values to be passed through
+         **/
+        multipartQueuedPost: function (source, sourceForm, context, passThrgh) {
+            var args = this._getArguments(source, sourceForm, context, passThrgh);
+            // note in get the timeout is not working delay however is and queue size as well
+            // since there are no cross browser ways to resolve a timeout on xhr level
+            this._q.enqueue(
+                new (this._getMultipartReqClass(context))(args));
+        },
+
+        /**
+         * iframe get without queueing
+         *
+         * mapped options already have the exec and view properly in place
+         * myfaces specifics can be found under mappedOptions.myFaces
+         * @param {Node} source the source of this call
+         * @param {Node} sourceForm the html form which is the source of this call
+         * @param {Object} context (Map) the internal pass through context
+         * @param {Object} passThrgh (Map) values to be passed through
+         **/
+        multipartGet: function (source, sourceForm, context, passThrgh) {
+            var args = this._getArguments(source, sourceForm, context, passThrgh);
+            // note in get the timeout is not working delay however is and queue size as well
+            // since there are no cross browser ways to resolve a timeout on xhr level
+            // we have to live with it
+            args.ajaxType = "GET";
+            delete args.xhrQueue;
+            (new (this._getMultipartReqClass(context))(args)).send();
+        },
+
+        /**
+         * multipart queued http get
+         *
+         * mapped options already have the exec and view properly in place
+         * myfaces specifics can be found under mappedOptions.myFaces
+         * @param {Node} source the source of this call
+         * @param {Node} sourceForm the html form which is the source of this call
+         * @param {Object} context (Map) the internal pass through context
+         * @param {Object} passThrgh (Map) values to be passed through
+         **/
+        multipartQueuedGet: function (source, sourceForm, context, passThrgh) {
+            var args = this._getArguments(source, sourceForm, context, passThrgh);
+            // note in get the timeout is not working delay however is and queue size as well
+            // since there are no cross browser ways to resolve a timeout on xhr level
+            args.ajaxType = "GET";
+            this._q.enqueue(
+                new (this._getMultipartReqClass(context))(args));
+        },
+
+
+        /**
+         * creates the arguments map and
+         * fetches the config params in a proper way in to
+         * deal with them in a flat way (from the nested context way)
+         *
+         * @param source the source of the request
+         * @param sourceForm the sourceform
+         * @param context   the context holding all values
+         * @param passThrgh the passThrough values to be blended into the response
+         */
+        _getArguments: function (source, sourceForm, context, passThrgh) {
+            var _RT = myfaces._impl.core._Runtime,
+                /** @ignore */
+                _Lang = myfaces._impl._util._Lang,
+                applyCfg = _Lang.hitch(this, this._applyConfig),
+                //RT does not have this references, hence no hitch needed
+                getCfg = _RT.getLocalOrGlobalConfig,
+
+
+                ret = {
+                    "source": source,
+                    "sourceForm": sourceForm,
+                    "context": context,
+                    "passThrough": passThrgh,
+                    "xhrQueue": this._q
+                };
+
+            //we now mix in the config settings which might either be set globally
+            //or pushed in under the context myfaces.<contextValue> into the current request
+            applyCfg(ret, context, "alarmThreshold", this._PAR_ERRORLEVEL);
+            applyCfg(ret, context, "queueSize", this._PAR_QUEUESIZE);
+            //TODO timeout probably not needed anymore
+            applyCfg(ret, context, "timeout", this._PAR_TIMEOUT);
+            //applyCfg(ret, context, "delay", this._PAR_DELAY);
+
+            //now partial page submit needs a different treatment
+            //since pps == execute strings
+            if (getCfg(context, this._PAR_PPS, false)
                 && _Lang.exists(passThrgh, myfaces._impl.core.Impl.P_EXECUTE)
                 && passThrgh[myfaces._impl.core.Impl.P_EXECUTE].length > 0) {
-            ret['partialIdsArray'] = passThrgh[myfaces._impl.core.Impl.P_EXECUTE].split(" ");
+                ret['partialIdsArray'] = passThrgh[myfaces._impl.core.Impl.P_EXECUTE].split(" ");
+            }
+            return ret;
+        },
+
+        /**
+         * helper method to apply a config setting to our varargs param list
+         *
+         * @param destination the destination map to receive the setting
+         * @param context the current context
+         * @param destParm the destination param of the destination map
+         * @param srcParm the source param which is the key to our config setting
+         */
+        _applyConfig: function (destination, context, destParm, srcParm) {
+            var _RT = myfaces._impl.core._Runtime;
+            /** @ignore */
+            var _getConfig = _RT.getLocalOrGlobalConfig;
+            if (_getConfig(context, srcParm, null) != null) {
+                destination[destParm] = _getConfig(context, srcParm, null);
+            }
+        },
+
+        /**
+         * centralized transport switching helper
+         * for the multipart submit case
+         *
+         * @param context the context which is passed down
+         */
+        _getMultipartReqClass: function (context) {
+            return myfaces._impl.xhrCore._FormDataRequest;
+        },
+
+
+        _getAjaxReqClass: function (context) {
+            return myfaces._impl.xhrCore._AjaxRequest;
         }
-        return ret;
-    },
 
-    /**
-     * helper method to apply a config setting to our varargs param list
-     *
-     * @param destination the destination map to receive the setting
-     * @param context the current context
-     * @param destParm the destination param of the destination map
-     * @param srcParm the source param which is the key to our config setting
-     */
-    _applyConfig: function(destination, context, destParm, srcParm) {
-        var _RT = myfaces._impl.core._Runtime;
-        /** @ignore */
-        var _getConfig = _RT.getLocalOrGlobalConfig;
-        if (_getConfig(context, srcParm, null) != null) {
-            destination[destParm] = _getConfig(context, srcParm, null);
-        }
-    },
-
-    /**
-     * centralized transport switching helper
-     * for the multipart submit case
-     *
-     * @param context the context which is passed down
-     */
-    _getMultipartReqClass: function(context) {
-       if (this._RT.getXHRLvl() >= 2) {
-            return myfaces._impl.xhrCore._MultipartAjaxRequestLevel2;
-       } else {
-            return myfaces._impl.xhrCore._IFrameRequest;
-       }
-    },
-
-
-    _getAjaxReqClass: function(context) {
-        // var _RT = myfaces._impl.core._Runtime;
-        if(this._RT.getXHRLvl() < 2) {
-           return myfaces._impl.xhrCore._AjaxRequest;
-        } else {
-           return myfaces._impl.xhrCore._AjaxRequestLevel2;
-        }
-    }
-
-});
+    });

--- a/api/src/main/javascript/META-INF/resources/myfaces/api/jsf.js
+++ b/api/src/main/javascript/META-INF/resources/myfaces/api/jsf.js
@@ -356,7 +356,7 @@ if (!jsf.push) {
     }
 
     // Public static functions ----------------------------------------------------------------------------------------
-
+    var _t = this;
     /**
      *
      * @param {function} onopen The function to be invoked when the web socket is opened.
@@ -394,7 +394,7 @@ if (!jsf.push) {
         }
 
         if (autoconnect) {
-            this.open(socketClientId);
+            _t.open(socketClientId);
         }
     }
 


### PR DESCRIPTION
Also related to: https://issues.apache.org/jira/browse/MYFACES-4535

This pr unifies the code between 2.3-next and 3.0 and 4.0
Also backwards compatibility to older browsers has been improved by readding the shim layer from 2.3, now that it has a clear boundary.
Unused Ext code has been removed.
Synching between next and 3.0 now should be relatively straight forward.
Also all patches which have been added to 2.3 also are now active in this one
The only fix missing is the f:param TCK fix, which needs also patches on the impl side.
