### PR TITLE
Revert 2.3-next-M8 release

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.myfaces.core</groupId>
         <artifactId>myfaces-core-project</artifactId>
-        <version>2.3-next-M9-SNAPSHOT</version>
+        <version>2.3-next-SNAPSHOT</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
 

--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.myfaces.core</groupId>
         <artifactId>myfaces-core-project</artifactId>
-        <version>2.3-next-M9-SNAPSHOT</version>
+        <version>2.3-next-SNAPSHOT</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
 

--- a/bundle/pom.xml
+++ b/bundle/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.myfaces.core</groupId>
         <artifactId>myfaces-core-project</artifactId>
-        <version>2.3-next-M9-SNAPSHOT</version>
+        <version>2.3-next-SNAPSHOT</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
 

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.myfaces.core</groupId>
         <artifactId>myfaces-core-project</artifactId>
-        <version>2.3-next-M9-SNAPSHOT</version>
+        <version>2.3-next-SNAPSHOT</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
 

--- a/extensions/quarkus/deployment/pom.xml
+++ b/extensions/quarkus/deployment/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.myfaces.core.extensions</groupId>
         <artifactId>myfaces-quarkus</artifactId>
-        <version>2.3-next-M9-SNAPSHOT</version>
+        <version>2.3-next-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/extensions/quarkus/pom.xml
+++ b/extensions/quarkus/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.myfaces.core</groupId>
         <artifactId>myfaces-extensions</artifactId>
-        <version>2.3-next-M9-SNAPSHOT</version>
+        <version>2.3-next-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/extensions/quarkus/runtime/pom.xml
+++ b/extensions/quarkus/runtime/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.myfaces.core.extensions</groupId>
         <artifactId>myfaces-quarkus</artifactId>
-        <version>2.3-next-M9-SNAPSHOT</version>
+        <version>2.3-next-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.myfaces.core</groupId>
         <artifactId>myfaces-core-project</artifactId>
-        <version>2.3-next-M9-SNAPSHOT</version>
+        <version>2.3-next-SNAPSHOT</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
 

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -34,7 +34,7 @@
         This project is the home of the MyFaces implementation of the JavaServer Faces 2.3 specification, and
         consists of an API module (javax.faces.* classes) and an implementation module (org.apache.myfaces.* classes).
     </description>
-    <version>2.3-next-M9-SNAPSHOT</version>
+    <version>2.3-next-SNAPSHOT</version>
     <url>http://myfaces.apache.org/#/core23next</url>
 
     <issueManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
         This project is the home of the MyFaces implementation of the JavaServer Faces 2.3 specification, and
         consists of an API module (javax.faces.* classes) and an implementation module (org.apache.myfaces.* classes).
     </description>
-    <version>2.3-next-M9-SNAPSHOT</version>
+    <version>2.3-next-SNAPSHOT</version>
     <url>http://myfaces.apache.org/#/core23next</url>
 
     <issueManagement>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.myfaces.core</groupId>
         <artifactId>myfaces-core-project</artifactId>
-        <version>2.3-next-M9-SNAPSHOT</version>
+        <version>2.3-next-SNAPSHOT</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
`mvn release:rollback` didn't work since I don't have the backup poms, so I'm doing a manual revert here. 

This reverts commit ff9f09afdbc6c83a70d885433fcc15c1749ab1ac.

This reverts commit c70c4bf9b15160f06fefdc0fb3cb76e42a4ad73c.