### PR TITLE
Fix typo and log warning indicating jakarta.faces.FULL_STATE_SAVING_VIEW_ID is deprecated

### DIFF
--- a/impl/src/main/java/org/apache/myfaces/config/webparameters/MyfacesConfig.java
+++ b/impl/src/main/java/org/apache/myfaces/config/webparameters/MyfacesConfig.java
@@ -1215,12 +1215,19 @@ public class MyfacesConfig
         {
             Logger.getLogger(MyfacesConfig.class.getName()).warning(
                 "The configuration 'jakarta.faces.PARTIAL_STATE_SAVING' is deprecated " +
-                    "as of Faces 4.1 and should not longer be used.");
+                    "as of Faces 4.1");
         }
 
         cfg.fullStateSavingViewIds = StringUtils.splitShortString(
                 getString(extCtx, StateManager.FULL_STATE_SAVING_VIEW_IDS_PARAM_NAME, null),
                 ',');
+
+        if (cfg.fullStateSavingViewIds.length > 0)
+        {
+            Logger.getLogger(MyfacesConfig.class.getName()).warning(
+                "The configuration 'jakarta.faces.FULL_STATE_SAVING_VIEW_IDS' is deprecated " +
+                    "as of Faces 4.1");
+        }
         
         cfg.faceletsBufferSize = getInt(extCtx, ViewHandler.FACELETS_BUFFER_SIZE_PARAM_NAME,
                 1024);


### PR DESCRIPTION
The following warnings are logged when the context parameters are used:

```
[WARNING ] The configuration 'jakarta.faces.PARTIAL_STATE_SAVING' is deprecated as of Faces 4.1
[WARNING ] The configuration 'jakarta.faces.FULL_STATE_SAVING_VIEW_IDS' is deprecated as of Faces 4.1
```

Once approved, I'll update main (5.0) directly.