### PR TITLE
Create setResponseContentLengthLong in ServletExternalContextImpl

### DIFF
--- a/impl/src/main/java/org/apache/myfaces/context/servlet/ServletExternalContextImpl.java
+++ b/impl/src/main/java/org/apache/myfaces/context/servlet/ServletExternalContextImpl.java
@@ -741,6 +741,16 @@ public final class ServletExternalContextImpl extends ServletExternalContextImpl
         _httpServletResponse.setContentLength(length);
     }
 
+    /**
+     * @since 4.1
+     */
+    @Override
+    public void setResponseContentLengthLong(long length)
+    {
+        checkHttpServletResponse();
+        _httpServletResponse.setContentLengthLong(length);
+    }
+
     @Override
     public void setResponseContentType(String contentType)
     {


### PR DESCRIPTION
Missed in https://github.com/apache/myfaces/pull/617

Additionally, I don't see any mention of getters in the spec, so only the setter is implemented. 