### PR TITLE
Revert MYFACES-4676 due to TCK failures

### DIFF
--- a/api/src/client/typescript/faces/impl/core/Const.ts
+++ b/api/src/client/typescript/faces/impl/core/Const.ts
@@ -90,7 +90,7 @@ export const RESPONSE_TEXT = "responseText";
 export const RESPONSE_XML = "responseXML";
 
 /*ajax errors spec 14.4.2*/
-export const HTTP_ERROR = "httpError";
+export const HTTPERROR = "httpError";
 export const EMPTY_RESPONSE = "emptyResponse";
 export const MALFORMEDXML = "malformedXML";
 export const SERVER_ERROR = "serverError";

--- a/api/src/client/typescript/faces/test/xhrCore/EventTests.spec.ts
+++ b/api/src/client/typescript/faces/test/xhrCore/EventTests.spec.ts
@@ -111,7 +111,7 @@ describe('tests the addOnEvent and addOnError handling', function () {
             expect(onErrorCalled1).to.eq(1);
             expect(onErrorCalled2).to.eq(1);
             expect(errorTitle).to.eq('Erro21');
-            expect(errorMessage).to.eq('Error2 Text');
+            expect(errorMessage).to.eq('serverError: Error2 Text');
         } finally {
             console.error = oldErr;
         }

--- a/api/src/client/typescript/faces/test/xhrCore/RequestTest.spec.ts
+++ b/api/src/client/typescript/faces/test/xhrCore/RequestTest.spec.ts
@@ -501,9 +501,9 @@ describe('Tests after core when it hits response', function () {
                 },
                 onerror: (error: any) => {
                     expect(error.type).to.eq("error");
-                    expect(error.status).to.eq(null);
-                    expect(!!error.errorMessage).to.eq(true);
-                    expect(!!error.source).to.eq(true);
+                    expect(error.status).to.eq(EMPTY_STR);
+                    expect(!!error.message).to.eq(true);
+                    expect(!!error.source?.id).to.eq(true);
                     expect(!!error.responseCode).to.eq(true);
                     expect(!!error.responseText).to.eq(true);
                     expect(!error.responseXML).to.eq(true);

--- a/api/src/client/typescript/faces/test/xhrCore/RequestTest_23.spec.ts
+++ b/api/src/client/typescript/faces/test/xhrCore/RequestTest_23.spec.ts
@@ -334,9 +334,9 @@ describe('Tests after core when it hits response', function () {
                 pass2: "pass2",
                 onerror: (error: any) => {
                     expect(error.type).to.eq("error");
-                    expect(error.status).to.eq(null);
-                    expect(!!error.errorMessage).to.eq(true);
-                    expect(!!error.source).to.eq(true);
+                    expect(error.status).to.eq(EMPTY_STR);
+                    expect(!!error.message).to.eq(true);
+                    expect(!!error.source.id).to.eq(true);
                     expect(!!error.responseCode).to.eq(true);
                     expect(!!error.responseText).to.eq(true);
                     expect(!error.responseXML).to.eq(true);

--- a/api/src/client/typescript/faces/test/xhrCore/ResponseTest.spec.ts
+++ b/api/src/client/typescript/faces/test/xhrCore/ResponseTest.spec.ts
@@ -739,8 +739,8 @@ describe('Tests of the various aspects of the response protocol functionality', 
             let errorCalled = 0;
             faces.ajax.addOnError((error) => {
                 expect(error.errorName).to.eq("jakarta.faces.application.ViewExpiredException");
-                expect(error.errorMessage).to.eq("View \"/testhmtl.xhtml\" could not be restored.");
-                expect(error.source).to.eq("form1x:button");
+                expect(error.errorMessage).to.eq("serverError: View \"/testhmtl.xhtml\" could not be restored.");
+                expect(error.source.id).to.eq("form1x:button");
                 errorCalled++;
             });
 


### PR DESCRIPTION
Reverts change for https://issues.apache.org/jira/projects/MYFACES/issues/MYFACES-4676

Taken from comment in JIRA above:
```
I think this is causing 3 new errors in the TCK:   (linked the 4.1.0 TCK but I tested 4.0 code)
_____
Name: undefined Error:  decode: A RuntimeException Has Occurred!

http://localhost:9080/test-faces22-ajax/issue2179-page2.xhtml

https://github.com/jakartaee/faces/blob/4.1.0-RELEASE/tck/faces22/ajax/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_selenium/Issue2179IT.java#L49

____

Error from undefined 

http://localhost:9080/test-faces22-ajax/ajaxScriptError.xhtml

https://github.com/jakartaee/faces/blob/4.1.0-RELEASE/tck/faces22/ajax/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_selenium/Issue3473IT.java#L35

 ____

Error from undefined 

http://localhost:9080/test-faces22-ajax/exceptionDuringRender.xhtml 

https://github.com/jakartaee/faces/blob/4.1.0-RELEASE/tck/faces22/ajax/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_selenium/Issue3171IT.java#L35

````