### PR TITLE
SPEC-1558 UIComponent#subscribeToEvent() should not allow duplicate values

### DIFF
--- a/api/src/main/java/jakarta/faces/component/UIComponent.java
+++ b/api/src/main/java/jakarta/faces/component/UIComponent.java
@@ -795,10 +795,17 @@ public abstract class UIComponent
         {
             listeners = new _DeltaList<>(3);
             _systemEventListenerClassMap.put(eventClass, listeners);
+            listeners.add(listener);
+        }
+        else
+        {
+            if(!listeners.contains(listener))
+            {
+                listeners.add(listener);
+            }
         }
 
-        // Deal with contains? Spec is silent
-        listeners.add(listener);
+        
     }
 
     public void unsubscribeFromEvent(Class<? extends SystemEvent> eventClass,


### PR DESCRIPTION
This issue was previously tracked by https://issues.apache.org/jira/browse/MYFACES-4385

No TCK test was ever written for this change in SPEC documentation, so I wrote a test here: 
https://github.com/OpenLiberty/open-liberty/blob/86a8d4a81f2c0424c1e975ccd6eb837225edbf52/dev/io.openliberty.org.apache.myfaces.4.0_fat/test-applications/SubscribeToEventTest.war/src/io/openliberty/org/apache/faces40/fat/subscribe/SubscribeTest.java

Test output: 
```txt
subscribeToEvent method behaved incorrectly 
expected:<[true]> 
but was:   <[false - Failed testSubscribeToEvent after 2 attempt(s) with message: 
testSubscribeToEvent subscribeList was either null, or contained more than one listener:
[
  jakarta.faces.component._EventListenerWrapper@49fc76dc, 
  jakarta.faces.component._EventListenerWrapper@49fc76dc
]]> 
```

MyFaces still allows for duplicate values when subscribing a listener to an event.
Mojarra does not, 

https://github.com/eclipse-ee4j/mojarra/blob/875994bfe8aec20f5ac87bfa53f23a5630de7ef5/impl/src/main/java/jakarta/faces/component/UIComponentBase.java#L765-L767

This will ensure MyFaces behaves the same, and that we follow the updated SPEC. 