### PR TITLE
5.0: Quarkus RepeatStatus reflection

### DIFF
--- a/extensions/quarkus/deployment/src/main/java/org/apache/myfaces/core/extensions/quarkus/deployment/MyFacesProcessor.java
+++ b/extensions/quarkus/deployment/src/main/java/org/apache/myfaces/core/extensions/quarkus/deployment/MyFacesProcessor.java
@@ -111,6 +111,7 @@ import org.apache.myfaces.util.lang.ThreadsafeXorShiftRandom;
 import org.apache.myfaces.view.ViewScopeProxyMap;
 import org.apache.myfaces.view.facelets.compiler.SAXCompiler;
 import org.apache.myfaces.view.facelets.compiler.TagLibraryConfig;
+import org.apache.myfaces.view.facelets.component.RepeatStatus;
 import org.apache.myfaces.view.facelets.tag.LambdaMetadataTargetImpl;
 import org.apache.myfaces.view.facelets.tag.MethodRule;
 import org.apache.myfaces.view.facelets.tag.faces.ComponentSupport;
@@ -560,7 +561,8 @@ class MyFacesProcessor
                 FacesInitializerImpl.class,
                 FactoryFinderProviderFactory.class,
                 JstlFunction.class,
-                QuarkusFactoryFinderProvider.class));
+                QuarkusFactoryFinderProvider.class,
+                RepeatStatus.class));
 
         reflectiveClass.produce(
                 ReflectiveClassBuildItem.builder(classNames.toArray(new String[0])).methods(true).build());


### PR DESCRIPTION
5.0: Quarkus RepeatStatus reflection, 3.8.4 LTS

This needs to be a reflected as its a POJO and if you reference it in EL for index it fails in Native mode