### PR TITLE
Faces 5.0: Spec 1584 - Rely on CDI Class Scanning

### DIFF
--- a/impl/src/main/java/org/apache/myfaces/config/annotation/DefaultAnnotationProvider.java
+++ b/impl/src/main/java/org/apache/myfaces/config/annotation/DefaultAnnotationProvider.java
@@ -128,21 +128,19 @@ public class DefaultAnnotationProvider extends AnnotationProvider
     @Override
     public Map<Class<? extends Annotation>, Set<Class<?>>> getAnnotatedClasses(ExternalContext ctx)
     {
-        if (MyfacesConfig.getCurrentInstance(ctx).isUseCdiForAnnotationScanning())
+        //1. Use CDI
+        BeanManager beanManager = CDIUtils.getBeanManager(ctx);
+        CdiAnnotationProviderExtension extension = CDIUtils.getOptional(beanManager,
+                CdiAnnotationProviderExtension.class);
+        if (extension != null)
         {
-            BeanManager beanManager = CDIUtils.getBeanManager(ctx);
-            CdiAnnotationProviderExtension extension = CDIUtils.getOptional(beanManager,
-                    CdiAnnotationProviderExtension.class);
-            if (extension != null)
-            {
-                return extension.getMap();
-            }
+            return extension.getMap();
         }
 
         Map<Class<? extends Annotation>, Set<Class<?>>> map = new HashMap<>();
         Collection<Class<?>> classes = null;
 
-        //1. Scan for annotations on /WEB-INF/classes
+        //2. Scan for annotations on /WEB-INF/classes
         try
         {
             classes = getAnnotatedWebInfClasses(ctx);
@@ -157,7 +155,7 @@ public class DefaultAnnotationProvider extends AnnotationProvider
             processClass(map, clazz);
         }
         
-        //2. Scan for annotations on classpath
+        //3. Scan for annotations on classpath
         try
         {
             AnnotationProvider provider

--- a/impl/src/main/java/org/apache/myfaces/config/annotation/DefaultAnnotationProvider.java
+++ b/impl/src/main/java/org/apache/myfaces/config/annotation/DefaultAnnotationProvider.java
@@ -130,12 +130,16 @@ public class DefaultAnnotationProvider extends AnnotationProvider
     {
         //1. Use CDI
         BeanManager beanManager = CDIUtils.getBeanManager(ctx);
-        CdiAnnotationProviderExtension extension = CDIUtils.getOptional(beanManager,
-                CdiAnnotationProviderExtension.class);
-        if (extension != null)
+        if(beanManager != null)  // shouldnt be null, but needed for our mock junit tests
         {
-            return extension.getMap();
+        CdiAnnotationProviderExtension extension = 
+            CDIUtils.getOptional(beanManager,CdiAnnotationProviderExtension.class);
+            if (extension != null)
+            {
+                return extension.getMap();
+            }
         }
+        
 
         Map<Class<? extends Annotation>, Set<Class<?>>> map = new HashMap<>();
         Collection<Class<?>> classes = null;

--- a/impl/src/main/java/org/apache/myfaces/config/webparameters/MyfacesConfig.java
+++ b/impl/src/main/java/org/apache/myfaces/config/webparameters/MyfacesConfig.java
@@ -363,15 +363,6 @@ public class MyfacesConfig
     public static final String VALIDATE = "org.apache.myfaces.VALIDATE";
     
     /**
-     * Defines if CDI should be used for annotation scanning to improve the startup performance.
-     */
-    @JSFWebConfigParam(since="2.2.9", tags = "performance", defaultValue = "false")
-    public static final String USE_CDI_FOR_ANNOTATION_SCANNING
-            = "org.apache.myfaces.annotation.USE_CDI_FOR_ANNOTATION_SCANNING";
-    private static final boolean USE_CDI_FOR_ANNOTATION_SCANNING_DEFAULT = false;
-    
-    
-    /**
      * Controls the size of the cache used to check if a resource exists or not. 
      * 
      * <p>See org.apache.myfaces.RESOURCE_HANDLER_CACHE_ENABLED for details.</p>
@@ -808,7 +799,6 @@ public class MyfacesConfig
     private boolean supportEL3ImportHandler = SUPPORT_EL_3_IMPORT_HANDLER_DEFAULT;
     private boolean strictJsf2OriginHeaderAppPath = STRICT_JSF_2_ORIGIN_HEADER_APP_PATH_DEFAULT;
     private int resourceBufferSize = RESOURCE_BUFFER_SIZE_DEFAULT;
-    private boolean useCdiForAnnotationScanning = USE_CDI_FOR_ANNOTATION_SCANNING_DEFAULT;
     private boolean resourceHandlerCacheEnabled = RESOURCE_HANDLER_CACHE_ENABLED_DEFAULT;
     private int resourceHandlerCacheSize = RESOURCE_HANDLER_CACHE_SIZE_DEFAULT;
     private String scanPackages;
@@ -1085,9 +1075,6 @@ public class MyfacesConfig
 
         cfg.resourceBufferSize = getInt(extCtx, RESOURCE_BUFFER_SIZE, 
                 RESOURCE_BUFFER_SIZE_DEFAULT);
-        
-        cfg.useCdiForAnnotationScanning = getBoolean(extCtx, USE_CDI_FOR_ANNOTATION_SCANNING,
-                USE_CDI_FOR_ANNOTATION_SCANNING_DEFAULT);
         
         cfg.resourceHandlerCacheEnabled = getBoolean(extCtx, RESOURCE_HANDLER_CACHE_ENABLED,
                 RESOURCE_HANDLER_CACHE_ENABLED_DEFAULT);
@@ -1517,11 +1504,6 @@ public class MyfacesConfig
     public int getResourceBufferSize()
     {
         return resourceBufferSize;
-    }
-
-    public boolean isUseCdiForAnnotationScanning()
-    {
-        return useCdiForAnnotationScanning;
     }
 
     public boolean isResourceHandlerCacheEnabled()

--- a/impl/src/test/java/org/apache/myfaces/application/contracts/ContractsCreateResourceMyFacesRequestTestCase.java
+++ b/impl/src/test/java/org/apache/myfaces/application/contracts/ContractsCreateResourceMyFacesRequestTestCase.java
@@ -27,11 +27,12 @@ import jakarta.faces.application.ViewResource;
 
 import org.apache.myfaces.config.RuntimeConfig;
 import org.apache.myfaces.config.webparameters.MyfacesConfig;
-import org.apache.myfaces.test.core.AbstractMyFacesRequestTestCase;
+import org.apache.myfaces.test.core.AbstractMyFacesCDIRequestTestCase;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-public class ContractsCreateResourceMyFacesRequestTestCase extends AbstractMyFacesRequestTestCase
+public class ContractsCreateResourceMyFacesRequestTestCase extends AbstractMyFacesCDIRequestTestCase
+
 {
 
     @Override

--- a/impl/src/test/java/org/apache/myfaces/application/contracts/DefaultContractsConfigMyFacesRequestTestCase.java
+++ b/impl/src/test/java/org/apache/myfaces/application/contracts/DefaultContractsConfigMyFacesRequestTestCase.java
@@ -25,10 +25,11 @@ import jakarta.faces.application.StateManager;
 import org.junit.jupiter.api.Assertions;
 import org.apache.myfaces.config.RuntimeConfig;
 import org.apache.myfaces.config.webparameters.MyfacesConfig;
-import org.apache.myfaces.test.core.AbstractMyFacesRequestTestCase;
+import org.apache.myfaces.test.core.AbstractMyFacesCDIRequestTestCase;
 import org.junit.jupiter.api.Test;
 
-public class DefaultContractsConfigMyFacesRequestTestCase extends AbstractMyFacesRequestTestCase
+public class DefaultContractsConfigMyFacesRequestTestCase extends AbstractMyFacesCDIRequestTestCase
+
 {
 
     @Override

--- a/impl/src/test/java/org/apache/myfaces/application/contracts/SingleContractMyFacesRequestTestCase.java
+++ b/impl/src/test/java/org/apache/myfaces/application/contracts/SingleContractMyFacesRequestTestCase.java
@@ -30,12 +30,13 @@ import jakarta.faces.component.UICommand;
 
 import org.apache.myfaces.config.RuntimeConfig;
 import org.apache.myfaces.config.webparameters.MyfacesConfig;
-import org.apache.myfaces.test.core.AbstractMyFacesRequestTestCase;
+import org.apache.myfaces.test.core.AbstractMyFacesCDIRequestTestCase;
 import org.apache.myfaces.test.mock.MockPrintWriter;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-public class SingleContractMyFacesRequestTestCase extends AbstractMyFacesRequestTestCase
+public class SingleContractMyFacesRequestTestCase extends AbstractMyFacesCDIRequestTestCase
+
 {
 
     @Override

--- a/impl/src/test/java/org/apache/myfaces/application/flow/FlowMyFacesRequestTestCase.java
+++ b/impl/src/test/java/org/apache/myfaces/application/flow/FlowMyFacesRequestTestCase.java
@@ -28,7 +28,7 @@ import jakarta.faces.flow.FlowHandler;
 import jakarta.faces.render.ResponseStateManager;
 
 import org.apache.myfaces.config.webparameters.MyfacesConfig;
-import org.apache.myfaces.test.core.AbstractMyFacesRequestTestCase;
+import org.apache.myfaces.test.core.AbstractMyFacesCDIRequestTestCase;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -36,7 +36,8 @@ import org.junit.jupiter.api.Test;
  *
  * @author Leonardo Uribe
  */
-public class FlowMyFacesRequestTestCase extends AbstractMyFacesRequestTestCase
+public class FlowMyFacesRequestTestCase extends AbstractMyFacesCDIRequestTestCase
+
 {
 
     @Override

--- a/impl/src/test/java/org/apache/myfaces/application/flow/FlowResourceHandlerMyFacesRequestTestCase.java
+++ b/impl/src/test/java/org/apache/myfaces/application/flow/FlowResourceHandlerMyFacesRequestTestCase.java
@@ -21,7 +21,8 @@ package org.apache.myfaces.application.flow;
 import java.util.Iterator;
 import java.util.stream.Stream;
 import jakarta.faces.application.StateManager;
-import org.apache.myfaces.test.core.AbstractMyFacesRequestTestCase;
+
+import org.apache.myfaces.test.core.AbstractMyFacesCDIRequestTestCase;
 import org.apache.myfaces.config.webparameters.MyfacesConfig;
 import org.apache.myfaces.resource.ClassLoaderResourceLoader;
 import org.apache.myfaces.resource.ExternalContextResourceLoader;
@@ -31,7 +32,8 @@ import org.junit.jupiter.api.Test;
  *
  * @author lu4242
  */
-public class FlowResourceHandlerMyFacesRequestTestCase extends AbstractMyFacesRequestTestCase
+public class FlowResourceHandlerMyFacesRequestTestCase extends AbstractMyFacesCDIRequestTestCase
+
 {
 
     @Override

--- a/impl/src/test/java/org/apache/myfaces/view/facelets/TemplateInResourcesDirTestCase.java
+++ b/impl/src/test/java/org/apache/myfaces/view/facelets/TemplateInResourcesDirTestCase.java
@@ -20,7 +20,7 @@ package org.apache.myfaces.view.facelets;
 
 import jakarta.el.ExpressionFactory;
 
-import org.apache.myfaces.test.core.AbstractMyFacesRequestTestCase;
+import org.apache.myfaces.test.core.AbstractMyFacesCDIRequestTestCase;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -30,7 +30,8 @@ import org.junit.jupiter.api.Test;
  * @author Jay Sartoris
  */
 
-public class TemplateInResourcesDirTestCase extends AbstractMyFacesRequestTestCase
+public class TemplateInResourcesDirTestCase extends AbstractMyFacesCDIRequestTestCase
+
 {
 
     @Override

--- a/impl/src/test/java/org/apache/myfaces/view/facelets/stateless/StatelessTest.java
+++ b/impl/src/test/java/org/apache/myfaces/view/facelets/stateless/StatelessTest.java
@@ -23,14 +23,15 @@ import jakarta.faces.component.UIComponent;
 import jakarta.faces.render.ResponseStateManager;
 
 import org.apache.myfaces.config.webparameters.MyfacesConfig;
-import org.apache.myfaces.test.core.AbstractMyFacesRequestTestCase;
+import org.apache.myfaces.test.core.AbstractMyFacesCDIRequestTestCase;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 /**
  * See https://issues.apache.org/jira/browse/MYFACES-4267
  */
-public class StatelessTest extends AbstractMyFacesRequestTestCase
+public class StatelessTest extends AbstractMyFacesCDIRequestTestCase
+
 {
 
     @Override

--- a/impl/src/test/java/org/apache/myfaces/view/facelets/test/component/FacesComponentAnnotationMyFacesRequestTestCase.java
+++ b/impl/src/test/java/org/apache/myfaces/view/facelets/test/component/FacesComponentAnnotationMyFacesRequestTestCase.java
@@ -23,10 +23,12 @@ import jakarta.faces.application.StateManager;
 import jakarta.faces.component.UIComponent;
 import org.junit.jupiter.api.Assertions;
 import org.apache.myfaces.config.webparameters.MyfacesConfig;
+import org.apache.myfaces.test.core.AbstractMyFacesCDIRequestTestCase;
 import org.apache.myfaces.test.core.AbstractMyFacesRequestTestCase;
 import org.junit.jupiter.api.Test;
 
-public class FacesComponentAnnotationMyFacesRequestTestCase extends AbstractMyFacesRequestTestCase
+public class FacesComponentAnnotationMyFacesRequestTestCase extends AbstractMyFacesCDIRequestTestCase
+
 {
 
     @Override

--- a/test/src/main/java/org/apache/myfaces/test/base/junit/AbstractJsfConfigurableMockTestCase.java
+++ b/test/src/main/java/org/apache/myfaces/test/base/junit/AbstractJsfConfigurableMockTestCase.java
@@ -46,6 +46,8 @@ import org.apache.myfaces.test.mock.MockServletContext;
 import  org.junit.jupiter.api.AfterEach;
 import  org.junit.jupiter.api.BeforeEach;
 
+// import org.apache.myfaces.spi.impl.CDIAnnotationDelegateInjectionProvider;
+
 /**
  * <p>Abstract JUnit 4.5 test case base class, which sets up the JavaServer Faces
  * mock object environment for a particular simulated request.  The following
@@ -171,6 +173,8 @@ public abstract class AbstractJsfConfigurableMockTestCase
     protected void setUpServletObjects() throws Exception
     {
         servletContext = new MockServletContext();
+        // servletContext.addInitParameter("org.apache.myfaces.spi.InjectionProvider", 
+                //CDIAnnotationDelegateInjectionProvider.class.getName());
         config = new MockServletConfig(servletContext);
         session = new MockHttpSession();
         session.setServletContext(servletContext);


### PR DESCRIPTION
For `https://github.com/jakartaee/faces/issues/1584` 

Since CDI scanning is default now, I removed the `USE_CDI_FOR_ANNOTATION_SCANNING` configuration.

Question: Should we still have fallbacks 2 & 3?  

TODO: Create JIRA if one doesn't exist.  And investigate unit test failures...