### PR TITLE
Use Java11+ HTTP Client for Selenium

### DIFF
--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -68,6 +68,9 @@
                             <includes>
                                 <include>**/*IntegrationTest</include>
                             </includes>
+                            <systemPropertyVariables>
+                                <webdriver.http.factory>jdk-http-client</webdriver.http.factory>
+                            </systemPropertyVariables>
                         </configuration>
                     </execution>
                 </executions>
@@ -128,6 +131,16 @@
             <artifactId>selenium-java</artifactId>
             <version>4.7.2</version>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.seleniumhq.selenium</groupId>
+            <artifactId>selenium-java</artifactId>
+            <version>4.5.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.seleniumhq.selenium</groupId>
+            <artifactId>selenium-http-jdk-client</artifactId>
+            <version>4.5.0</version>
         </dependency>
         <dependency>
             <groupId>com.google.code.gson</groupId>


### PR DESCRIPTION
https://www.selenium.dev/blog/2022/using-java11-httpclient/#integrating-the-java-11-client

Resolves issues we're seeing with Chrome 111:
[ERROR]   IntegrationTest.test ▒ Runtime Unable to instantiate Drone via org.openqa.selenium.chrome.ChromeDriver(ChromeOptions): org.openqa.selenium.remote.http.ConnectionFailedException: Unable to establish websocket connection