### PR TITLE
MYFACES-4553 - fix placement of flow transition

### DIFF
--- a/impl/src/main/java/org/apache/myfaces/application/NavigationHandlerImpl.java
+++ b/impl/src/main/java/org/apache/myfaces/application/NavigationHandlerImpl.java
@@ -705,6 +705,12 @@ public class NavigationHandlerImpl extends ConfigurableNavigationHandler
                                 }
                                 continue;
                             }
+                            if(!complete && flowHandler.getCurrentFlow() == null) // See  MYFACES-4553 for details
+                            {
+                                flowHandler.transition(facesContext, null, targetFlow, null, outcomeToGo);
+                                facesContext.getAttributes().put(STARTED_FLOW_TRANSITION, true);
+                                continue;
+                            }
                             if (!complete && flowNode instanceof FlowCallNode)
                             {
                                 // "... If the node is a FlowCallNode, save it aside as facesFlowCallNode. ..."
@@ -723,12 +729,6 @@ public class NavigationHandlerImpl extends ConfigurableNavigationHandler
                                     // reference to the start node and execute this algorithm again, on that start node.
                                     complete = true;
                                 }
-                            }
-                            if(!complete && flowHandler.getCurrentFlow() == null) // See  MYFACES-4553 for details
-                            {
-                                flowHandler.transition(facesContext, null, targetFlow, null, outcomeToGo);
-                                facesContext.getAttributes().put(STARTED_FLOW_TRANSITION, true);
-                                continue;
                             }
                             if (!complete && flowNode instanceof SwitchNode)
                             {


### PR DESCRIPTION
Current code has the early flow transition after a FlowCallNode, but it should be before.  This was mistaken done in the previous PR: https://github.com/apache/myfaces/pull/504

Otherwise, the some flows might not transition due to the `for (int i = didFlowTransitionAlready(facesContext) ? 1 : 0` in applyFlowTransition. 

Basically, a flow could transition into the same one twice.  


Rough outline...
1) Not in flow
2) getNavigationCase, begin the node algorithm, and Hit Flow Node
3) Restart node algorithm
4) early transition into flow for nested flow
5) The navigationContext.targetFlows has two flows.  Since the transition marker was set, the first flow would be skipped.     It would transition into the second flow and miss the first. 

