### PR TITLE
Update import package version for digester

### DIFF
--- a/bundle/pom.xml
+++ b/bundle/pom.xml
@@ -98,7 +98,7 @@
                             javax.xml.parsers,
                             org.apache;resolution:=optional,
                             org.apache.commons.beanutils;version="[1.8.3, 2.0.0)",
-                            org.apache.commons.digester;version="[1.8.0, 2.0.0)",
+                            org.apache.commons.digester;version="[1.8.0, 2.1.0]",
                             org.apache.commons.logging;version="[1.1.1, 2.0.0)",
                             org.w3c.dom,
                             org.xml.sax,


### PR DESCRIPTION
Accidentally forgot about this.  Thoughts on the versions? 

Should I use 
[1.8.0, 2.1.0]
or 
[1.8.0, 3.0.0) 

2.1 is the latest currently. 