### PR TITLE
MYFACES-4692: provide default implementations for getActionExpression and setActionExpression

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -138,6 +138,9 @@
                 <artifactId>myfaces-builder-plugin</artifactId>
                 <executions>
                     <execution>
+                        <configuration>
+                            <excludes>**/src/main/java/jakarta/faces/component/ActionSource.java</excludes>
+                        </configuration>
                         <goals>
                             <goal>build-metadata</goal>
                         </goals>
@@ -147,6 +150,7 @@
                         <configuration>
                             <jsfVersion>20</jsfVersion>
                             <templateComponentName>componentClass20.vm</templateComponentName>
+                            <excludes>**/src/main/java/jakarta/faces/component/ActionSource.java</excludes>
                         </configuration>
                         <goals>
                             <goal>make-components</goal>

--- a/api/src/main/java/jakarta/faces/component/ActionSource.java
+++ b/api/src/main/java/jakarta/faces/component/ActionSource.java
@@ -35,7 +35,13 @@ public interface ActionSource
 
     public void removeActionListener(jakarta.faces.event.ActionListener listener);
 
-    public MethodExpression getActionExpression();
+    default MethodExpression getActionExpression()
+    {
+        throw new UnsupportedOperationException();
+    }
 
-    public void setActionExpression(MethodExpression action);
+    default void setActionExpression(MethodExpression action)
+    {
+        throw new UnsupportedOperationException();
+    }
 }

--- a/api/src/main/java/jakarta/faces/component/ActionSource2.java
+++ b/api/src/main/java/jakarta/faces/component/ActionSource2.java
@@ -19,11 +19,15 @@
 
 package jakarta.faces.component;
 
+import jakarta.el.MethodExpression;
+
 /**
  * See Javadoc of <a href="http://java.sun.com/javaee/javaserverfaces/1.2/docs/api/index.html">Faces Specification</a>
  */
 @Deprecated(since = "4.1", forRemoval = true)
 public interface ActionSource2 extends ActionSource
 {
+    MethodExpression getActionExpression();
 
+    void setActionExpression(MethodExpression action);
 }

--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -169,6 +169,7 @@
                         <configuration>
                             <jsfVersion>20</jsfVersion>
                             <templateComponentName>componentClass20.vm</templateComponentName>
+                            <excludes>**/package.html</excludes>
                         </configuration>
                         <goals>
                             <goal>make-components</goal>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -180,7 +180,7 @@
                 <plugin>
                     <groupId>org.apache.myfaces.buildtools</groupId>
                     <artifactId>myfaces-builder-plugin</artifactId>
-                    <version>1.0.11</version>
+                    <version>1.0.12</version>
                 </plugin>
 
                 <plugin>


### PR DESCRIPTION
https://issues.apache.org/jira/browse/MYFACES-4692


Code looks right, but I'm getting a build error: 

`
[ERROR] Failed to execute goal org.apache.myfaces.buildtools:myfaces-builder-plugin:1.0.11:build-metadata (default) on project myfaces-api: Execution default of goal org.apache.myfaces.buildtools:myfaces-builder-plugin:1.0.11:build-metadata failed: syntax error @[48,1] in file: myfaces/api/src/main/java/jakarta/faces/component/ActionSource.java -> [Help 1]
`