### PR TITLE
MYFACES-4572 - Return 'Production' as default project stage

### DIFF
--- a/api/src/client/typescript/faces/impl/AjaxImpl.ts
+++ b/api/src/client/typescript/faces/impl/AjaxImpl.ts
@@ -208,7 +208,7 @@ export module Implementation {
 
         /* run through all script tags and try to find the one that includes faces.js */
         const foundStage = ExtDomQuery.searchJsfJsFor(/stage=([^&;]*)/).value as string;
-        return (foundStage in ProjectStages) ? foundStage : null;
+        return (foundStage in ProjectStages) ? foundStage : ProjectStages.Production; // MYFACES-4572: default is production
     }
 
     /**


### PR DESCRIPTION
https://issues.apache.org/jira/browse/MYFACES-4572

Previous JS code: 
```
   getProjectStage:function () {
   ....
                    }
                    else {
                        //we found the script, but there was no stage parameter -- Production
                        //(we also add an override here for testing purposes, the default, however is Production)
                        projectStage = getConfig(PRJ_STAGE, STG_PROD);
                    }
                }
            }
            /* we could not find anything valid --> return the default value */
            this._projectStage = getConfig(PRJ_STAGE, projectStage || STG_PROD);
            }
```