### PR TITLE
MYFACES-4666: Overload simpleClassForName -- new param to log exception only

### DIFF
--- a/api/src/main/java/org/apache/myfaces/core/api/shared/lang/ClassUtils.java
+++ b/api/src/main/java/org/apache/myfaces/core/api/shared/lang/ClassUtils.java
@@ -163,14 +163,15 @@ public class ClassUtils
 
     /**
      * Same as {link {@link #simpleClassForName(String)}, but will only
-     * log the exception and rethrow a RunTimeException if logException is true.
+     * log the exception and rethrow a RunTimeException if logAndThrowException is true.
      *
      * @param type
-     * @param logException - true to log/throw FacesException, false to avoid logging/throwing FacesException
+     * @param logAndThrowException - true to log and throw FacesException, false to avoid logging and throwing 
+     *  the FacesException
      * @return the corresponding Class
-     * @throws FacesException if class not found and logException is true
+     * @throws FacesException if class not found and logAndThrowException is true
      */
-    public static Class simpleClassForName(String type, boolean logException)
+    public static Class simpleClassForName(String type, boolean logAndThrowException)
     {
         Class returnClass = null;
         try
@@ -179,7 +180,7 @@ public class ClassUtils
         }
         catch (ClassNotFoundException e)
         {
-            if (logException)
+            if (logAndThrowException)
             {
                 log.log(Level.SEVERE, "Class " + type + " not found", e);
                 throw new FacesException(e);
@@ -187,6 +188,38 @@ public class ClassUtils
         }
         return returnClass;
     }
+
+    /**
+     * Same as {link {@link #simpleClassForName(String)}, but accepts two booleans
+     * One to log an exception and another to rethrow a FacesExceptions
+     *
+     * @param type
+     * @param logException - true to log the ClassNotFoundException, false to avoid logging
+     * @param throwException - true to throw a FacesException, false to avoid throwing a FacesException
+     * @return the corresponding Class
+     * @throws FacesException if class not found and throwException is true
+     */
+    public static Class simpleClassForName(String type, boolean throwException, boolean logException)
+    {
+        Class returnClass = null;
+        try
+        {
+            returnClass = classForName(type);
+        }
+        catch (ClassNotFoundException e)
+        {
+            if(logException)
+            {
+                log.log(Level.SEVERE, "Class " + type + " not found", e);
+            }
+            if (throwException)
+            {
+                throw new FacesException(e);
+            }
+        }
+        return returnClass;
+    }
+
 
     /**
      * Similar as {@link #classForName(String)}, but also supports primitive types and arrays as specified for the

--- a/impl/src/main/java/org/apache/myfaces/application/FacesServletMappingUtils.java
+++ b/impl/src/main/java/org/apache/myfaces/application/FacesServletMappingUtils.java
@@ -174,7 +174,7 @@ public class FacesServletMappingUtils
             return true;
         }
 
-        Class servletClass = ClassUtils.simpleClassForName(servletClassName, true);
+        Class servletClass = ClassUtils.simpleClassForName(servletClassName, false, true);
         if (servletClass != null)
         {
             return FacesServlet.class.isAssignableFrom(servletClass);

--- a/impl/src/main/java/org/apache/myfaces/util/lang/ClassUtils.java
+++ b/impl/src/main/java/org/apache/myfaces/util/lang/ClassUtils.java
@@ -241,16 +241,17 @@ public final class ClassUtils extends org.apache.myfaces.core.api.shared.lang.Cl
 
     /**
      * Same as {link {@link #simpleClassForName(String)}, but will only
-     * log the exception and rethrow a RunTimeException if logException is true.
+     * log the exception and rethrow a RunTimeException if logAndThrowException is true.
      *
      * @param type
-     * @param logException - true to log/throw FacesException, false to avoid logging/throwing FacesException
+     * @param logAndThrowException - true to log and throw FacesException, false to avoid logging and throwing 
+     *  the FacesException
      * @return the corresponding Class
-     * @throws FacesException if class not found and logException is true
+     * @throws FacesException if class not found and logAndThrowException is true
      */
     // @Override MYFACES-4449: Methods that call ClassUtils.class.getClassLoader() need to be here
     //           as well as in the API ClassUtils so that the correct ClassLoader is used.
-    public static Class simpleClassForName(String type, boolean logException)
+    public static Class simpleClassForName(String type, boolean logAndThrowException)
     {
         Class returnClass = null;
         try
@@ -259,9 +260,42 @@ public final class ClassUtils extends org.apache.myfaces.core.api.shared.lang.Cl
         }
         catch (ClassNotFoundException e)
         {
-            if (logException)
+            if (logAndThrowException)
             {
                 log.log(Level.SEVERE, "Class " + type + " not found", e);
+                throw new FacesException(e);
+            }
+        }
+        return returnClass;
+    }
+
+    /**
+     * Same as {link {@link #simpleClassForName(String)}, but accepts two booleans
+     * One to log an exception and another to rethrow a FacesExceptions
+     *
+     * @param type
+     * @param logException - true to log the ClassNotFoundException, false to avoid logging
+     * @param throwException - true to throw a FacesException, false to avoid throwing a FacesException
+     * @return the corresponding Class
+     * @throws FacesException if class not found and throwException is true
+     */
+    // @Override MYFACES-4449: Methods that call ClassUtils.class.getClassLoader() need to be here
+    //           as well as in the API ClassUtils so that the correct ClassLoader is used.
+    public static Class simpleClassForName(String type, boolean throwException, boolean logException)
+    {
+        Class returnClass = null;
+        try
+        {
+            returnClass = classForName(type);
+        }
+        catch (ClassNotFoundException e)
+        {
+            if(logException)
+            {
+                log.log(Level.SEVERE, "Class " + type + " not found", e);
+            }
+            if (throwException)
+            {
                 throw new FacesException(e);
             }
         }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/MYFACES-4666

By throwing the faces exception, this logic causes apps to fail during start-up. In our scenario, it happens to the servlet TCK app, as reported in this challenge : `https://github.com/jakartaee/servlet/issues/691` 

This PR tries to find a balance between allowing the app to start up while also alerting the user of the non-existent servlet class. 

The git diff is a bit wonky -- the new simpleClassForName method is the second one, not the first as git shows. 
