### PR TITLE
MYFACES-4582: Quarkus hot reload

### DIFF
--- a/impl/src/main/java/org/apache/myfaces/cdi/model/FacesDataModelManager.java
+++ b/impl/src/main/java/org/apache/myfaces/cdi/model/FacesDataModelManager.java
@@ -64,6 +64,11 @@ public class FacesDataModelManager
         }
     }
 
+    public void reset()
+    {
+        facesDataModels = null;
+    }
+
     public DataModel tryToCreateDataModel(FacesContext facesContext, Class<?> forClass, Object value)
     {
         if (facesDataModels == null)


### PR DESCRIPTION
@tandraschko this works but still generates this warning:

```
Called FactoryFinderProviderFactory.setFactory after initialized FactoryFinder (first call to getFactory() or setFactory()). This method should be called before any 'web context' is initialized in the current 'classloader context'. By that reason it will not be changed.
```

But everything seems to be working and hot reload works again.

I had to remove the unmodifiable map or else it also throws an exception trying to add the models.