### PR TITLE
Fix up rowStatePreserved in UIRepeat

### DIFF
--- a/impl/src/main/java/org/apache/myfaces/view/facelets/component/UIRepeat.java
+++ b/impl/src/main/java/org/apache/myfaces/view/facelets/component/UIRepeat.java
@@ -2027,7 +2027,7 @@ public class UIRepeat extends UIComponentBase implements NamingContainer
             if (context.getCurrentPhaseId() != null && 
                 !PhaseId.RENDER_RESPONSE.equals(context.getCurrentPhaseId()))
             {
-                if (parentSaved == null /*&&_rowDeltaStates.isEmpty()*/ && _rowStates.isEmpty())
+                if (parentSaved == null &&_rowDeltaStates.isEmpty() && _rowStates.isEmpty())
                 {
                     return null;
                 }
@@ -2061,17 +2061,18 @@ public class UIRepeat extends UIComponentBase implements NamingContainer
             if (context.getCurrentPhaseId() != null && 
                 !PhaseId.RENDER_RESPONSE.equals(context.getCurrentPhaseId()))
             {
-                Object[] values = new Object[3];
+                Object[] values = new Object[4];
                 values[0] = super.saveState(context);
-                values[1] = null;
+                values[1] = UIComponentBase.saveAttachedState(context, _rowDeltaStates);
                 values[2] = UIComponentBase.saveAttachedState(context, _rowStates);
+                values[3] = UIComponentBase.saveAttachedState(context, _rowTransientStates);
                 return values; 
             }
             else
             {
                 Object[] values = new Object[2];
                 values[0] = super.saveState(context);
-                values[1] = null;
+                values[1] = UIComponentBase.saveAttachedState(context, _rowDeltaStates);
                 return values;
             }
         }


### PR DESCRIPTION
Discovered via TCK testing.

The saveState method wasn't property updated, but it's fixed now.  I used UIData as a reference. 

I added a test case previously, but the TCK is a bit more thorough ( nested ui reeats). 

https://issues.apache.org/jira/browse/MYFACES-4664