### PR TITLE
Fixed potential test failure due to nondeterminism in the order of elements in List used in _Delta2StateHelperTest.testAddItemOnList1

### DIFF
--- a/impl/src/test/java/jakarta/faces/component/_Delta2StateHelperTest.java
+++ b/impl/src/test/java/jakarta/faces/component/_Delta2StateHelperTest.java
@@ -20,7 +20,7 @@ package jakarta.faces.component;
 
 import java.util.List;
 import java.util.Map;
-
+import java.util.Collections;
 import jakarta.el.ValueExpression;
 import jakarta.faces.context.FacesContext;
 import jakarta.faces.event.PhaseEvent;
@@ -334,7 +334,7 @@ public class _Delta2StateHelperTest extends AbstractComponentTest
         Assertions.assertEquals("someValue3",listA.get(2));
         
         List listB = (List) helperB.get("somePropertyList");
-        
+        Collections.sort(listB);
         Assertions.assertEquals("someValue1",listB.get(0));
         Assertions.assertEquals("someValue2",listB.get(1));
         Assertions.assertEquals("someValue3",listB.get(2));


### PR DESCRIPTION
This pull request addresses the flakiness in the `_Delta2StateHelperTest.testAddItemOnList1` test by resolving the non-deterministic behavior identified using the NonDex tool. The root cause of the flakiness was the non-deterministic order of elements in `listB`, which is created after the `restoreState` method is called on `UITestComponent b`. The test can be found [here](https://github.com/apache/myfaces/blob/main/impl/src/test/java/jakarta/faces/component/_Delta2StateHelperTest.java).

- How was the non-deterministic behavior identified in the test?
The non-deterministic behavior in the test was identified by using an open-source research tool named [NonDex](https://github.com/TestingResearchIllinois/NonDex) which is responsible for finding and diagnosing non-deterministic runtime exceptions in Java programs.

- Why does the test fail?
The order of elements in list `listB` is not deterministic. The test assumes that the elements in the list will be `[someValue1, someValue2, someValue3]`. However, the order of elements in `listB` is shuffled sometimes, due to which the test fails some times.

- How I fixed the test?
I fixed the test by sorting `listB` before the assertions using `Collections.sort()`. 

- Output from NonDex:
```
[INFO] Running jakarta.faces.component._Delta2StateHelperTest
Dec 01, 2023 10:20:00 PM org.apache.myfaces.util.ExternalSpecifications lambda$static$1
INFO: MyFaces Core CDI support enabled
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.237 s <<< FAILURE! - in jakarta.faces.component._Delta2StateHelperTest
[ERROR] jakarta.faces.component._Delta2StateHelperTest.testAddItemOnList1  Time elapsed: 0.202 s  <<< FAILURE!
org.opentest4j.AssertionFailedError: expected: <someValue2> but was: <someValue3>
	at org.junit.jupiter.api.AssertionFailureBuilder.build(AssertionFailureBuilder.java:151)
	at org.junit.jupiter.api.AssertionFailureBuilder.buildAndThrow(AssertionFailureBuilder.java:132)
	at org.junit.jupiter.api.AssertEquals.failNotEqual(AssertEquals.java:197)
	at org.junit.jupiter.api.AssertEquals.assertEquals(AssertEquals.java:182)
	at org.junit.jupiter.api.AssertEquals.assertEquals(AssertEquals.java:177)
	at org.junit.jupiter.api.Assertions.assertEquals(Assertions.java:1142)
	at jakarta.faces.component._Delta2StateHelperTest.testAddItemOnList1(_Delta2StateHelperTest.java:341)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
	at org.junit.jupiter.engine.extension.TimeoutExtension.intercept(TimeoutExtension.java:156)
	at org.junit.jupiter.engine.extension.TimeoutExtension.interceptTestableMethod(TimeoutExtension.java:147)
	at org.junit.jupiter.engine.extension.TimeoutExtension.interceptTestMethod(TimeoutExtension.java:86)
	at org.junit.jupiter.engine.execution.InterceptingExecutableInvoker$ReflectiveInterceptorCall.lambda$ofVoidMethod$0(InterceptingExecutableInvoker.java:103)
	at org.junit.jupiter.engine.execution.InterceptingExecutableInvoker.lambda$invoke$0(InterceptingExecutableInvoker.java:93)
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$InterceptedInvocation.proceed(InvocationInterceptorChain.java:106)
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.proceed(InvocationInterceptorChain.java:64)
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.chainAndInvoke(InvocationInterceptorChain.java:45)
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.invoke(InvocationInterceptorChain.java:37)
	at org.junit.jupiter.engine.execution.InterceptingExecutableInvoker.invoke(InterceptingExecutableInvoker.java:92)
	at org.junit.jupiter.engine.execution.InterceptingExecutableInvoker.invoke(InterceptingExecutableInvoker.java:86)
	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.lambda$invokeTestMethod$7(TestMethodTestDescriptor.java:217)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.invokeTestMethod(TestMethodTestDescriptor.java:213)
	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.execute(TestMethodTestDescriptor.java:138)
	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.execute(TestMethodTestDescriptor.java:68)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$6(NodeTestTask.java:151)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:141)
	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:137)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$9(NodeTestTask.java:139)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:138)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:95)
	at org.junit.platform.engine.support.hierarchical.ForkJoinPoolHierarchicalTestExecutorService$ExclusiveTask.compute(ForkJoinPoolHierarchicalTestExecutorService.java:202)
	at org.junit.platform.engine.support.hierarchical.ForkJoinPoolHierarchicalTestExecutorService.invokeAll(ForkJoinPoolHierarchicalTestExecutorService.java:146)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$6(NodeTestTask.java:155)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:141)
	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:137)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$9(NodeTestTask.java:139)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:138)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:95)
	at org.junit.platform.engine.support.hierarchical.ForkJoinPoolHierarchicalTestExecutorService$ExclusiveTask.compute(ForkJoinPoolHierarchicalTestExecutorService.java:202)
	at org.junit.platform.engine.support.hierarchical.ForkJoinPoolHierarchicalTestExecutorService.invokeAll(ForkJoinPoolHierarchicalTestExecutorService.java:146)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$6(NodeTestTask.java:155)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:141)
	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:137)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$9(NodeTestTask.java:139)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:138)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:95)
	at org.junit.platform.engine.support.hierarchical.ForkJoinPoolHierarchicalTestExecutorService$ExclusiveTask.compute(ForkJoinPoolHierarchicalTestExecutorService.java:202)
	at java.base/java.util.concurrent.RecursiveAction.exec(RecursiveAction.java:189)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:290)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1020)
	at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1656)
	at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1594)
	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:183)

[INFO] 
[INFO] Results:
[INFO] 
[ERROR] Failures: 
[ERROR]   _Delta2StateHelperTest.testAddItemOnList1:341 expected: <someValue2> but was: <someValue3>
[INFO] 
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0
[INFO] 
INFO: Surefire failed when running tests for Uonzpfm2Rvzk+Ce42SB4BVCTLfl7HYfrtbieMeeGsw=
INFO: Adding excluded groups to newly created one
INFO: Adding NonDex argLine to existing argLine specified by the project
CONFIG: nondexFilter=.*
nondexMode=FULL
nondexSeed=974622
nondexStart=0
nondexEnd=9223372036854775807
nondexPrintstack=false
nondexDir=/home/shetty5/project/newtests/myfaces/impl/.nondex
nondexJarDir=/home/shetty5/project/newtests/myfaces/impl/.nondex
nondexExecid=QEB4R+co9HtaKw2jTDbiifaZpMEe89wogXE5PDOCL10=
nondexLogging=CONFIG
```

You can run the following command to run the test using the NonDex tool:

```
mvn edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=jakarta.faces.component._Delta2StateHelperTest#testAddItemOnList1
```

<br>
Test Environment:

```
java version 11.0.20.1
Apache Maven 3.6.3
```

Let me know if this fix is acceptable

Thank you!