### PR TITLE
FacesConfig#version() cannot return null

### DIFF
--- a/api/src/main/java/jakarta/faces/annotation/FacesConfig.java
+++ b/api/src/main/java/jakarta/faces/annotation/FacesConfig.java
@@ -52,7 +52,7 @@ public @interface FacesConfig
         @Override
         public Version version()
         {
-            return null; // non binding, so not used
+            return Version.JSF_2_3; 
         }
     }
 }


### PR DESCRIPTION
Related to https://github.com/jakartaee/faces/issues/1784
Mojarra already fixed: https://github.com/eclipse-ee4j/mojarra/pull/5210

We need to return a valid value and not null. 
Mojarra also backported this to their 4.0 release. MyFaces might also want to do the same. 
