### PR TITLE
MYFACES-4561 Change Context Parameter Logging

### DIFF
--- a/impl/src/main/java/org/apache/myfaces/config/webparameters/MyfacesConfig.java
+++ b/impl/src/main/java/org/apache/myfaces/config/webparameters/MyfacesConfig.java
@@ -713,12 +713,12 @@ public class MyfacesConfig
     /**
      * Indicate if log all web config params should be done before initialize the webapp. 
      * <p>
-     * If is set in "auto" mode, web config params are only logged on "Development" and "Production" project stages.
+     * Web config params are only logged on "Development" project stages when set to true.
      * </p> 
      */
-    @JSFWebConfigParam(expectedValues="true, auto, false", defaultValue="auto")
-    public static final String LOG_WEB_CONTEXT_PARAMS = "org.apache.myfaces.LOG_WEB_CONTEXT_PARAMS";
-    private static final String LOG_WEB_CONTEXT_PARAMS_DEFAULT = "auto";
+    @JSFWebConfigParam(expectedValues="true, false", defaultValue="true")
+    public static final String LOG_WEB_CONTEXT_PARAMS_IN_DEV_MODE = "org.apache.myfaces.LOG_WEB_CONTEXT_PARAMS_IN_DEV_MODE";
+    private static final String LOG_WEB_CONTEXT_PARAMS_IN_DEV_MODE_DEFAULT = "true";
     
 
     public static final boolean AUTOMATIC_EXTENSIONLESS_MAPPING_DEFAULT = false;
@@ -1256,19 +1256,18 @@ public class MyfacesConfig
         {
             cfg.resourceCacheLastModified = false;
         }
-        
-        String logWebContextParams = getString(extCtx, LOG_WEB_CONTEXT_PARAMS,
-                LOG_WEB_CONTEXT_PARAMS_DEFAULT);    
-        if (logWebContextParams.equals("false") || (logWebContextParams.equals("auto")
-                && (cfg.projectStage == ProjectStage.SystemTest || cfg.projectStage == ProjectStage.UnitTest)))
-        {
-            cfg.logWebContextParams = false;
-        }
-        else
+
+        String logWebContextParams = getString(extCtx, LOG_WEB_CONTEXT_PARAMS_IN_DEV_MODE, LOG_WEB_CONTEXT_PARAMS_IN_DEV_MODE_DEFAULT);    
+
+        if(logWebContextParams.equals("true") && cfg.projectStage == ProjectStage.Development)
         {
             cfg.logWebContextParams = true;
         }
-        
+        else
+        {
+            cfg.logWebContextParams = false;
+        }
+
         cfg.websocketMaxConnections = getInt(extCtx, WEBSOCKET_MAX_CONNECTIONS,
                 WEBSOCKET_MAX_CONNECTIONS_DEFAULT);
 
@@ -1709,6 +1708,7 @@ public class MyfacesConfig
     {
         return resourceCacheLastModified;
     }
+
 
     public boolean isLogWebContextParams()
     {

--- a/impl/src/main/resources/META-INF/WebConfigParamsLogger.vm
+++ b/impl/src/main/resources/META-INF/WebConfigParamsLogger.vm
@@ -54,56 +54,56 @@ public class WebConfigParamsLogger
 ## -------------------------------
 ##
 #macro (writePropertyCheck $webConfigParam)
-            paramValue = facesContext.getExternalContext().getInitParameter("$webConfigParam.name");
-            if (paramValue == null)
-            {
-                logMessageToAppropriateLevel("No context init parameter '$webConfigParam.name' found#if($webConfigParam.defaultValue), using default value '$webConfigParam.defaultValue'#end.");
-            }
+        paramValue = facesContext.getExternalContext().getInitParameter("$webConfigParam.name");
+        if (paramValue == null)
+        {
+            logMessageToAppropriateLevel("No context init parameter '$webConfigParam.name' found#if($webConfigParam.defaultValue), using default value '$webConfigParam.defaultValue'#end.");
+        }
 #if (!$webConfigParam.isDeprecated())
 #if ($webConfigParam.expectedValues)
-            else
+        else
+        {
+            boolean found = false;
+            String[] expectedValues = StringUtils.trim(StringUtils.splitShortString("$webConfigParam.expectedValues",','));
+            for (int i = 0; i < expectedValues.length; i++)
             {
-                boolean found = false;
-                String[] expectedValues = StringUtils.trim(StringUtils.splitShortString("$webConfigParam.expectedValues",','));
-                for (int i = 0; i < expectedValues.length; i++)
-                {
 #if ($webConfigParam.isIgnoreUpperLowerCase())
-                    if (paramValue.equalsIgnoreCase(expectedValues[i]))
+                if (paramValue.equalsIgnoreCase(expectedValues[i]))
 #else
-                    if (paramValue.equals(expectedValues[i]))
+                if (paramValue.equals(expectedValues[i]))
 #end
-                    {
-                        found = true;
-                        break;
-                    }
-                }
-                if (!found)
                 {
-                    if (log.isLoggable(Level.WARNING))
-                    {
-                        log.warning("Wrong value in context init parameter '$webConfigParam.name' (='" + paramValue + "'), using default value #if($webConfigParam.defaultValue)'$webConfigParam.defaultValue'#else'null'#end");
-                    }
-                }
-                else
-                {
-                    logMessageToAppropriateLevel("Init Context parameter FOUND '$webConfigParam.name' set to '" + paramValue + "'");
+                    found = true;
+                    break;
                 }
             }
-#elseif ($webConfigParam.classType)
+            if (!found)
+            {
+                if (log.isLoggable(Level.WARNING))
+                {
+                    log.warning("Wrong value in context init parameter '$webConfigParam.name' (='" + paramValue + "'), using default value #if($webConfigParam.defaultValue)'$webConfigParam.defaultValue'#else'null'#end");
+                }
+            }
             else
             {
-                try
+                logMessageToAppropriateLevel("Init context parameter found '$webConfigParam.name' set to '" + paramValue + "'");
+            }
+        }
+#elseif ($webConfigParam.classType)
+        else
+        {
+            try
+            {
+                ${webConfigParam.classType}.valueOf(paramValue);
+            }
+            catch(Exception e)
+            {
+                if (log.isLoggable(Level.WARNING))
                 {
-                    ${webConfigParam.classType}.valueOf(paramValue);
-                }
-                catch(Exception e)
-                {
-                    if (log.isLoggable(Level.WARNING))
-                    {
-                        log.warning("Wrong value in context init parameter '$webConfigParam.name' (='" + paramValue + "'), using default value #if($webConfigParam.defaultValue)'$webConfigParam.defaultValue'#else'null'#end");
-                    }
+                    log.warning("Wrong value in context init parameter '$webConfigParam.name' (='" + paramValue + "'), using default value #if($webConfigParam.defaultValue)'$webConfigParam.defaultValue'#else'null'#end");
                 }
             }
+        }
 #end
 #end
 #end

--- a/impl/src/main/resources/META-INF/WebConfigParamsLogger.vm
+++ b/impl/src/main/resources/META-INF/WebConfigParamsLogger.vm
@@ -38,18 +38,12 @@ public class WebConfigParamsLogger
     {
         MyfacesConfig myfacesConfig = MyfacesConfig.getCurrentInstance(facesContext.getExternalContext());
 
-        if (!myfacesConfig.isLogWebContextParams())
-        {
-            //No log if is disabled or is in auto mode and project stage is UnitTest or SystemTest
-            return;
-        }
-
+        Boolean infologgingEnabled = myfacesConfig.isLogWebContextParams();
 
         if(myfacesConfig.isRiImplAvailable() && myfacesConfig.isMyfacesImplAvailable())
         {
             log.severe("Both MyFaces and the RI are on your classpath. Please make sure to use only one of the two JSF-implementations.");
         }
-
 
 ## ----------------------------- PROPERTY MACROS -----------------------------
 ##
@@ -61,7 +55,14 @@ public class WebConfigParamsLogger
             paramValue = facesContext.getExternalContext().getInitParameter("$webConfigParam.name");
             if (paramValue == null)
             {
-                log.info("No context init parameter '$webConfigParam.name' found#if($webConfigParam.defaultValue), using default value '$webConfigParam.defaultValue'#end.");
+                if(infologgingEnabled) 
+                {
+                    log.info("No context init parameter '$webConfigParam.name' found#if($webConfigParam.defaultValue), using default value '$webConfigParam.defaultValue'#end.");
+                }
+                else if (!infologgingEnabled && log.isLoggable(Level.FINEST))
+                {
+                    log.finest("No context init parameter '$webConfigParam.name' found#if($webConfigParam.defaultValue), using default value '$webConfigParam.defaultValue'#end.");
+                }
             }
 #if (!$webConfigParam.isDeprecated())
 #if ($webConfigParam.expectedValues)
@@ -88,6 +89,10 @@ public class WebConfigParamsLogger
                         log.warning("Wrong value in context init parameter '$webConfigParam.name' (='" + paramValue + "'), using default value #if($webConfigParam.defaultValue)'$webConfigParam.defaultValue'#else'null'#end");
                     }
                 }
+                else if (!infologgingEnabled && log.isLoggable(Level.FINEST))
+                {
+                    log.finest("Context parameter FOUND: '$webConfigParam.name' set to '" + paramValue + "'");
+                }
             }
 #elseif ($webConfigParam.classType)
             else
@@ -110,12 +115,9 @@ public class WebConfigParamsLogger
 ##
 ## ----------------------------- END PROPERTY MACROS -------------------------
 ##
-
         if (log.isLoggable(Level.INFO))
         {
-            log.info("Scanning for context init parameters not defined. It is not necessary to define them all into your web.xml, " +
-                     "they are just provided here for informative purposes. To disable this messages set " +
-                     MyfacesConfig.LOG_WEB_CONTEXT_PARAMS + " config param to 'false'");
+
             String paramValue = null;
 #set ($webConfigList = ${model.getWebConfigs()})
 #foreach( $webConfig in $webConfigList )

--- a/impl/src/main/resources/META-INF/WebConfigParamsLogger.vm
+++ b/impl/src/main/resources/META-INF/WebConfigParamsLogger.vm
@@ -34,11 +34,13 @@ public class WebConfigParamsLogger
 {
     private static final Logger log = Logger.getLogger(WebConfigParamsLogger.class.getName());
 
+    private static Boolean LOG_WEB_CONTEXT_PARAM = false;
+
     public static void logWebContextParams(FacesContext facesContext)
     {
         MyfacesConfig myfacesConfig = MyfacesConfig.getCurrentInstance(facesContext.getExternalContext());
 
-        Boolean infologgingEnabled = myfacesConfig.isLogWebContextParams();
+        LOG_WEB_CONTEXT_PARAM = myfacesConfig.isLogWebContextParams();
 
         if(myfacesConfig.isRiImplAvailable() && myfacesConfig.isMyfacesImplAvailable())
         {
@@ -55,14 +57,7 @@ public class WebConfigParamsLogger
             paramValue = facesContext.getExternalContext().getInitParameter("$webConfigParam.name");
             if (paramValue == null)
             {
-                if(infologgingEnabled) 
-                {
-                    log.info("No context init parameter '$webConfigParam.name' found#if($webConfigParam.defaultValue), using default value '$webConfigParam.defaultValue'#end.");
-                }
-                else if (!infologgingEnabled && log.isLoggable(Level.FINEST))
-                {
-                    log.finest("No context init parameter '$webConfigParam.name' found#if($webConfigParam.defaultValue), using default value '$webConfigParam.defaultValue'#end.");
-                }
+                logMessageToAppropriateLevel("No context init parameter '$webConfigParam.name' found#if($webConfigParam.defaultValue), using default value '$webConfigParam.defaultValue'#end.");
             }
 #if (!$webConfigParam.isDeprecated())
 #if ($webConfigParam.expectedValues)
@@ -89,9 +84,9 @@ public class WebConfigParamsLogger
                         log.warning("Wrong value in context init parameter '$webConfigParam.name' (='" + paramValue + "'), using default value #if($webConfigParam.defaultValue)'$webConfigParam.defaultValue'#else'null'#end");
                     }
                 }
-                else if (!infologgingEnabled && log.isLoggable(Level.FINEST))
+                else
                 {
-                    log.finest("Context parameter FOUND: '$webConfigParam.name' set to '" + paramValue + "'");
+                    logMessageToAppropriateLevel("Init Context parameter FOUND '$webConfigParam.name' set to '" + paramValue + "'");
                 }
             }
 #elseif ($webConfigParam.classType)
@@ -115,9 +110,12 @@ public class WebConfigParamsLogger
 ##
 ## ----------------------------- END PROPERTY MACROS -------------------------
 ##
-        if (log.isLoggable(Level.INFO))
+        if(LOG_WEB_CONTEXT_PARAM)
         {
-
+            log.info("Scanning for context init parameters not defined. It is not necessary to define them all into your web.xml, " +
+                "they are just provided here for informative purposes. To disable this messages set " +
+                MyfacesConfig.LOG_WEB_CONTEXT_PARAMS + " config param to 'false'");
+        }
             String paramValue = null;
 #set ($webConfigList = ${model.getWebConfigs()})
 #foreach( $webConfig in $webConfigList )
@@ -131,7 +129,18 @@ public class WebConfigParamsLogger
 #end
 #end
 #end
-        }
 ##
+    }
+
+    private static void logMessageToAppropriateLevel(String text)
+    {
+        if(LOG_WEB_CONTEXT_PARAM && log.isLoggable(Level.INFO))
+        {
+            log.info(text);
+        }
+        else if (log.isLoggable(Level.FINEST))
+        {
+            log.finest(text);
+        }
     }
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/MYFACES-4561

Although the hope was to not log these context param messages in production. That change would have unintended consequences since the params then won't be logged in at all.  This can make it difficult to debug applications if there's no trace regarding the context parameters. 

I add new logging and refactored the code, so the new behavior is now: 

auto - logs in dev mode only
true - logs in production and dev mode
false - no logging in either mode (fine messages still logged when trace is specified -- added for support)

Other project stage modes are not considered. 

Additionally,  _found_ context parameters are now logged. 
