### PR TITLE
MYFACES-4660 view destroying fix + keeping track of user connection in multiple tabs

### DIFF
--- a/impl/src/main/java/org/apache/myfaces/push/cdi/WebsocketScopeManager.java
+++ b/impl/src/main/java/org/apache/myfaces/push/cdi/WebsocketScopeManager.java
@@ -161,26 +161,12 @@ public class WebsocketScopeManager
         @Inject private WebsocketScopeManager scopeManager;
         @Inject private WebsocketSessionManager sessionManager;
         
-        /*
-         * If the view is discarded, destroy the websocket sessions associated with the view because they are no
-         * longer valid
-         */
         @PreDestroy
         public void destroy()
         {
-            // destroy parent scope ("session")
-            SessionScope sessionScope = (SessionScope) scopeManager.getScope(SCOPE_SESSION, false);
-            if (sessionScope != null)
-            {
-                for (String token : tokens.keySet())
-                {
-                    sessionScope.destroyChannelToken(token);
-                }
-            }
-
             channelTokens.clear();
             tokens.clear();
-       }
+        }
     }
     
     


### PR DESCRIPTION
1/ when the view is destroyed (i.e. the user reaches the NUMBER_OF_VIEWS_IN_SESSION limit), sessionScope channels are not destroyed. Channel could still be active for other views or newly created ones. In other words, session-scoped channels only get destroyed when the entire session is destroyed.

2/ we have to track number of user channelToken usage connections (when the user is using same channelToken in multiple browser windows / tabs with same http session, the channelToken remains same), and we can't close this channel until all user connections to this channel are closed (all tabs/windows).