### PR TITLE
JavaScript: Check if getAttribute is a function before calling it (MYFACES-4533 follow up)

### DIFF
--- a/api/src/main/javascript/META-INF/resources/myfaces/_impl/xhrCore/_AjaxUtils.js
+++ b/api/src/main/javascript/META-INF/resources/myfaces/_impl/xhrCore/_AjaxUtils.js
@@ -186,7 +186,10 @@ _MF_SINGLTN(_PFX_XHR+"_AjaxUtils", _MF_OBJECT,
         form = this._Dom.byId(form);
         var _t = this;
         var foundNames = this._Dom.findAll(form, function(node) {
-            var name = node.getAttribute("name");
+            var name;
+            if (typeof node.getAttribute === 'function') {
+                name = node.getAttribute("name")
+            }
             if(!name || name.indexOf("jakarta.faces.ViewState") <= 0) {
                 return false;
             }


### PR DESCRIPTION
With the MYFACES-4533 fix (#510) merged in, we tries to run our test suite against it and found this htmlunit/javascipt error hitting numerous tests:

`Caused by: net.sourceforge.htmlunit.corejs.javascript.EcmaError: TypeError: Cannot find function getAttribute in object [object Text]. (http://localhost:8010/JSF22Miscellaneous/jakarta.faces.resource/faces.js.xhtml?ln=jakarta.faces&stage=Development#5213) `

Manual tests via web browser show no errors so this problem looks to be just another HTMLUnit bug. 

As a workaround for now, I'd like to test if this is a function so that these tests can pass. 

