### PR TITLE
Deprecate composite:extension

### DIFF
--- a/impl/src/main/java/org/apache/myfaces/view/facelets/tag/composite/ExtensionHandler.java
+++ b/impl/src/main/java/org/apache/myfaces/view/facelets/tag/composite/ExtensionHandler.java
@@ -30,12 +30,18 @@ import jakarta.faces.view.facelets.TagHandler;
 import org.apache.myfaces.buildtools.maven2.plugin.builder.annotation.JSFFaceletTag;
 
 /**
+ * This tag is deprecated since 4.1 with plans to remove it in Faces 5.0 
+ * 
+ * @deprecated Since 4.1 
  * @author Leonardo Uribe (latest modification by $Author$)
  * @version $Revision$ $Date$
  */
 @JSFFaceletTag(name="composite:extension")
 public class ExtensionHandler extends TagHandler
 {
+
+    // Log warning once rather than every time the page is accessed
+    private static boolean WARNING_LOGGED = false;
 
     private static final Logger log = Logger.getLogger(ExtensionHandler.class.getName());
     
@@ -47,6 +53,11 @@ public class ExtensionHandler extends TagHandler
     @Override
     public void apply(FaceletContext ctx, UIComponent parent) throws IOException
     {
+        if (log.isLoggable(Level.WARNING) && !WARNING_LOGGED)
+        {
+                log.warning("The tag composite:extension is deprecated as of 4.1.");
+                WARNING_LOGGED = true;
+        }
         // TODO: In theory the xml data inside this tag should be saved,
         // but the spec does not say where and how this should be done.
         // For now we just prevent execute any handler inside this tag.


### PR DESCRIPTION
TLDDocs are updated via the class comment and a warning is logged once. 