### PR TITLE
MYFACES-4654: Support Schema Validation for 4.1

### DIFF
--- a/extensions/quarkus/deployment/src/main/java/org/apache/myfaces/core/extensions/quarkus/deployment/MyFacesProcessor.java
+++ b/extensions/quarkus/deployment/src/main/java/org/apache/myfaces/core/extensions/quarkus/deployment/MyFacesProcessor.java
@@ -623,7 +623,9 @@ class MyFacesProcessor
                 "org/apache/myfaces/resource/javaee_5.xsd",
                 "org/apache/myfaces/resource/jakartaee_9.xsd",
                 "org/apache/myfaces/resource/jakartaee_10.xsd",
+                "org/apache/myfaces/resource/jakartaee_11.xsd",
                 "org/apache/myfaces/resource/web-facelettaglibrary_2_0.xsd",
+                "org/apache/myfaces/resource/web-facelettaglibrary_4_1.xsd",
                 "org/apache/myfaces/resource/XMLSchema.dtd",
                 "org/apache/myfaces/resource/facesconfig_1_0.dtd",
                 "org/apache/myfaces/resource/web-facesconfig_1_1.dtd",
@@ -634,6 +636,7 @@ class MyFacesProcessor
                 "org/apache/myfaces/resource/web-facesconfig_2_3.dtd",
                 "org/apache/myfaces/resource/web-facesconfig_3_0.dtd",
                 "org/apache/myfaces/resource/web-facesconfig_4_0.dtd",
+                "org/apache/myfaces/resource/web-facesconfig_4_1.dtd",
                 "org/apache/myfaces/resource/xml.xsd"));
 
         resourceBundleBuildItem.produce(new NativeImageResourceBundleBuildItem("jakarta.faces.Messages"));

--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -92,6 +92,9 @@
                         -->
                         <exclude>src/main/resources/org/apache/myfaces/resource/javaee_5.xsd</exclude>
                         <exclude>src/main/resources/org/apache/myfaces/resource/javaee_web_services_client_1_2.xsd</exclude>
+                        <exclude>src/main/resources/org/apache/myfaces/resource/jakartaee_11.xsd</exclude>
+                        <exclude>src/main/resources/org/apache/myfaces/resource/web-facesconfig_4_1.xsd</exclude>
+                        <exclude>src/main/resources/org/apache/myfaces/resource/web-facelettaglibrary_4_1.xsd</exclude>
 
                         <!-- This file probably needs a license, but I don't know if it's safe to put it in there -->
                         <exclude>src/test/resources/org/apache/myfaces/context/nestedScriptCDATA.xml</exclude>

--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -95,6 +95,7 @@
                         <exclude>src/main/resources/org/apache/myfaces/resource/jakartaee_11.xsd</exclude>
                         <exclude>src/main/resources/org/apache/myfaces/resource/web-facesconfig_4_1.xsd</exclude>
                         <exclude>src/main/resources/org/apache/myfaces/resource/web-facelettaglibrary_4_1.xsd</exclude>
+                        <exclude>src/main/resources/org/apache/myfaces/resource/jakartaee_web_services_client_2_0.xsd</exclude>
 
                         <!-- This file probably needs a license, but I don't know if it's safe to put it in there -->
                         <exclude>src/test/resources/org/apache/myfaces/context/nestedScriptCDATA.xml</exclude>

--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -96,6 +96,12 @@
                         <exclude>src/main/resources/org/apache/myfaces/resource/web-facesconfig_4_1.xsd</exclude>
                         <exclude>src/main/resources/org/apache/myfaces/resource/web-facelettaglibrary_4_1.xsd</exclude>
                         <exclude>src/main/resources/org/apache/myfaces/resource/jakartaee_web_services_client_2_0.xsd</exclude>
+                        <exclude>src/main/resources/org/apache/myfaces/resource/javaee_8.xsd</exclude>
+                        <exclude>src/main/resources/org/apache/myfaces/resource/web-facelettaglibrary_3_0.xsd</exclude>
+                        <exclude>src/main/resources/org/apache/myfaces/resource/web-facelettaglibrary_4_0.xsd</exclude>
+                        <exclude>src/main/resources/org/apache/myfaces/resource/web-facelettaglibrary_2_3.xsd</exclude>
+                        <exclude>src/main/resources/org/apache/myfaces/resource/javaee_web_services_client_1_4.xsd</exclude>
+                        <exclude>src/main/resources/org/apache/myfaces/resource/web-facelettaglibrary_2_2.xsd</exclude>
 
                         <!-- This file probably needs a license, but I don't know if it's safe to put it in there -->
                         <exclude>src/test/resources/org/apache/myfaces/context/nestedScriptCDATA.xml</exclude>

--- a/impl/src/main/conf/META-INF/standard-faces-config-base.xml
+++ b/impl/src/main/conf/META-INF/standard-faces-config-base.xml
@@ -19,10 +19,10 @@
  * under the License.
 -->
 
-<faces-config xmlns="http://java.sun.com/xml/ns/javaee" 
-              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
-              xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-facesconfig_2_0.xsd" 
-              version="2.0">
+<faces-config xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+   xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-facesconfig_2_3.xsd"
+   version="2.3">
 
    <!-- Initial application element with partial values -->
 

--- a/impl/src/main/java/org/apache/myfaces/config/ConfigFilesXmlValidationUtils.java
+++ b/impl/src/main/java/org/apache/myfaces/config/ConfigFilesXmlValidationUtils.java
@@ -60,7 +60,10 @@ public class ConfigFilesXmlValidationUtils
     private final static String FACES_CONFIG_SCHEMA_PATH_23 = "org/apache/myfaces/resource/web-facesconfig_2_3.xsd";
     private final static String FACES_CONFIG_SCHEMA_PATH_30 = "org/apache/myfaces/resource/web-facesconfig_3_0.xsd";
     private final static String FACES_CONFIG_SCHEMA_PATH_40 = "org/apache/myfaces/resource/web-facesconfig_4_0.xsd";
-    private final static String FACES_TAGLIB_SCHEMA_PATH = "org/apache/myfaces/resource/web-facelettaglibrary_2_0.xsd";
+    private final static String FACES_TAGLIB_SCHEMA_PATH_20 = 
+                                                        "org/apache/myfaces/resource/web-facelettaglibrary_2_0.xsd";
+    private final static String FACES_TAGLIB_SCHEMA_PATH_41 = 
+                                                        "org/apache/myfaces/resource/web-facelettaglibrary_4_1.xsd";
 
     public static class LSInputImpl implements LSInput
     {
@@ -211,6 +214,11 @@ public class ConfigFilesXmlValidationUtils
                      return new LSInputImpl(publicId, systemId, baseURI,
                              ClassUtils.getResourceAsStream("org/apache/myfaces/resource/jakartaee_10.xsd"));
                  }
+                 if ("jakartaee_11.xsd".equals(systemId))
+                 {
+                     return new LSInputImpl(publicId, systemId, baseURI,
+                             ClassUtils.getResourceAsStream("org/apache/myfaces/resource/jakartaee_11.xsd"));
+                 }
              }
             if ("http://www.w3.org/XML/1998/namespace".equals(namespaceURI))
             {
@@ -297,7 +305,7 @@ public class ConfigFilesXmlValidationUtils
 
     public static final String getFacesConfigVersion(URL url)
     {
-        String result = "4.0";
+        String result = "4.1";
 
         try
         {
@@ -368,9 +376,13 @@ public class ConfigFilesXmlValidationUtils
             {
                 return "3.0";
             }
-            else if (handler.isVersion40OrLater())
+            else if (handler.isVersion40())
             {
                 return "4.0";
+            }
+            else if (handler.isVersion41OrLater())
+            {
+                return "4.1";
             }
         }
         catch (Throwable e)
@@ -390,7 +402,8 @@ public class ConfigFilesXmlValidationUtils
         private boolean version22;
         private boolean version23;
         private boolean version30;
-        private boolean version40OrLater;
+        private boolean version40;
+        private boolean version41OrLater;
 
         public boolean isVersion11()
         {
@@ -427,9 +440,14 @@ public class ConfigFilesXmlValidationUtils
             return this.version30;
         }
 
-        public boolean isVersion40OrLater()
+        public boolean isVersion40()
         {
-            return this.version40OrLater;
+            return this.version40;
+        }
+
+        public boolean isVersion41OrLater()
+        {
+            return this.version41OrLater;
         }
 
         protected void reset()
@@ -441,7 +459,8 @@ public class ConfigFilesXmlValidationUtils
             this.version22 = false;
             this.version23 = false;
             this.version30 = false;
-            this.version40OrLater = false;
+            this.version40 = false;
+            this.version41OrLater = false;
         }
 
         @Override
@@ -495,10 +514,15 @@ public class ConfigFilesXmlValidationUtils
                             reset();
                             this.version30 = true;
                         }
+                        else if (attributes.getValue(i).equals("4.0"))
+                        {
+                            reset();
+                            this.version40 = true;
+                        }
                         else
                         {
                             reset();
-                            this.version40OrLater = true;
+                            this.version41OrLater = true;
                         }
                     }
                 }
@@ -532,11 +556,11 @@ public class ConfigFilesXmlValidationUtils
 
     private static Source getFaceletSchemaFileAsSource(ExternalContext externalContext)
     {
-        InputStream stream = ClassUtils.getResourceAsStream(FACES_TAGLIB_SCHEMA_PATH);
+        InputStream stream = ClassUtils.getResourceAsStream(FACES_TAGLIB_SCHEMA_PATH_41);
 
         if (stream == null)
         {
-           stream = externalContext.getResourceAsStream(FACES_TAGLIB_SCHEMA_PATH);
+           stream = externalContext.getResourceAsStream(FACES_TAGLIB_SCHEMA_PATH_41);
         }
 
         if (stream == null)

--- a/impl/src/main/java/org/apache/myfaces/config/ConfigFilesXmlValidationUtils.java
+++ b/impl/src/main/java/org/apache/myfaces/config/ConfigFilesXmlValidationUtils.java
@@ -60,6 +60,7 @@ public class ConfigFilesXmlValidationUtils
     private final static String FACES_CONFIG_SCHEMA_PATH_23 = "org/apache/myfaces/resource/web-facesconfig_2_3.xsd";
     private final static String FACES_CONFIG_SCHEMA_PATH_30 = "org/apache/myfaces/resource/web-facesconfig_3_0.xsd";
     private final static String FACES_CONFIG_SCHEMA_PATH_40 = "org/apache/myfaces/resource/web-facesconfig_4_0.xsd";
+    private final static String FACES_CONFIG_SCHEMA_PATH_41 = "org/apache/myfaces/resource/web-facesconfig_4_1.xsd";
     private final static String FACES_TAGLIB_SCHEMA_PATH_20 = 
                                                         "org/apache/myfaces/resource/web-facelettaglibrary_2_0.xsd";
     private final static String FACES_TAGLIB_SCHEMA_PATH_41 = 
@@ -219,12 +220,19 @@ public class ConfigFilesXmlValidationUtils
                      return new LSInputImpl(publicId, systemId, baseURI,
                              ClassUtils.getResourceAsStream("org/apache/myfaces/resource/jakartaee_11.xsd"));
                  }
+                 if ("jakartaee_web_services_client_2_0.xsd".equals(systemId))
+                 {
+                    String location = "org/apache/myfaces/resource/jakartaee_web_services_client_2_0.xsd";
+                    return new LSInputImpl(publicId, systemId, baseURI,
+                            ClassUtils.getResourceAsStream(location));
+                 }
              }
             if ("http://www.w3.org/XML/1998/namespace".equals(namespaceURI))
             {
                 return new LSInputImpl(publicId, systemId, baseURI,
                         ClassUtils.getResourceAsStream("org/apache/myfaces/resource/xml.xsd"));
             }
+            
             return null;
         }
 
@@ -286,7 +294,8 @@ public class ConfigFilesXmlValidationUtils
                             : ("2.1".equals(version) ? FACES_CONFIG_SCHEMA_PATH_21
                             : ("2.2".equals(version) ? FACES_CONFIG_SCHEMA_PATH_22
                             : ("2.3".equals(version) ? FACES_CONFIG_SCHEMA_PATH_23
-                            : ("3.0".equals(version) ? FACES_CONFIG_SCHEMA_PATH_30 : FACES_CONFIG_SCHEMA_PATH_40)))));
+                            : ("3.0".equals(version) ? FACES_CONFIG_SCHEMA_PATH_30
+                            : ("4.0".equals(version) ? FACES_CONFIG_SCHEMA_PATH_40 : FACES_CONFIG_SCHEMA_PATH_41))))));
 
         InputStream stream = ClassUtils.getResourceAsStream(xmlSchema);
 

--- a/impl/src/main/java/org/apache/myfaces/config/ConfigFilesXmlValidationUtils.java
+++ b/impl/src/main/java/org/apache/myfaces/config/ConfigFilesXmlValidationUtils.java
@@ -64,6 +64,14 @@ public class ConfigFilesXmlValidationUtils
     private final static String FACES_CONFIG_SCHEMA_PATH_41 = "org/apache/myfaces/resource/web-facesconfig_4_1.xsd";
     private final static String FACES_TAGLIB_SCHEMA_PATH_20 = 
                                                         "org/apache/myfaces/resource/web-facelettaglibrary_2_0.xsd";
+    private final static String FACES_TAGLIB_SCHEMA_PATH_22 = 
+                                                        "org/apache/myfaces/resource/web-facelettaglibrary_2_2.xsd";
+    private final static String FACES_TAGLIB_SCHEMA_PATH_23 = 
+                                                        "org/apache/myfaces/resource/web-facelettaglibrary_2_3.xsd";
+    private final static String FACES_TAGLIB_SCHEMA_PATH_30 = 
+                                                        "org/apache/myfaces/resource/web-facelettaglibrary_3_0.xsd";
+    private final static String FACES_TAGLIB_SCHEMA_PATH_40 = 
+                                                        "org/apache/myfaces/resource/web-facelettaglibrary_4_0.xsd";
     private final static String FACES_TAGLIB_SCHEMA_PATH_41 = 
                                                         "org/apache/myfaces/resource/web-facelettaglibrary_4_1.xsd";
 
@@ -203,6 +211,18 @@ public class ConfigFilesXmlValidationUtils
                      return new LSInputImpl(publicId, systemId, baseURI,
                              ClassUtils.getResourceAsStream("org/apache/myfaces/resource/javaee_7.xsd"));
                  }
+                 if ("javaee_8.xsd".equals(systemId))
+                 {
+                     return new LSInputImpl(publicId, systemId, baseURI,
+                             ClassUtils.getResourceAsStream("org/apache/myfaces/resource/javaee_8.xsd"));
+                 }
+                 if ("javaee_web_services_client_1_4.xsd".equals(systemId))
+                 {
+                    String location = "org/apache/myfaces/resource/javaee_web_services_client_1_4.xsd";
+                    return new LSInputImpl(publicId, systemId, baseURI,
+                            ClassUtils.getResourceAsStream(location));
+                 }
+
              }
              if ("https://jakarta.ee/xml/ns/jakartaee".equals(namespaceURI))
              {
@@ -572,7 +592,23 @@ public class ConfigFilesXmlValidationUtils
         {
             tagLibraryPath = FACES_TAGLIB_SCHEMA_PATH_41;
         } 
-        else 
+        else if(version == 4.0)
+        {
+            tagLibraryPath = FACES_TAGLIB_SCHEMA_PATH_40;
+        }
+        else if(version == 3.0)
+        {
+            tagLibraryPath = FACES_TAGLIB_SCHEMA_PATH_30;
+        }
+        else if(version == 2.3)
+        {
+            tagLibraryPath = FACES_TAGLIB_SCHEMA_PATH_23;
+        }
+        else if(version == 2.2)
+        {
+            tagLibraryPath = FACES_TAGLIB_SCHEMA_PATH_22;
+        }
+        else
         {
             tagLibraryPath = FACES_TAGLIB_SCHEMA_PATH_20;
         }
@@ -588,8 +624,6 @@ public class ConfigFilesXmlValidationUtils
         {
             return null;
         }
-
-        System.out.println("USING: "  + tagLibraryPath);
 
         return new StreamSource(stream);
     }

--- a/impl/src/main/java/org/apache/myfaces/config/DefaultFacesConfigurationProvider.java
+++ b/impl/src/main/java/org/apache/myfaces/config/DefaultFacesConfigurationProvider.java
@@ -453,7 +453,8 @@ public class DefaultFacesConfigurationProvider extends FacesConfigurationProvide
     {
         String version = ConfigFilesXmlValidationUtils.getFacesConfigVersion(url);
         if ("1.2".equals(version) || "2.0".equals(version) || "2.1".equals(version) 
-            || "2.2".equals(version) || "2.3".equals(version))
+            || "2.2".equals(version) || "2.3".equals(version) || "3.0".equals(version)
+            || "4.0".equals(version) || "4.1".equals(version))
         {
             ConfigFilesXmlValidationUtils.validateFacesConfigFile(url, ectx, version);
         }

--- a/impl/src/main/java/org/apache/myfaces/view/facelets/compiler/TagLibraryConfigUnmarshallerImpl.java
+++ b/impl/src/main/java/org/apache/myfaces/view/facelets/compiler/TagLibraryConfigUnmarshallerImpl.java
@@ -71,10 +71,10 @@ public class TagLibraryConfigUnmarshallerImpl
             // validate XML
             if (MyfacesConfig.getCurrentInstance(externalContext).isValidateXML())
             {
-                String version = ConfigFilesXmlValidationUtils.getFaceletTagLibVersion(url);
-                schemaValidating = "2.0".equals(version);
-                if (schemaValidating)
+                Double version = ConfigFilesXmlValidationUtils.getTagLibVersion(url);
+                if (version >= 2.0)
                 {
+                    schemaValidating = true;
                     ConfigFilesXmlValidationUtils.validateFaceletTagLibFile(url, externalContext, version);
                 }
             }

--- a/impl/src/main/resources/META-INF/faces-config20.vm
+++ b/impl/src/main/resources/META-INF/faces-config20.vm
@@ -19,10 +19,10 @@
  * under the License.
 -->
 
-<faces-config xmlns="http://java.sun.com/xml/ns/javaee" 
-              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
-              xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-facesconfig_2_0.xsd" 
-              version="2.0">
+<faces-config xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+   xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-facesconfig_2_3.xsd"
+   version="2.3">
 
 $baseContent
 

--- a/impl/src/main/resources/org/apache/myfaces/resource/jakartaee_11.xsd
+++ b/impl/src/main/resources/org/apache/myfaces/resource/jakartaee_11.xsd
@@ -1,0 +1,3648 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema targetNamespace="https://jakarta.ee/xml/ns/jakartaee"
+            xmlns:jakartaee="https://jakarta.ee/xml/ns/jakartaee"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            elementFormDefault="qualified"
+            attributeFormDefault="unqualified"
+            version="11">
+  <xsd:annotation>
+    <xsd:documentation>
+
+      Copyright (c) 2009, 2024 Oracle and/or its affiliates. All rights reserved.
+      
+      This program and the accompanying materials are made available under the
+      terms of the Eclipse Public License v. 2.0, which is available at
+      http://www.eclipse.org/legal/epl-2.0.
+      
+      This Source Code may also be made available under the following Secondary
+      Licenses when the conditions for such availability set forth in the
+      Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+      version 2 with the GNU Classpath Exception, which is available at
+      https://www.gnu.org/software/classpath/license.html.
+      
+      SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+      
+    </xsd:documentation>
+  </xsd:annotation>
+
+  <xsd:annotation>
+    <xsd:documentation>
+
+      The following definitions that appear in the common
+      shareable schema(s) of Jakarta EE deployment descriptors should be
+      interpreted with respect to the context they are included:
+      
+      Deployment Component may indicate one of the following:
+      Jakarta EE application;
+      application client;
+      web application;
+      enterprise bean;
+      resource adapter; 
+      
+      Deployment File may indicate one of the following:
+      ear file;
+      war file;
+      jar file;
+      rar file;
+      
+    </xsd:documentation>
+  </xsd:annotation>
+
+  <xsd:import namespace="http://www.w3.org/XML/1998/namespace"
+              schemaLocation="https://www.w3.org/2001/xml.xsd"/>
+
+  <xsd:include schemaLocation="jakartaee_web_services_client_2_0.xsd"/>
+
+  <xsd:group name="descriptionGroup">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        This group keeps the usage of the contained description related
+        elements consistent across Jakarta EE deployment descriptors.
+        
+        All elements may occur multiple times with different languages,
+        to support localization of the content.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description"
+                   type="jakartaee:descriptionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="display-name"
+                   type="jakartaee:display-nameType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="icon"
+                   type="jakartaee:iconType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:group>
+
+  <xsd:group name="jndiEnvironmentRefsGroup">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        This group keeps the usage of the contained JNDI environment
+        reference elements consistent across Jakarta EE deployment descriptors.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="env-entry"
+                   type="jakartaee:env-entryType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="ejb-ref"
+                   type="jakartaee:ejb-refType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="ejb-local-ref"
+                   type="jakartaee:ejb-local-refType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:group ref="jakartaee:service-refGroup"/>
+      <xsd:element name="resource-ref"
+                   type="jakartaee:resource-refType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="resource-env-ref"
+                   type="jakartaee:resource-env-refType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="message-destination-ref"
+                   type="jakartaee:message-destination-refType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="persistence-context-ref"
+                   type="jakartaee:persistence-context-refType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="persistence-unit-ref"
+                   type="jakartaee:persistence-unit-refType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="post-construct"
+                   type="jakartaee:lifecycle-callbackType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="pre-destroy"
+                   type="jakartaee:lifecycle-callbackType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="data-source"
+                   type="jakartaee:data-sourceType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="jms-connection-factory"
+                   type="jakartaee:jms-connection-factoryType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="jms-destination"
+                   type="jakartaee:jms-destinationType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="mail-session"
+                   type="jakartaee:mail-sessionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="connection-factory"
+                   type="jakartaee:connection-factory-resourceType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="administered-object"
+                   type="jakartaee:administered-objectType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="context-service"
+                   type="jakartaee:context-serviceType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="managed-executor"
+                   type="jakartaee:managed-executorType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="managed-scheduled-executor"
+                   type="jakartaee:managed-scheduled-executorType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="managed-thread-factory"
+                   type="jakartaee:managed-thread-factoryType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:group>
+
+  <xsd:group name="resourceGroup">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        This group collects elements that are common to most
+        JNDI resource elements.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="jakartaee:resourceBaseGroup"/>
+      <xsd:element name="lookup-name"
+                   type="jakartaee:xsdStringType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The JNDI name to be looked up to resolve a resource reference.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+  </xsd:group>
+
+  <xsd:group name="resourceBaseGroup">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        This group collects elements that are common to all the
+        JNDI resource elements. It does not include the lookup-name
+        element, that is only applicable to some resource elements.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="mapped-name"
+                   type="jakartaee:xsdStringType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            A product specific name that this resource should be
+            mapped to.  The name of this resource, as defined by the
+            resource's name element or defaulted, is a name that is
+            local to the application component using the resource.
+            (It's a name in the JNDI java:comp/env namespace.)  Many
+            application servers provide a way to map these local
+            names to names of resources known to the application
+            server.  This mapped name is often a global JNDI name,
+            but may be a name of any form.
+            
+            Application servers are not required to support any
+            particular form or type of mapped name, nor the ability
+            to use mapped names.  The mapped name is
+            product-dependent and often installation-dependent.  No
+            use of a mapped name is portable.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="injection-target"
+                   type="jakartaee:injection-targetType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:group>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="administered-objectType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        Configuration of an administered object.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description"
+                   type="jakartaee:descriptionType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Description of this administered object.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="name"
+                   type="jakartaee:jndi-nameType">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The name element specifies the JNDI name of the
+            administered object being defined.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="interface-name"
+                   type="jakartaee:fully-qualified-classType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The administered object's interface type.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="class-name"
+                   type="jakartaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The administered object's class name.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="resource-adapter"
+                   type="jakartaee:string">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Resource adapter name.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="property"
+                   type="jakartaee:propertyType"
+                   minOccurs="0"
+                   maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Property of the administered object property.  This may be a 
+            vendor-specific property.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="connection-factory-resourceType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        Configuration of a Connector Connection Factory resource.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description"
+                   type="jakartaee:descriptionType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Description of this resource.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="name"
+                   type="jakartaee:jndi-nameType">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The name element specifies the JNDI name of the
+            resource being defined.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="interface-name"
+                   type="jakartaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The fully qualified class name of the connection factory 
+            interface. 
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="resource-adapter"
+                   type="jakartaee:string">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Resource adapter name.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="max-pool-size"
+                   type="jakartaee:xsdIntegerType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Maximum number of connections that should be concurrently
+            allocated for a connection pool.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="min-pool-size"
+                   type="jakartaee:xsdIntegerType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Minimum number of connections that should be concurrently
+            allocated for a connection pool.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="transaction-support"
+                   type="jakartaee:transaction-supportType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The level of transaction support the connection factory 
+            needs to support. 
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="property"
+                   type="jakartaee:propertyType"
+                   minOccurs="0"
+                   maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Resource property.  This may be a vendor-specific
+            property.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="context-serviceType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        Configuration of a ContextService.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description"
+                   type="jakartaee:descriptionType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Description of this ContextService.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="name"
+                   type="jakartaee:jndi-nameType">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            JNDI name of the ContextService instance being defined.
+            The JNDI name must be in a valid Jakarta EE namespace,
+            such as java:comp, java:module, java:app, or java:global.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="qualifier"
+                   type="jakartaee:fully-qualified-classType"
+                   minOccurs="0"
+                   maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            A ContextService injection point annotated with these qualifier annotations
+            injects a bean that is produced by this context-service element.
+            Applications can define their own Producers for ContextService injection points 
+            as long as the qualifier annotations on the producer do not conflict with the 
+            non-empty qualifier list of a context-service.
+            
+            You can specify a single qualifier element with no value to indicate an
+            empty list of qualifier annotation classes.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="cleared"
+                   type="jakartaee:string"
+                   minOccurs="0"
+                   maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Types of context to clear whenever a thread runs a
+            contextual task or action. The thread's previous context
+            is restored afterward. Context types that are defined by
+            the Jakarta EE Concurrency specification include:
+            Application, Security, Transaction,
+            and Remaining, which means all available thread context
+            types that are not specified elsewhere. You can also specify
+            vendor-specific context types. Absent other configuration,
+            cleared context defaults to Transaction. You can specify
+            a single cleared element with no value to indicate an
+            empty list of context types to clear. If neither
+            propagated nor unchanged specify (or default to) Remaining,
+            then Remaining is automatically appended to the list of
+            cleared context types.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="propagated"
+                   type="jakartaee:string"
+                   minOccurs="0"
+                   maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Types of context to capture from the requesting thread
+            and propagate to a thread that runs a contextual task
+            or action. The captured context is re-established
+            when threads run the contextual task or action,
+            with the respective thread's previous context being
+            restored afterward. Context types that are defined by
+            the Jakarta EE Concurrency specification include:
+            Application, Security,
+            and Remaining, which means all available thread context
+            types that are not specified elsewhere. You can also specify
+            vendor-specific context types. Absent other configuration,
+            propagated context defaults to Remaining. You can specify
+            a single propagated element with no value to indicate that
+            no context types should be propagated.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="unchanged"
+                   type="jakartaee:string"
+                   minOccurs="0"
+                   maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Types of context that are left alone when a thread runs a
+            contextual task or action. Context types that are defined
+            by the Jakarta EE Concurrency specification include:
+            Application, Security, Transaction,
+            and Remaining, which means all available thread context
+            types that are not specified elsewhere. You can also specify
+            vendor-specific context types. Absent other configuration,
+            unchanged context defaults to empty. You can specify
+            a single unchanged element with no value to indicate that
+            no context types should be left unchanged.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="property"
+                   type="jakartaee:propertyType"
+                   minOccurs="0"
+                   maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Vendor-specific property.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="data-sourceType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        Configuration of a DataSource.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description"
+                   type="jakartaee:descriptionType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Description of this DataSource.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="name"
+                   type="jakartaee:jndi-nameType">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The name element specifies the JNDI name of the
+            data source being defined.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="class-name"
+                   type="jakartaee:fully-qualified-classType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            DataSource, XADataSource or ConnectionPoolDataSource
+            implementation class.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="server-name"
+                   type="jakartaee:string"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Database server name.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="port-number"
+                   type="jakartaee:xsdIntegerType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Port number where a server is listening for requests.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="database-name"
+                   type="jakartaee:string"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Name of a database on a server.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="url"
+                   type="jakartaee:jdbc-urlType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            A JDBC URL. If the <code>url</code> property is specified
+            along with other standard <code>DataSource</code> properties
+            such as <code>serverName</code>, <code>databaseName</code>
+            and <code>portNumber</code>, the more specific properties will
+            take precedence and <code>url</code> will be ignored.
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="user"
+                   type="jakartaee:string"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            User name to use for connection authentication.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="password"
+                   type="jakartaee:string"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Password to use for connection authentication.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="property"
+                   type="jakartaee:propertyType"
+                   minOccurs="0"
+                   maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            JDBC DataSource property.  This may be a vendor-specific
+            property or a less commonly used DataSource property.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="login-timeout"
+                   type="jakartaee:xsdIntegerType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Sets the maximum time in seconds that this data source
+            will wait while attempting to connect to a database.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="transactional"
+                   type="jakartaee:xsdBooleanType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Set to false if connections should not participate in
+            transactions.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="isolation-level"
+                   type="jakartaee:isolation-levelType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Isolation level for connections.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="initial-pool-size"
+                   type="jakartaee:xsdIntegerType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Number of connections that should be created when a
+            connection pool is initialized.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="max-pool-size"
+                   type="jakartaee:xsdIntegerType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Maximum number of connections that should be concurrently
+            allocated for a connection pool.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="min-pool-size"
+                   type="jakartaee:xsdIntegerType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Minimum number of connections that should be concurrently
+            allocated for a connection pool.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="max-idle-time"
+                   type="jakartaee:xsdIntegerType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The number of seconds that a physical connection should
+            remain unused in the pool before the connection is
+            closed for a connection pool.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="max-statements"
+                   type="jakartaee:xsdIntegerType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The total number of statements that a connection pool
+            should keep open.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="descriptionType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The description type is used by a description element to
+        provide text describing the parent element.  The elements
+        that use this type should include any information that the
+        Deployment Component's Deployment File file producer wants
+        to provide to the consumer of the Deployment Component's
+        Deployment File (i.e., to the Deployer). Typically, the
+        tools used by such a Deployment File consumer will display
+        the description when processing the parent element that
+        contains the description.
+        
+        The lang attribute defines the language that the
+        description is provided in. The default value is "en" (English). 
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:extension base="jakartaee:xsdStringType">
+        <xsd:attribute ref="xml:lang"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+  <xsd:simpleType name="dewey-versionType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        This type defines a dewey decimal that is used
+        to describe versions of documents. 
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:restriction base="xsd:token">
+      <xsd:pattern value="\.?[0-9]+(\.[0-9]+)*"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="display-nameType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        The display-name type contains a short name that is intended
+        to be displayed by tools. It is used by display-name
+        elements.  The display name need not be unique.
+        
+        Example: 
+        
+        ...
+        <display-name xml:lang="en">
+        Employee Self Service
+        </display-name>
+        
+        The value of the xml:lang attribute is "en" (English) by default. 
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:extension base="jakartaee:string">
+        <xsd:attribute ref="xml:lang"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="ejb-linkType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        The ejb-linkType is used by ejb-link
+        elements in the ejb-ref or ejb-local-ref elements to specify
+        that an enterprise bean reference is linked to enterprise bean.
+        
+        The value of the ejb-link element must be the ejb-name of an
+        enterprise bean in the same ejb-jar file or in another ejb-jar
+        file in the same Jakarta EE application unit. 
+        
+        Alternatively, the name in the ejb-link element may be
+        composed of a path name specifying the ejb-jar containing the
+        referenced enterprise bean with the ejb-name of the target
+        bean appended and separated from the path name by "#".  The
+        path name is relative to the Deployment File containing
+        Deployment Component that is referencing the enterprise
+        bean.  This allows multiple enterprise beans with the same
+        ejb-name to be uniquely identified.
+        
+        Examples:
+        
+        <ejb-link>EmployeeRecord</ejb-link>
+        
+        <ejb-link>../products/product.jar#ProductEJB</ejb-link>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="jakartaee:string"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="ejb-local-refType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The ejb-local-refType is used by ejb-local-ref elements for
+        the declaration of a reference to an enterprise bean's local
+        home or to the local business interface of a 3.0 bean.
+        The declaration consists of:
+        
+        - an optional description
+        - the enterprise bean's reference name used in the code of the 
+        Deployment Component that's referencing the enterprise bean.
+        - the optional expected type of the referenced enterprise bean
+        - the optional expected local interface of the referenced 
+        enterprise bean or the local business interface of the 
+        referenced enterprise bean.
+        - the optional expected local home interface of the referenced 
+        enterprise bean. Not applicable if this ejb-local-ref refers
+        to the local business interface of a 3.0 bean.
+        - optional ejb-link information, used to specify the 
+        referenced enterprise bean
+        - optional elements to define injection of the named enterprise  
+        bean into a component field or property.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description"
+                   type="jakartaee:descriptionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="ejb-ref-name"
+                   type="jakartaee:ejb-ref-nameType"/>
+      <xsd:element name="ejb-ref-type"
+                   type="jakartaee:ejb-ref-typeType"
+                   minOccurs="0"/>
+      <xsd:element name="local-home"
+                   type="jakartaee:local-homeType"
+                   minOccurs="0"/>
+      <xsd:element name="local"
+                   type="jakartaee:localType"
+                   minOccurs="0"/>
+      <xsd:element name="ejb-link"
+                   type="jakartaee:ejb-linkType"
+                   minOccurs="0"/>
+      <xsd:group ref="jakartaee:resourceGroup"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="ejb-ref-nameType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        The ejb-ref-name element contains the name of an enterprise bean reference. 
+        The enterprise bean reference is an entry in the Deployment Component's 
+        environment and is relative to the java:comp/env context.  The name must 
+        be unique within the Deployment Component.
+        
+        It is recommended that name is prefixed with "ejb/".
+        
+        Example:
+        
+        <ejb-ref-name>ejb/Payroll</ejb-ref-name>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="jakartaee:jndi-nameType"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="ejb-refType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The ejb-refType is used by ejb-ref elements for the
+        declaration of a reference to an enterprise bean's home or
+        to the remote business interface of a 3.0 bean.  
+        The declaration consists of:
+        
+        - an optional description
+        - the enterprise bean's reference name used in the code of
+        the Deployment Component that's referencing the enterprise
+        bean. 
+        - the optional expected type of the referenced enterprise bean
+        - the optional remote interface of the referenced enterprise bean
+        or the remote business interface of the referenced enterprise 
+        bean
+        - the optional expected home interface of the referenced 
+        enterprise bean.  Not applicable if this ejb-ref
+        refers to the remote business interface of a 3.0 bean.
+        - optional ejb-link information, used to specify the
+        referenced enterprise bean
+        - optional elements to define injection of the named enterprise
+        bean into a component field or property
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description"
+                   type="jakartaee:descriptionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="ejb-ref-name"
+                   type="jakartaee:ejb-ref-nameType"/>
+      <xsd:element name="ejb-ref-type"
+                   type="jakartaee:ejb-ref-typeType"
+                   minOccurs="0"/>
+      <xsd:element name="home"
+                   type="jakartaee:homeType"
+                   minOccurs="0"/>
+      <xsd:element name="remote"
+                   type="jakartaee:remoteType"
+                   minOccurs="0"/>
+      <xsd:element name="ejb-link"
+                   type="jakartaee:ejb-linkType"
+                   minOccurs="0"/>
+      <xsd:group ref="jakartaee:resourceGroup"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="ejb-ref-typeType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The ejb-ref-typeType contains the expected type of the
+        referenced enterprise bean.
+        
+        The ejb-ref-type designates a value
+        that must be one of the following:
+        
+        Entity
+        Session
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="jakartaee:string">
+        <xsd:enumeration value="Entity"/>
+        <xsd:enumeration value="Session"/>
+      </xsd:restriction>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="emptyType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        This type is used to designate an empty
+        element when used. 
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="env-entryType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The env-entryType is used to declare an application's
+        environment entry. The declaration consists of an optional
+        description, the name of the environment entry, a type
+        (optional if the value is injected, otherwise required), and
+        an optional value.
+        
+        It also includes optional elements to define injection of
+        the named resource into fields or JavaBeans properties.
+        
+        If a value is not specified and injection is requested,
+        no injection will occur and no entry of the specified name
+        will be created.  This allows an initial value to be
+        specified in the source code without being incorrectly
+        changed when no override has been specified.
+        
+        If a value is not specified and no injection is requested,
+        a value must be supplied during deployment. 
+        
+        This type is used by env-entry elements.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description"
+                   type="jakartaee:descriptionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="env-entry-name"
+                   type="jakartaee:jndi-nameType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            The env-entry-name element contains the name of a
+            Deployment Component's environment entry.  The name
+            is a JNDI name relative to the java:comp/env
+            context.  The name must be unique within a 
+            Deployment Component. The uniqueness
+            constraints must be defined within the declared
+            context.
+            
+            Example:
+            
+            <env-entry-name>minAmount</env-entry-name>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="env-entry-type"
+                   type="jakartaee:env-entry-type-valuesType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            The env-entry-type element contains the Java language
+            type of the environment entry.  If an injection target
+            is specified for the environment entry, the type may
+            be omitted, or must match the type of the injection
+            target.  If no injection target is specified, the type
+            is required.
+            
+            Example:
+            
+            <env-entry-type>java.lang.Integer</env-entry-type>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="env-entry-value"
+                   type="jakartaee:xsdStringType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            The env-entry-value designates the value of a
+            Deployment Component's environment entry. The value
+            must be a String that is valid for the
+            constructor of the specified type that takes a
+            single String parameter, or for java.lang.Character,
+            a single character.
+            
+            Example:
+            
+            <env-entry-value>100.00</env-entry-value>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:group ref="jakartaee:resourceGroup"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="env-entry-type-valuesType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        This type contains the fully-qualified Java type of the
+        environment entry value that is expected by the
+        application's code.
+        
+        The following are the legal values of env-entry-type-valuesType:
+        
+        java.lang.Boolean
+        java.lang.Byte
+        java.lang.Character
+        java.lang.String
+        java.lang.Short
+        java.lang.Integer
+        java.lang.Long
+        java.lang.Float
+        java.lang.Double
+        		  java.lang.Class
+        		  any enumeration type (i.e. a subclass of java.lang.Enum)
+        
+        Examples:
+        
+        <env-entry-type>java.lang.Boolean</env-entry-type>
+        <env-entry-type>java.lang.Class</env-entry-type>
+        <env-entry-type>com.example.Color</env-entry-type>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="jakartaee:fully-qualified-classType"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="fully-qualified-classType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The elements that use this type designate the name of a
+        Java class or interface.  The name is in the form of a
+        "binary name", as defined in the JLS.  This is the form
+        of name used in Class.forName().  Tools that need the
+        canonical name (the name used in source code) will need
+        to convert this binary name to the canonical name.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="jakartaee:string"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="generic-booleanType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        This type defines four different values which can designate
+        boolean values. This includes values yes and no which are 
+        not designated by xsd:boolean
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="jakartaee:string">
+        <xsd:enumeration value="true"/>
+        <xsd:enumeration value="false"/>
+        <xsd:enumeration value="yes"/>
+        <xsd:enumeration value="no"/>
+      </xsd:restriction>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="iconType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The icon type contains small-icon and large-icon elements
+        that specify the file names for small and large GIF, JPEG,
+        or PNG icon images used to represent the parent element in a
+        GUI tool. 
+        
+        The xml:lang attribute defines the language that the
+        icon file names are provided in. Its value is "en" (English)
+        by default. 
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="small-icon"
+                   type="jakartaee:pathType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            The small-icon element contains the name of a file
+            containing a small (16 x 16) icon image. The file
+            name is a relative path within the Deployment
+            Component's Deployment File.
+            
+            The image may be in the GIF, JPEG, or PNG format.
+            The icon can be used by tools.
+            
+            Example:
+            
+            <small-icon>employee-service-icon16x16.jpg</small-icon>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="large-icon"
+                   type="jakartaee:pathType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            The large-icon element contains the name of a file
+            containing a large
+            (32 x 32) icon image. The file name is a relative 
+            path within the Deployment Component's Deployment
+            File.
+            
+            The image may be in the GIF, JPEG, or PNG format.
+            The icon can be used by tools.
+            
+            Example:
+            
+            <large-icon>employee-service-icon32x32.jpg</large-icon>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute ref="xml:lang"/>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="injection-targetType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        An injection target specifies a class and a name within
+        that class into which a resource should be injected.
+        
+        The injection target class specifies the fully qualified
+        class name that is the target of the injection.  The
+        Jakarta EE specifications describe which classes can be an
+        injection target.
+        
+        The injection target name specifies the target within
+        the specified class.  The target is first looked for as a
+        JavaBeans property name.  If not found, the target is
+        looked for as a field name.
+        
+        The specified resource will be injected into the target
+        during initialization of the class by either calling the
+        set method for the target property or by setting a value
+        into the named field.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="injection-target-class"
+                   type="jakartaee:fully-qualified-classType"/>
+      <xsd:element name="injection-target-name"
+                   type="jakartaee:java-identifierType"/>
+    </xsd:sequence>
+  </xsd:complexType>
+
+  <xsd:simpleType name="isolation-levelType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        	The following transaction isolation levels are allowed
+        	(see documentation for the java.sql.Connection interface):
+        TRANSACTION_READ_UNCOMMITTED
+        TRANSACTION_READ_COMMITTED
+        TRANSACTION_REPEATABLE_READ
+        TRANSACTION_SERIALIZABLE
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="TRANSACTION_READ_UNCOMMITTED"/>
+      <xsd:enumeration value="TRANSACTION_READ_COMMITTED"/>
+      <xsd:enumeration value="TRANSACTION_REPEATABLE_READ"/>
+      <xsd:enumeration value="TRANSACTION_SERIALIZABLE"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="java-identifierType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The java-identifierType defines a Java identifier.
+        The users of this type should further verify that 
+        the content does not contain Java reserved keywords.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="jakartaee:string">
+        <xsd:pattern value="($|_|\p{L})(\p{L}|\p{Nd}|_|$)*"/>
+      </xsd:restriction>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="java-typeType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        This is a generic type that designates a Java primitive
+        type or a fully qualified name of a Java interface/type,
+        or an array of such types.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="jakartaee:string">
+        <xsd:pattern value="[^\p{Z}]*"/>
+      </xsd:restriction>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="jdbc-urlType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        The jdbc-urlType contains the url pattern of the mapping.
+        It must follow the rules specified in Section 9.3 of the
+        JDBC Specification where the format is:
+        
+        jdbc:<subprotocol>:<subname>
+        
+        Example:
+        
+        <url>jdbc:mysql://localhost:3307/testdb</url>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="jakartaee:string">
+        <xsd:pattern value="jdbc:(.*):(.*)"/>
+      </xsd:restriction>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="jms-connection-factoryType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        Configuration of a Messaging Connection Factory.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description"
+                   type="jakartaee:descriptionType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Description of this Messaging Connection Factory.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="name"
+                   type="jakartaee:jndi-nameType">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The name element specifies the JNDI name of the
+            messaging connection factory being defined.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="interface-name"
+                   type="jakartaee:fully-qualified-classType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Fully-qualified name of the messaging connection factory
+            interface.  Permitted values are jakarta.jms.ConnectionFactory,
+            jakarta.jms.QueueConnectionFactory, or 
+            jakarta.jms.TopicConnectionFactory.  If not specified,
+            jakarta.jms.ConnectionFactory will be used.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="class-name"
+                   type="jakartaee:fully-qualified-classType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Fully-qualified name of the messaging connection factory 
+            implementation class.  Ignored if a resource adapter  
+            is used.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="resource-adapter"
+                   type="jakartaee:string"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Resource adapter name.  If not specified, the application
+            server will define the default behavior, which may or may
+            not involve the use of a resource adapter.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="user"
+                   type="jakartaee:string"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            User name to use for connection authentication.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="password"
+                   type="jakartaee:string"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Password to use for connection authentication.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="client-id"
+                   type="jakartaee:string"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Client id to use for connection.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="property"
+                   type="jakartaee:propertyType"
+                   minOccurs="0"
+                   maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Messaging Connection Factory property.  This may be a vendor-specific
+            property or a less commonly used ConnectionFactory property.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="transactional"
+                   type="jakartaee:xsdBooleanType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Set to false if connections should not participate in
+            transactions.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="max-pool-size"
+                   type="jakartaee:xsdIntegerType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Maximum number of connections that should be concurrently
+            allocated for a connection pool.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="min-pool-size"
+                   type="jakartaee:xsdIntegerType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Minimum number of connections that should be concurrently
+            allocated for a connection pool.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="jms-destinationType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        Configuration of a Messaging Destination.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description"
+                   type="jakartaee:descriptionType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Description of this Messaging Destination.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="name"
+                   type="jakartaee:jndi-nameType">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The name element specifies the JNDI name of the
+            messaging destination being defined.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="interface-name"
+                   type="jakartaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Fully-qualified name of the messaging destination interface.
+            Permitted values are jakarta.jms.Queue and jakarta.jms.Topic
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="class-name"
+                   type="jakartaee:fully-qualified-classType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Fully-qualified name of the messaging destination implementation
+            class.  Ignored if a resource adapter is used unless the
+            resource adapter defines more than one destination implementation
+            class for the specified interface.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="resource-adapter"
+                   type="jakartaee:string"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Resource adapter name.  If not specified, the application
+            server will define the default behavior, which may or may
+            not involve the use of a resource adapter.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="destination-name"
+                   type="jakartaee:string"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Name of the queue or topic.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="property"
+                   type="jakartaee:propertyType"
+                   minOccurs="0"
+                   maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Messaging Destination property.  This may be a vendor-specific
+            property or a less commonly used Destination property.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="jndi-nameType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The jndi-nameType type designates a JNDI name in the
+        Deployment Component's environment and is relative to the
+        java:comp/env context.  A JNDI name must be unique within the
+        Deployment Component.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="jakartaee:string"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="homeType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        The homeType defines the fully-qualified name of
+        an enterprise bean's home interface. 
+        
+        Example:
+        
+        <home>com.aardvark.payroll.PayrollHome</home>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="jakartaee:fully-qualified-classType"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="lifecycle-callbackType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The lifecycle-callback type specifies a method on a
+        class to be called when a lifecycle event occurs.
+        Note that each class may have only one lifecycle callback
+        method for any given event and that the method may not
+        be overloaded.
+        
+        If the lifefycle-callback-class element is missing then
+        the class defining the callback is assumed to be the
+        component class in scope at the place in the descriptor
+        in which the callback definition appears.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="lifecycle-callback-class"
+                   type="jakartaee:fully-qualified-classType"
+                   minOccurs="0"/>
+      <xsd:element name="lifecycle-callback-method"
+                   type="jakartaee:java-identifierType"/>
+    </xsd:sequence>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="listenerType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The listenerType indicates the deployment properties for a web
+        application listener bean.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="jakartaee:descriptionGroup"/>
+      <xsd:element name="listener-class"
+                   type="jakartaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The listener-class element declares a class in the
+            application must be registered as a web
+            application listener bean. The value is the fully
+            qualified classname of the listener class.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="localType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The localType defines the fully-qualified name of an
+        enterprise bean's local interface.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="jakartaee:fully-qualified-classType"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="local-homeType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The local-homeType defines the fully-qualified
+        name of an enterprise bean's local home interface.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="jakartaee:fully-qualified-classType"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="mail-sessionType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        Configuration of a Mail Session resource.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description"
+                   type="jakartaee:descriptionType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Description of this Mail Session resource.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="name"
+                   type="jakartaee:jndi-nameType">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The name element specifies the JNDI name of the
+            Mail Session resource being defined.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="store-protocol"
+                   type="jakartaee:string"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Storage protocol.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="store-protocol-class"
+                   type="jakartaee:fully-qualified-classType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Service provider store protocol implementation class
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="transport-protocol"
+                   type="jakartaee:string"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Transport protocol.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="transport-protocol-class"
+                   type="jakartaee:fully-qualified-classType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Service provider transport protocol implementation class
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="host"
+                   type="jakartaee:string"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Mail server host name.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="user"
+                   type="jakartaee:string"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Mail server user name.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="password"
+                   type="jakartaee:string"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Password.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="from"
+                   type="jakartaee:string"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Email address to indicate the message sender.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="property"
+                   type="jakartaee:propertyType"
+                   minOccurs="0"
+                   maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Mail server property.  This may be a vendor-specific
+            property.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="managed-executorType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        Configuration of a ManagedExecutorService.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description"
+                   type="jakartaee:descriptionType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Description of this ManagedExecutorService.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="name"
+                   type="jakartaee:jndi-nameType">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            JNDI name of the ManagedExecutorService instance being defined.
+            The JNDI name must be in a valid Jakarta EE namespace,
+            such as java:comp, java:module, java:app, or java:global.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="context-service-ref"
+                   type="jakartaee:jndi-nameType"
+                   minOccurs="0"
+                   maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Refers to the name of a ContextServiceDefinition or
+            context-service deployment descriptor element,
+            which determines how context is applied to tasks and actions
+            that run on this executor.
+            The name must be in a valid Jakarta EE namespace,
+            such as java:comp, java:module, java:app, or java:global.
+            In the absence of a configured value,
+            java:comp/DefaultContextService is used.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="qualifier"
+                   type="jakartaee:fully-qualified-classType"
+                   minOccurs="0"
+                   maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            A ManagedExecutorService injection point annotated with these qualifier annotations
+            injects a bean that is produced by this managed-executor element.
+            Applications can define their own Producers for ManagedExecutorService injection points 
+            as long as the qualifier annotations on the producer do not conflict with the 
+            non-empty qualifier list of a managed-executor.
+            
+            You can specify a single qualifier element with no value to indicate an
+            empty list of qualifier annotation classes.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="max-async"
+                   type="jakartaee:xsdPositiveIntegerType"
+                   minOccurs="0"
+                   maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Upper bound on contextual tasks and actions that this executor
+            will simultaneously execute asynchronously. This constraint does
+            not apply to tasks and actions that the executor runs inline,
+            such as when a thread requests CompletableFuture.join and the
+            action runs inline if it has not yet started.
+            The default is unbounded, although still subject to
+            resource constraints of the system.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="hung-task-threshold"
+                   type="jakartaee:xsdPositiveIntegerType"
+                   minOccurs="0"
+                   maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The amount of time in milliseconds that a task or action
+            can execute before it is considered hung.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="virtual"
+                   type="jakartaee:true-falseType"
+                   minOccurs="0"
+                   maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Indicates whether this executor is requested to
+            create virtual threads for tasks that do not run inline.
+            When true, the executor can create
+            virtual threads if it is capable of doing so
+            and if the request is not overridden by vendor-specific
+            configuration that restricts the use of virtual threads.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="property"
+                   type="jakartaee:propertyType"
+                   minOccurs="0"
+                   maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Vendor-specific property.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="managed-scheduled-executorType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        Configuration of a ManagedScheduledExecutorService.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description"
+                   type="jakartaee:descriptionType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Description of this ManagedScheduledExecutorService.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="name"
+                   type="jakartaee:jndi-nameType">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            JNDI name of the ManagedScheduledExecutorService instance
+            being defined.
+            The JNDI name must be in a valid Jakarta EE namespace,
+            such as java:comp, java:module, java:app, or java:global.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="context-service-ref"
+                   type="jakartaee:jndi-nameType"
+                   minOccurs="0"
+                   maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Refers to the name of a ContextServiceDefinition or
+            context-service deployment descriptor element,
+            which determines how context is applied to tasks and actions
+            that run on this executor.
+            The name must be in a valid Jakarta EE namespace,
+            such as java:comp, java:module, java:app, or java:global.
+            In the absence of a configured value,
+            java:comp/DefaultContextService is used.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="qualifier"
+                   type="jakartaee:fully-qualified-classType"
+                   minOccurs="0"
+                   maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            A ManagedScheduledExecutorService injection point annotated with these qualifier annotations
+            injects a bean that is produced by this managed-scheduled-executor element.
+            Applications can define their own Producers for ManagedScheduledExecutorService injection points 
+            as long as the qualifier annotations on the producer do not conflict with the 
+            non-empty qualifier list of a managed-scheduled-executor.
+            
+            You can specify a single qualifier element with no value to indicate an
+            empty list of qualifier annotation classes.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="max-async"
+                   type="jakartaee:xsdPositiveIntegerType"
+                   minOccurs="0"
+                   maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Upper bound on contextual tasks and actions that this executor
+            will simultaneously execute asynchronously. This constraint does
+            not apply to tasks and actions that the executor runs inline,
+            such as when a thread requests CompletableFuture.join and the
+            action runs inline if it has not yet started. This constraint also
+            does not apply to tasks that are scheduled via the schedule methods.
+            The default is unbounded, although still subject to
+            resource constraints of the system.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="hung-task-threshold"
+                   type="jakartaee:xsdPositiveIntegerType"
+                   minOccurs="0"
+                   maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The amount of time in milliseconds that a task or action
+            can execute before it is considered hung.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="virtual"
+                   type="jakartaee:true-falseType"
+                   minOccurs="0"
+                   maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Indicates whether this executor is requested to
+            create virtual threads for tasks that do not run inline.
+            When true, the executor can create
+            virtual threads if it is capable of doing so
+            and if the request is not overridden by vendor-specific
+            configuration that restricts the use of virtual threads.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="property"
+                   type="jakartaee:propertyType"
+                   minOccurs="0"
+                   maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Vendor-specific property.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="managed-thread-factoryType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        Configuration of a ManagedThreadFactory.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description"
+                   type="jakartaee:descriptionType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Description of this ManagedThreadFactory.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="name"
+                   type="jakartaee:jndi-nameType">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            JNDI name of the ManagedThreadFactory instance being defined.
+            The JNDI name must be in a valid Jakarta EE namespace,
+            such as java:comp, java:module, java:app, or java:global.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="context-service-ref"
+                   type="jakartaee:jndi-nameType"
+                   minOccurs="0"
+                   maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Refers to the name of a ContextServiceDefinition or
+            context-service deployment descriptor element,
+            which determines how context is applied to threads
+            from this thread factory.
+            The name must be in a valid Jakarta EE namespace,
+            such as java:comp, java:module, java:app, or java:global.
+            In the absence of a configured value,
+            java:comp/DefaultContextService is used.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="qualifier"
+                   type="jakartaee:fully-qualified-classType"
+                   minOccurs="0"
+                   maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            A ManagedThreadFactory injection point annotated with these qualifier annotations
+            injects a bean that is produced by this managed-thread-factory element.
+            Applications can define their own Producers for ManagedThreadFactory injection points 
+            as long as the qualifier annotations on the producer do not conflict with the 
+            non-empty qualifier list of a managed-thread-factory.
+            
+            You can specify a single qualifier element with no value to indicate an
+            empty list of qualifier annotation classes.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="priority"
+                   type="jakartaee:priorityType"
+                   minOccurs="0"
+                   maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Priority for threads created by this thread factory.
+            The default is 5 (java.lang.Thread.NORM_PRIORITY).
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="virtual"
+                   type="jakartaee:true-falseType"
+                   minOccurs="0"
+                   maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Indicates whether this executor is requested to
+            create virtual threads for tasks that do not run inline.
+            When true, the executor can create
+            virtual threads if it is capable of doing so
+            and if the request is not overridden by vendor-specific
+            configuration that restricts the use of virtual threads.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="property"
+                   type="jakartaee:propertyType"
+                   minOccurs="0"
+                   maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Vendor-specific property.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="param-valueType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        This type is a general type that can be used to declare
+        parameter/value lists.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description"
+                   type="jakartaee:descriptionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="param-name"
+                   type="jakartaee:string">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The param-name element contains the name of a
+            parameter.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="param-value"
+                   type="jakartaee:xsdStringType">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The param-value element contains the value of a
+            parameter.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="pathType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The elements that use this type designate either a relative
+        path or an absolute path starting with a "/".
+        
+        In elements that specify a pathname to a file within the
+        same Deployment File, relative filenames (i.e., those not
+        starting with "/") are considered relative to the root of
+        the Deployment File's namespace.  Absolute filenames (i.e.,
+        those starting with "/") also specify names in the root of
+        the Deployment File's namespace.  In general, relative names
+        are preferred.  The exception is .war files where absolute
+        names are preferred for consistency with the Servlet API.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="jakartaee:string"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="persistence-context-refType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        The persistence-context-ref element contains a declaration
+        of Deployment Component's reference to a persistence context
+        associated within a Deployment Component's
+        environment. It consists of:
+        
+        - an optional description
+        - the persistence context reference name
+        - an optional persistence unit name.  If not specified,
+        the default persistence unit is assumed.
+        - an optional specification as to whether
+        the persistence context type is Transaction or
+        Extended.  If not specified, Transaction is assumed.
+        - an optional specification as to whether
+        the persistence context synchronization with the current
+        transaction is Synchronized or Unsynchronized. If not
+        specified, Synchronized is assumed.
+        - an optional list of persistence properties
+        - optional injection targets
+        
+        Examples:
+        
+        <persistence-context-ref>
+        <persistence-context-ref-name>myPersistenceContext
+        </persistence-context-ref-name>
+        </persistence-context-ref>
+        
+        <persistence-context-ref>
+        <persistence-context-ref-name>myPersistenceContext
+        </persistence-context-ref-name>
+        <persistence-unit-name>PersistenceUnit1
+        </persistence-unit-name>
+        <persistence-context-type>Extended</persistence-context-type>
+        </persistence-context-ref>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description"
+                   type="jakartaee:descriptionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="persistence-context-ref-name"
+                   type="jakartaee:jndi-nameType">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The persistence-context-ref-name element specifies
+            the name of a persistence context reference; its
+            value is the environment entry name used in
+            Deployment Component code.  The name is a JNDI name
+            relative to the java:comp/env context.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="persistence-unit-name"
+                   type="jakartaee:string"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The Application Assembler(or BeanProvider) may use the
+            following syntax to avoid the need to rename persistence
+            units to have unique names within a Jakarta EE application.
+            
+            The Application Assembler specifies the pathname of the
+            root of the persistence.xml file for the referenced
+            persistence unit and appends the name of the persistence
+            unit separated from the pathname by #. The pathname is
+            relative to the referencing application component jar file. 
+            In this manner, multiple persistence units with the same
+            persistence unit name may be uniquely identified when the 
+            Application Assembler cannot change persistence unit names.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="persistence-context-type"
+                   type="jakartaee:persistence-context-typeType"
+                   minOccurs="0"/>
+      <xsd:element name="persistence-context-synchronization"
+                   type="jakartaee:persistence-context-synchronizationType"
+                   minOccurs="0"/>
+      <xsd:element name="persistence-property"
+                   type="jakartaee:propertyType"
+                   minOccurs="0"
+                   maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Used to specify properties for the container or persistence
+            provider.  Vendor-specific properties may be included in
+            the set of properties.  Properties that are not recognized
+            by a vendor must be ignored.  Entries that make use of the 
+            namespace jakarta.persistence and its subnamespaces must not
+            be used for vendor-specific properties.  The namespace
+            jakarta.persistence is reserved for use by the specification.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:group ref="jakartaee:resourceBaseGroup"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="persistence-context-synchronizationType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The persistence-context-synchronizationType specifies 
+        whether a container-managed persistence context is automatically
+        synchronized with the current transaction.
+        
+        The value of the persistence-context-synchronization element 
+        must be one of the following:
+        Synchronized
+        Unsynchronized
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="jakartaee:string">
+        <xsd:enumeration value="Synchronized"/>
+        <xsd:enumeration value="Unsynchronized"/>
+      </xsd:restriction>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="persistence-context-typeType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The persistence-context-typeType specifies the transactional
+        nature of a persistence context reference.  
+        
+        The value of the persistence-context-type element must be
+        one of the following:
+        Transaction
+        Extended
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="jakartaee:string">
+        <xsd:enumeration value="Transaction"/>
+        <xsd:enumeration value="Extended"/>
+      </xsd:restriction>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="priorityType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        Specifies a thread priority value in the range of
+        1 (java.lang.Thread.MIN_PRIORITY) to 10 (java.lang.Thread.MAX_PRIORITY).
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="jakartaee:xsdPositiveIntegerType">
+        <xsd:maxInclusive value="10"/>
+      </xsd:restriction>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="propertyType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        Specifies a name/value pair.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="name"
+                   type="jakartaee:xsdStringType">
+      </xsd:element>
+      <xsd:element name="value"
+                   type="jakartaee:xsdStringType">
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="persistence-unit-refType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        The persistence-unit-ref element contains a declaration
+        of Deployment Component's reference to a persistence unit
+        associated within a Deployment Component's
+        environment. It consists of:
+        
+        - an optional description
+        - the persistence unit reference name
+        - an optional persistence unit name.  If not specified,
+        the default persistence unit is assumed.
+        - optional injection targets
+        
+        Examples:
+        
+        <persistence-unit-ref>
+        <persistence-unit-ref-name>myPersistenceUnit
+        </persistence-unit-ref-name>
+        </persistence-unit-ref>
+        
+        <persistence-unit-ref>
+        <persistence-unit-ref-name>myPersistenceUnit
+        </persistence-unit-ref-name>
+        <persistence-unit-name>PersistenceUnit1
+        </persistence-unit-name>
+        </persistence-unit-ref>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description"
+                   type="jakartaee:descriptionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="persistence-unit-ref-name"
+                   type="jakartaee:jndi-nameType">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The persistence-unit-ref-name element specifies
+            the name of a persistence unit reference; its
+            value is the environment entry name used in
+            Deployment Component code.  The name is a JNDI name
+            relative to the java:comp/env context.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="persistence-unit-name"
+                   type="jakartaee:string"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The Application Assembler(or BeanProvider) may use the
+            following syntax to avoid the need to rename persistence
+            units to have unique names within a Jakarta EE application.
+            
+            The Application Assembler specifies the pathname of the
+            root of the persistence.xml file for the referenced
+            persistence unit and appends the name of the persistence
+            unit separated from the pathname by #. The pathname is
+            relative to the referencing application component jar file. 
+            In this manner, multiple persistence units with the same
+            persistence unit name may be uniquely identified when the 
+            Application Assembler cannot change persistence unit names.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:group ref="jakartaee:resourceBaseGroup"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="remoteType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        The remote element contains the fully-qualified name
+        of the enterprise bean's remote interface.
+        
+        Example:
+        
+        <remote>com.wombat.empl.EmployeeService</remote>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="jakartaee:fully-qualified-classType"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="resource-env-refType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        The resource-env-refType is used to define
+        resource-env-ref elements.  It contains a declaration of a
+        Deployment Component's reference to an administered object
+        associated with a resource in the Deployment Component's
+        environment.  It consists of an optional description, the
+        resource environment reference name, and an optional
+        indication of the resource environment reference type
+        expected by the Deployment Component code.
+        
+        It also includes optional elements to define injection of
+        the named resource into fields or JavaBeans properties.
+        
+        The resource environment type must be supplied unless an
+        injection target is specified, in which case the type
+        of the target is used.  If both are specified, the type
+        must be assignment compatible with the type of the injection
+        target.
+        
+        Example:
+        
+        <resource-env-ref>
+        <resource-env-ref-name>jms/StockQueue
+        </resource-env-ref-name>
+        <resource-env-ref-type>jakarta.jms.Queue
+        </resource-env-ref-type>
+        </resource-env-ref>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description"
+                   type="jakartaee:descriptionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="resource-env-ref-name"
+                   type="jakartaee:jndi-nameType">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The resource-env-ref-name element specifies the name
+            of a resource environment reference; its value is
+            the environment entry name used in
+            the Deployment Component code.  The name is a JNDI 
+            name relative to the java:comp/env context and must 
+            be unique within a Deployment Component.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="resource-env-ref-type"
+                   type="jakartaee:fully-qualified-classType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The resource-env-ref-type element specifies the type
+            of a resource environment reference.  It is the
+            fully qualified name of a Java language class or
+            interface.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:group ref="jakartaee:resourceGroup"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="resource-refType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        The resource-refType contains a declaration of a
+        Deployment Component's reference to an external resource. It
+        consists of an optional description, the resource manager
+        connection factory reference name, an optional indication of
+        the resource manager connection factory type expected by the
+        Deployment Component code, an optional type of authentication
+        (Application or Container), and an optional specification of
+        the shareability of connections obtained from the resource
+        (Shareable or Unshareable).
+        
+        It also includes optional elements to define injection of
+        the named resource into fields or JavaBeans properties.
+        
+        The connection factory type must be supplied unless an
+        injection target is specified, in which case the type
+        of the target is used.  If both are specified, the type
+        must be assignment compatible with the type of the injection
+        target.
+        
+        Example:
+        
+        <resource-ref>
+        <res-ref-name>jdbc/EmployeeAppDB</res-ref-name>
+        <res-type>javax.sql.DataSource</res-type>
+        <res-auth>Container</res-auth>
+        <res-sharing-scope>Shareable</res-sharing-scope>
+        </resource-ref>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description"
+                   type="jakartaee:descriptionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="res-ref-name"
+                   type="jakartaee:jndi-nameType">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The res-ref-name element specifies the name of a
+            resource manager connection factory reference.
+            The name is a JNDI name relative to the
+            java:comp/env context.  
+            The name must be unique within a Deployment File. 
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="res-type"
+                   type="jakartaee:fully-qualified-classType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The res-type element specifies the type of the data
+            source. The type is specified by the fully qualified
+            Java language class or interface
+            expected to be implemented by the data source.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="res-auth"
+                   type="jakartaee:res-authType"
+                   minOccurs="0"/>
+      <xsd:element name="res-sharing-scope"
+                   type="jakartaee:res-sharing-scopeType"
+                   minOccurs="0"/>
+      <xsd:group ref="jakartaee:resourceGroup"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="res-authType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The res-authType specifies whether the Deployment Component
+        code signs on programmatically to the resource manager, or
+        whether the Container will sign on to the resource manager
+        on behalf of the Deployment Component. In the latter case,
+        the Container uses information that is supplied by the
+        Deployer.
+        
+        The value must be one of the two following:
+        
+        Application
+        Container
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="jakartaee:string">
+        <xsd:enumeration value="Application"/>
+        <xsd:enumeration value="Container"/>
+      </xsd:restriction>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="res-sharing-scopeType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The res-sharing-scope type specifies whether connections
+        obtained through the given resource manager connection
+        factory reference can be shared. The value, if specified,
+        must be one of the two following:
+        
+        Shareable
+        Unshareable
+        
+        The default value is Shareable.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="jakartaee:string">
+        <xsd:enumeration value="Shareable"/>
+        <xsd:enumeration value="Unshareable"/>
+      </xsd:restriction>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="run-asType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The run-asType specifies the run-as identity to be
+        used for the execution of a component. It contains an 
+        optional description, and the name of a security role.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description"
+                   type="jakartaee:descriptionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="role-name"
+                   type="jakartaee:role-nameType"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="role-nameType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The role-nameType designates the name of a security role.
+        
+        The name must conform to the lexical rules for a token.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="jakartaee:string"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="security-roleType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        The security-roleType contains the definition of a security
+        role. The definition consists of an optional description of
+        the security role, and the security role name.
+        
+        Example:
+        
+        <security-role>
+        <description>
+        This role includes all employees who are authorized
+        to access the employee service application.
+        </description>
+        <role-name>employee</role-name>
+        </security-role>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description"
+                   type="jakartaee:descriptionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="role-name"
+                   type="jakartaee:role-nameType"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="security-role-refType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The security-role-refType contains the declaration of a
+        security role reference in a component's or a
+        Deployment Component's code. The declaration consists of an
+        optional description, the security role name used in the
+        code, and an optional link to a security role. If the
+        security role is not specified, the Deployer must choose an
+        appropriate security role.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description"
+                   type="jakartaee:descriptionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="role-name"
+                   type="jakartaee:role-nameType">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The value of the role-name element must be the String used
+            as the parameter to the 
+            EJBContext.isCallerInRole(String roleName) method or the
+            HttpServletRequest.isUserInRole(String role) method.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="role-link"
+                   type="jakartaee:role-nameType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The role-link element is a reference to a defined
+            security role. The role-link element must contain
+            the name of one of the security roles defined in the
+            security-role elements.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="xsdQNameType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        This type adds an "id" attribute to xsd:QName.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:extension base="xsd:QName">
+        <xsd:attribute name="id"
+                       type="xsd:ID"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="xsdBooleanType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        This type adds an "id" attribute to xsd:boolean.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:extension base="xsd:boolean">
+        <xsd:attribute name="id"
+                       type="xsd:ID"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="xsdNMTOKENType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        This type adds an "id" attribute to xsd:NMTOKEN.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:extension base="xsd:NMTOKEN">
+        <xsd:attribute name="id"
+                       type="xsd:ID"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="xsdAnyURIType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        This type adds an "id" attribute to xsd:anyURI.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:extension base="xsd:anyURI">
+        <xsd:attribute name="id"
+                       type="xsd:ID"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="xsdIntegerType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        This type adds an "id" attribute to xsd:integer.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:extension base="xsd:integer">
+        <xsd:attribute name="id"
+                       type="xsd:ID"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="xsdPositiveIntegerType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        This type adds an "id" attribute to xsd:positiveInteger.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:extension base="xsd:positiveInteger">
+        <xsd:attribute name="id"
+                       type="xsd:ID"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="xsdNonNegativeIntegerType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        This type adds an "id" attribute to xsd:nonNegativeInteger.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:extension base="xsd:nonNegativeInteger">
+        <xsd:attribute name="id"
+                       type="xsd:ID"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="xsdStringType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        This type adds an "id" attribute to xsd:string.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:extension base="xsd:string">
+        <xsd:attribute name="id"
+                       type="xsd:ID"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="string">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        This is a special string datatype that is defined by Jakarta EE as
+        a base type for defining collapsed strings. When schemas
+        require trailing/leading space elimination as well as
+        collapsing the existing whitespace, this base type may be
+        used.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:extension base="xsd:token">
+        <xsd:attribute name="id"
+                       type="xsd:ID"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="true-falseType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        This simple type designates a boolean with only two
+        permissible values
+        
+        - true
+        - false
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="jakartaee:xsdBooleanType">
+        <xsd:pattern value="(true|false)"/>
+      </xsd:restriction>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="url-patternType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The url-patternType contains the url pattern of the mapping.
+        It must follow the rules specified in Section 11.2 of the
+        Servlet API Specification. This pattern is assumed to be in
+        URL-decoded form and must not contain CR(#xD) or LF(#xA).
+        If it contains those characters, the container must inform
+        the developer with a descriptive error message.
+        The container must preserve all characters including whitespaces.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:extension base="xsd:string"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="message-destinationType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        The message-destinationType specifies a message
+        destination. The logical destination described by this
+        element is mapped to a physical destination by the Deployer.
+        
+        The message destination element contains: 
+        
+        - an optional description
+        - an optional display-name
+        - an optional icon
+        - a message destination name which must be unique
+        among message destination names within the same 
+        Deployment File. 
+        - an optional mapped name
+        - an optional lookup name
+        
+        Example: 
+        
+        <message-destination>
+        <message-destination-name>CorporateStocks
+        </message-destination-name>
+        </message-destination>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="jakartaee:descriptionGroup"/>
+      <xsd:element name="message-destination-name"
+                   type="jakartaee:string">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The message-destination-name element specifies a
+            name for a message destination.  This name must be
+            unique among the names of message destinations
+            within the Deployment File.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="mapped-name"
+                   type="jakartaee:xsdStringType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            A product specific name that this message destination
+            should be mapped to.  Each message-destination-ref
+            element that references this message destination will
+            define a name in the namespace of the referencing
+            component or in one of the other predefined namespaces. 
+            Many application servers provide a way to map these
+            local names to names of resources known to the
+            application server.  This mapped name is often a global
+            JNDI name, but may be a name of any form.  Each of the
+            local names should be mapped to this same global name.
+            
+            Application servers are not required to support any
+            particular form or type of mapped name, nor the ability
+            to use mapped names.  The mapped name is
+            product-dependent and often installation-dependent.  No
+            use of a mapped name is portable.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="lookup-name"
+                   type="jakartaee:xsdStringType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The JNDI name to be looked up to resolve the message destination.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="message-destination-refType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        The message-destination-ref element contains a declaration
+        of Deployment Component's reference to a message destination
+        associated with a resource in Deployment Component's
+        environment. It consists of:
+        
+        - an optional description
+        - the message destination reference name
+        - an optional message destination type
+        - an optional specification as to whether
+        the destination is used for 
+        consuming or producing messages, or both.
+        if not specified, "both" is assumed.
+        - an optional link to the message destination
+        - optional injection targets
+        
+        The message destination type must be supplied unless an
+        injection target is specified, in which case the type
+        of the target is used.  If both are specified, the type
+        must be assignment compatible with the type of the injection
+        target.
+        
+        Examples:
+        
+        <message-destination-ref>
+        <message-destination-ref-name>jms/StockQueue
+        </message-destination-ref-name>
+        <message-destination-type>jakarta.jms.Queue
+        </message-destination-type>
+        <message-destination-usage>Consumes
+        </message-destination-usage>
+        <message-destination-link>CorporateStocks
+        </message-destination-link>
+        </message-destination-ref>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description"
+                   type="jakartaee:descriptionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="message-destination-ref-name"
+                   type="jakartaee:jndi-nameType">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The message-destination-ref-name element specifies
+            the name of a message destination reference; its
+            value is the environment entry name used in
+            Deployment Component code.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="message-destination-type"
+                   type="jakartaee:message-destination-typeType"
+                   minOccurs="0"/>
+      <xsd:element name="message-destination-usage"
+                   type="jakartaee:message-destination-usageType"
+                   minOccurs="0"/>
+      <xsd:element name="message-destination-link"
+                   type="jakartaee:message-destination-linkType"
+                   minOccurs="0"/>
+      <xsd:group ref="jakartaee:resourceGroup"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="message-destination-usageType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The message-destination-usageType specifies the use of the
+        message destination indicated by the reference.  The value
+        indicates whether messages are consumed from the message
+        destination, produced for the destination, or both.  The
+        Assembler makes use of this information in linking producers
+        of a destination with its consumers.
+        
+        The value of the message-destination-usage element must be
+        one of the following:
+        Consumes
+        Produces
+        ConsumesProduces
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="jakartaee:string">
+        <xsd:enumeration value="Consumes"/>
+        <xsd:enumeration value="Produces"/>
+        <xsd:enumeration value="ConsumesProduces"/>
+      </xsd:restriction>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="message-destination-typeType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        The message-destination-typeType specifies the type of
+        the destination. The type is specified by the Java interface
+        expected to be implemented by the destination.
+        
+        Example: 
+        
+        <message-destination-type>jakarta.jms.Queue
+        </message-destination-type>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="jakartaee:fully-qualified-classType"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="message-destination-linkType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The message-destination-linkType is used to link a message
+        destination reference or message-driven bean to a message
+        destination.
+        
+        The Assembler sets the value to reflect the flow of messages
+        between producers and consumers in the application.
+        
+        The value must be the message-destination-name of a message
+        destination in the same Deployment File or in another
+        Deployment File in the same Jakarta EE application unit.
+        
+        Alternatively, the value may be composed of a path name
+        specifying a Deployment File containing the referenced
+        message destination with the message-destination-name of the
+        destination appended and separated from the path name by
+        "#". The path name is relative to the Deployment File
+        containing Deployment Component that is referencing the
+        message destination.  This allows multiple message
+        destinations with the same name to be uniquely identified.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="jakartaee:string"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="transaction-supportType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The transaction-supportType specifies the level of
+        transaction support provided by the resource adapter. It is
+        used by transaction-support elements.
+        
+        The value must be one of the following:
+        
+        NoTransaction
+        LocalTransaction
+        XATransaction
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="jakartaee:string">
+        <xsd:enumeration value="NoTransaction"/>
+        <xsd:enumeration value="LocalTransaction"/>
+        <xsd:enumeration value="XATransaction"/>
+      </xsd:restriction>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+</xsd:schema>

--- a/impl/src/main/resources/org/apache/myfaces/resource/jakartaee_web_services_client_2_0.xsd
+++ b/impl/src/main/resources/org/apache/myfaces/resource/jakartaee_web_services_client_2_0.xsd
@@ -1,0 +1,714 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns="http://www.w3.org/2001/XMLSchema"
+            targetNamespace="https://jakarta.ee/xml/ns/jakartaee"
+            xmlns:jakartaee="https://jakarta.ee/xml/ns/jakartaee"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            elementFormDefault="qualified"
+            attributeFormDefault="unqualified"
+            version="2.0">
+  <xsd:annotation>
+    <xsd:documentation>
+
+      Copyright (c) 2009, 2021 Oracle and/or its affiliates. All rights reserved.
+      
+      This program and the accompanying materials are made available under the
+      terms of the Eclipse Public License v. 2.0, which is available at
+      http://www.eclipse.org/legal/epl-2.0.
+      
+      This Source Code may also be made available under the following Secondary
+      Licenses when the conditions for such availability set forth in the
+      Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+      version 2 with the GNU Classpath Exception, which is available at
+      https://www.gnu.org/software/classpath/license.html.
+      
+      SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+      
+    </xsd:documentation>
+  </xsd:annotation>
+
+  <xsd:annotation>
+    <xsd:documentation>
+
+      (C) Copyright International Business Machines Corporation 2002
+      
+    </xsd:documentation>
+  </xsd:annotation>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="service-refType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The service-ref element declares a reference to a Web
+        service. It contains optional description, display name and
+        icons, a declaration of the required Service interface,
+        an optional WSDL document location, an optional set
+        of Jakarta XML RPC mappings, an optional QName for the service element,
+        an optional set of Service Endpoint Interfaces to be resolved 
+        by the container to a WSDL port, and an optional set of handlers.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="jakartaee:descriptionGroup"/>
+      <xsd:element name="service-ref-name"
+                   type="jakartaee:jndi-nameType">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The service-ref-name element declares logical name that the
+            components in the module use to look up the Web service. It 
+            is recommended that all service reference names start with 
+            "service/".
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="service-interface"
+                   type="jakartaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The service-interface element declares the fully qualified class
+            name of the Jakarta XML RPC Service interface the client depends on. 
+            In most cases the value will be jakarta.xml.rpc.Service.  A Jakarta XML 
+            RPC generated Service Interface class may also be specified.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="service-ref-type"
+                   type="jakartaee:fully-qualified-classType"
+                   minOccurs="0"
+                   maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The service-ref-type element declares the type of the service-ref 
+            element that is injected or returned when a JNDI lookup is done.
+            This must be either a fully qualified name of Service class or 
+            the fully qualified name of service endpoint interface class. 
+            This is only used with Jakarta XML Web Services runtime where
+            the corresponding @WebServiceRef annotation can be used to denote both 
+            a Service or a Port.
+            
+            If this is not specified, then the type of service-ref element 
+            that is injected or returned when a JNDI lookup is done is 
+            always a Service interface/class.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="wsdl-file"
+                   type="jakartaee:xsdAnyURIType"
+                   minOccurs="0"
+                   maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The wsdl-file element contains the URI location of a WSDL
+            file. The location is relative to the root of the module.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="jaxrpc-mapping-file"
+                   type="jakartaee:pathType"
+                   minOccurs="0"
+                   maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The jaxrpc-mapping-file element contains the name of a file that
+            describes the Jakarta XML RPC mapping between the Java interaces used by
+            the application and the WSDL description in the wsdl-file.  The 
+            file name is a relative path within the module file.
+            
+            This is not required when Jakarta Enterprise Web Services based 
+            runtime is used.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="service-qname"
+                   type="jakartaee:xsdQNameType"
+                   minOccurs="0"
+                   maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The service-qname element declares the specific WSDL service
+            element that is being refered to.  It is not specified if no
+            wsdl-file is declared.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="port-component-ref"
+                   type="jakartaee:port-component-refType"
+                   minOccurs="0"
+                   maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The port-component-ref element declares a client dependency
+            on the container for resolving a Service Endpoint Interface
+            to a WSDL port. It optionally associates the Service Endpoint
+            Interface with a particular port-component. This is only used
+            by the container for a Service.getPort(Class) method call.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:choice>
+        <xsd:element name="handler"
+                     type="jakartaee:handlerType"
+                     minOccurs="0"
+                     maxOccurs="unbounded">
+          <xsd:annotation>
+            <xsd:documentation>
+
+              	Declares the handler for a port-component. Handlers can
+              	access the init-param name/value pairs using the
+              	HandlerInfo interface. If port-name is not specified, the
+              	handler is assumed to be associated with all ports of the
+              	service.
+              
+              	To be used with Jakarta XML RPC based runtime only.
+              
+            </xsd:documentation>
+          </xsd:annotation>
+        </xsd:element>
+        <xsd:element name="handler-chains"
+                     type="jakartaee:handler-chainsType"
+                     minOccurs="0"
+                     maxOccurs="1">
+          <xsd:annotation>
+            <xsd:documentation>
+
+              	 To be used with Jakarta XML Web Services based runtime only.
+              
+            </xsd:documentation>
+          </xsd:annotation>
+        </xsd:element>
+      </xsd:choice>
+      <xsd:group ref="jakartaee:resourceGroup"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="port-component-refType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The port-component-ref element declares a client dependency
+        on the container for resolving a Service Endpoint Interface
+        to a WSDL port. It optionally associates the Service Endpoint
+        Interface with a particular port-component. This is only used
+        by the container for a Service.getPort(Class) method call.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="service-endpoint-interface"
+                   type="jakartaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The service-endpoint-interface element defines a fully qualified
+            Java class that represents the Service Endpoint Interface of a
+            WSDL port.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="enable-mtom"
+                   type="jakartaee:true-falseType"
+                   minOccurs="0"
+                   maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Used to enable or disable SOAP MTOM/XOP mechanism on the client
+            side for a port-component. 
+            
+            Not to be specified for Jakarta XML RPC runtime
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="mtom-threshold"
+                   type="jakartaee:xsdNonNegativeIntegerType"
+                   minOccurs="0"
+                   maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            When MTOM is enabled, binary data above this size in bytes
+            should be XOP encoded or sent as attachment. Default value is 0.
+            
+            Not to be specified for Jakarta XML RPC runtime
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="addressing"
+                   type="jakartaee:addressingType"
+                   minOccurs="0"
+                   maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            This specifies the WS-Addressing requirements for a Jakarta XML 
+            web service. It corresponds to jakarta.xml.ws.soap.Addressing
+            annotation or its feature jakarta.xml.ws.soap.AddressingFeature.
+            
+            See the addressingType for more information.
+            
+            Not to be specified for Jakarta XML RPC runtime
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="respect-binding"
+                   type="jakartaee:respect-bindingType"
+                   minOccurs="0"
+                   maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Corresponds to the jakarta.xml.ws.RespectBinding annotation
+            or its corresponding jakarta.xml.ws.RespectBindingFeature web
+            service feature. This is used to control whether a Jakarta XML Web 
+            Services implementation must respect/honor the contents of the
+            wsdl:binding in the WSDL that is associated with the service.
+            
+            Not to be specified for Jakarta XML RPC runtime
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="port-component-link"
+                   type="jakartaee:string"
+                   minOccurs="0"
+                   maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The port-component-link element links a port-component-ref
+            to a specific port-component required to be made available
+            by a service reference.
+            
+            The value of a port-component-link must be the
+            port-component-name of a port-component in the same module
+            or another module in the same application unit. The syntax
+            for specification follows the syntax defined for ejb-link
+            in the EJB 2.0 specification.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="handler-chainsType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The handler-chains element defines the handlerchains associated with this
+        service or service endpoint.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="handler-chain"
+                   type="jakartaee:handler-chainType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="handler-chainType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The handler-chain element defines the handlerchain. 
+        Handlerchain can be defined such that the handlers in the
+        handlerchain operate,all ports of a service, on a specific
+        port or on a list of protocol-bindings. The choice of elements
+        service-name-pattern, port-name-pattern and protocol-bindings
+        are used to specify whether the handlers in handler-chain are
+        for a service, port or protocol binding. If none of these 
+        choices are specified with the handler-chain element then the
+        handlers specified in the handler-chain will be applied on 
+        everything.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:choice minOccurs="0"
+                  maxOccurs="1">
+        <xsd:element name="service-name-pattern"
+                     type="jakartaee:qname-pattern"/>
+        <xsd:element name="port-name-pattern"
+                     type="jakartaee:qname-pattern"/>
+        <xsd:element name="protocol-bindings"
+                     type="jakartaee:protocol-bindingListType"/>
+      </xsd:choice>
+      <xsd:element name="handler"
+                   type="jakartaee:handlerType"
+                   minOccurs="1"
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+  <xsd:simpleType name="protocol-bindingListType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        Defines the type used for specifying a list of
+        protocol-bindingType(s). For e.g.
+        
+        ##SOAP11_HTTP ##SOAP12_HTTP ##XML_HTTP
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:list itemType="jakartaee:protocol-bindingType"/>
+  </xsd:simpleType>
+
+  <xsd:simpleType name="protocol-bindingType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        Defines the type used for specifying the URI for the
+        protocol binding used by the port-component.  For
+        portability one could use one of the following tokens that
+        alias the standard binding types: 
+        
+        ##SOAP11_HTTP
+        ##SOAP11_HTTP_MTOM
+        ##SOAP12_HTTP
+        ##SOAP12_HTTP_MTOM
+        ##XML_HTTP
+        
+        Other specifications could define tokens that start with ##
+        to alias new standard binding URIs that are introduced.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:union memberTypes="xsd:anyURI jakartaee:protocol-URIAliasType"/>
+  </xsd:simpleType>
+
+  <xsd:simpleType name="protocol-URIAliasType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        Defines the type that is used for specifying tokens that
+        start with ## which are used to alias existing standard
+        protocol bindings and support aliases for new standard
+        binding URIs that are introduced in future specifications.
+        
+        The following tokens alias the standard protocol binding
+        URIs:
+        
+        ##SOAP11_HTTP = "http://schemas.xmlsoap.org/wsdl/soap/http"
+        ##SOAP11_HTTP_MTOM = 
+        "http://schemas.xmlsoap.org/wsdl/soap/http?mtom=true"
+        ##SOAP12_HTTP = "http://www.w3.org/2003/05/soap/bindings/HTTP/"
+        ##SOAP12_HTTP_MTOM = 
+        "http://www.w3.org/2003/05/soap/bindings/HTTP/?mtom=true"
+        ##XML_HTTP = "http://www.w3.org/2004/08/wsdl/http"
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:restriction base="xsd:token">
+      <xsd:pattern value="##.+"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+  <xsd:simpleType name="qname-pattern">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        This is used to specify the QName pattern in the
+        attribute service-name-pattern and port-name-pattern in
+        the handler-chain element
+        
+        For example, the various forms acceptable here for
+        service-name-pattern attribute in handler-chain element
+        are :
+        
+        Exact Name: service-name-pattern="ns1:EchoService"
+        
+        	 In this case, handlers specified in this
+        	 handler-chain element will apply to all ports with
+        	 this exact service name. The namespace prefix must
+        	 have been declared in a namespace declaration
+        	 attribute in either the start-tag of the element
+        	 where the prefix is used or in an an ancestor 
+        	 element (i.e. an element in whose content the 
+        	 prefixed markup occurs)
+        	 
+        
+        Pattern : service-name-pattern="ns1:EchoService*"
+        
+        	 In this case, handlers specified in this
+        	 handler-chain element will apply to all ports whose
+        	 Service names are like EchoService1, EchoServiceFoo
+        	 etc. The namespace prefix must have been declared in
+        	 a namespace declaration attribute in either the
+        	 start-tag of the element where the prefix is used or
+        	 in an an ancestor element (i.e. an element in whose 
+        	 content the prefixed markup occurs)
+        
+        Wild Card : service-name-pattern="*"
+        
+        	In this case, handlers specified in this handler-chain
+        	element will apply to ports of all service names.
+        
+        The same can be applied to port-name attribute in
+        handler-chain element.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:restriction base="xsd:token">
+      <xsd:pattern value="\*|([\i-[:]][\c-[:]]*:)?[\i-[:]][\c-[:]]*\*?"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="addressingType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        This specifies the WS-Addressing requirements for a Jakarta XML web 
+        service. It corresponds to jakarta.xml.ws.soap.Addressing annotation or its
+        feature jakarta.xml.ws.soap.AddressingFeature.
+        
+        If the "enabled" element is "true", WS-Addressing is enabled.
+        It means that the endpoint supports WS-Addressing but does not require
+        its use. The default value for "enabled" is "true".
+        
+        If the WS-Addressing is enabled and the "required" element is "true",
+        it means that the endpoint requires WS-Addressing. The default value
+        for "required" is "false".
+        
+        If WS-Addressing is enabled, the "responses" element determines
+        if an endpoint requires the use of only anonymous responses,
+        or only non-anonymous responses, or all. The value of the "responses"
+        element must be one of the following:
+        
+        ANONYMOUS
+        NON_ANONYMOUS
+        ALL
+        
+        The default value for the "responses" is ALL.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="enabled"
+                   type="jakartaee:true-falseType"
+                   minOccurs="0"
+                   maxOccurs="1"/>
+      <xsd:element name="required"
+                   type="jakartaee:true-falseType"
+                   minOccurs="0"
+                   maxOccurs="1"/>
+      <xsd:element name="responses"
+                   type="jakartaee:addressing-responsesType"
+                   minOccurs="0"
+                   maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="addressing-responsesType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        If WS-Addressing is enabled, this type determines if an endpoint
+        requires the use of only anonymous responses, or only non-anonymous
+        responses, or all.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="jakartaee:string">
+        <xsd:enumeration value="ANONYMOUS"/>
+        <xsd:enumeration value="NON_ANONYMOUS"/>
+        <xsd:enumeration value="ALL"/>
+      </xsd:restriction>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="respect-bindingType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        Corresponds to the jakarta.xml.ws.RespectBinding annotation
+        or its corresponding jakarta.xml.ws.RespectBindingFeature web
+        service feature. This is used to control whether a Jakarta XML 
+        Web Services implementation must respect/honor the contents of the
+        wsdl:binding in the WSDL that is associated with the service.
+        
+        If the "enabled" element is "true", wsdl:binding in the
+        associated WSDL, if any, must be respected/honored.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="enabled"
+                   type="jakartaee:true-falseType"
+                   minOccurs="0"
+                   maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="handlerType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        Declares the handler for a port-component, service-ref. Handlers can
+        access the init-param name/value pairs using the HandlerInfo interface.
+        
+        Used in: port-component, service-ref
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="jakartaee:descriptionGroup"/>
+      <xsd:element name="handler-name"
+                   type="jakartaee:string">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Defines the name of the handler. The name must be unique within the
+            module.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="handler-class"
+                   type="jakartaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Defines a fully qualified class name for the handler implementation.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="init-param"
+                   type="jakartaee:param-valueType"
+                   minOccurs="0"
+                   maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Not to be specified for Jakarta XML Web Services runtime
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="soap-header"
+                   type="jakartaee:xsdQNameType"
+                   minOccurs="0"
+                   maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Defines the QName of a SOAP header that will be processed by the
+            handler.
+            
+            Not to be specified for Jakarta XML Web Services runtime
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="soap-role"
+                   type="jakartaee:string"
+                   minOccurs="0"
+                   maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The soap-role element contains a SOAP actor definition that the
+            Handler will play as a role.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="port-name"
+                   type="jakartaee:string"
+                   minOccurs="0"
+                   maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The port-name element defines the WSDL port-name that a
+            handler should be associated with. If port-name is not
+            specified, the handler is assumed to be associated with
+            all ports of the service.
+            
+            Not to be specified for Jakarta XML Web Services runtime
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+  <xsd:group name="service-refGroup">
+    <xsd:sequence>
+      <xsd:element name="service-ref"
+                   type="jakartaee:service-refType"
+                   minOccurs="0"
+                   maxOccurs="unbounded">
+        <xsd:key name="service-ref_handler-name-key">
+          <xsd:annotation>
+            <xsd:documentation>
+
+              Defines the name of the handler. The name must be unique
+              within the module.
+              
+            </xsd:documentation>
+          </xsd:annotation>
+          <xsd:selector xpath="jakartaee:handler"/>
+          <xsd:field xpath="jakartaee:handler-name"/>
+        </xsd:key>
+      </xsd:element>
+    </xsd:sequence>
+  </xsd:group>
+
+</xsd:schema>

--- a/impl/src/main/resources/org/apache/myfaces/resource/javaee_8.xsd
+++ b/impl/src/main/resources/org/apache/myfaces/resource/javaee_8.xsd
@@ -1,0 +1,3098 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema targetNamespace="http://xmlns.jcp.org/xml/ns/javaee"
+            xmlns:javaee="http://xmlns.jcp.org/xml/ns/javaee"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            elementFormDefault="qualified"
+            attributeFormDefault="unqualified"
+            version="8">
+  <xsd:annotation>
+    <xsd:documentation>
+
+      DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+      
+      Copyright (c) 2009-2017 Oracle and/or its affiliates. All rights reserved.
+      
+      The contents of this file are subject to the terms of either the GNU
+      General Public License Version 2 only ("GPL") or the Common Development
+      and Distribution License("CDDL") (collectively, the "License").  You
+      may not use this file except in compliance with the License.  You can
+      obtain a copy of the License at
+      https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
+      or packager/legal/LICENSE.txt.  See the License for the specific
+      language governing permissions and limitations under the License.
+      
+      When distributing the software, include this License Header Notice in each
+      file and include the License file at packager/legal/LICENSE.txt.
+      
+      GPL Classpath Exception:
+      Oracle designates this particular file as subject to the "Classpath"
+      exception as provided by Oracle in the GPL Version 2 section of the License
+      file that accompanied this code.
+      
+      Modifications:
+      If applicable, add the following below the License Header, with the fields
+      enclosed by brackets [] replaced by your own identifying information:
+      "Portions Copyright [year] [name of copyright owner]"
+      
+      Contributor(s):
+      If you wish your version of this file to be governed by only the CDDL or
+      only the GPL Version 2, indicate your decision by adding "[Contributor]
+      elects to include this software in this distribution under the [CDDL or GPL
+      Version 2] license."  If you don't indicate a single choice of license, a
+      recipient has the option to distribute your version of this file under
+      either the CDDL, the GPL Version 2 or to extend the choice of license to
+      its licensees as provided above.  However, if you add GPL Version 2 code
+      and therefore, elected the GPL Version 2 license, then the option applies
+      only if the new code is made subject to such option by the copyright
+      holder.
+      
+    </xsd:documentation>
+  </xsd:annotation>
+
+  <xsd:annotation>
+    <xsd:documentation>
+
+      The following definitions that appear in the common
+      shareable schema(s) of Java EE deployment descriptors should be
+      interpreted with respect to the context they are included:
+      
+      Deployment Component may indicate one of the following:
+      java ee application;
+      application client;
+      web application;
+      enterprise bean;
+      resource adapter; 
+      
+      Deployment File may indicate one of the following:
+      ear file;
+      war file;
+      jar file;
+      rar file;
+      
+    </xsd:documentation>
+  </xsd:annotation>
+
+  <xsd:import namespace="http://www.w3.org/XML/1998/namespace"
+              schemaLocation="http://www.w3.org/2001/xml.xsd"/>
+
+  <xsd:include schemaLocation="javaee_web_services_client_1_4.xsd"/>
+
+  <xsd:group name="descriptionGroup">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        This group keeps the usage of the contained description related
+        elements consistent across Java EE deployment descriptors.
+        
+        All elements may occur multiple times with different languages,
+        to support localization of the content.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description"
+                   type="javaee:descriptionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="display-name"
+                   type="javaee:display-nameType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="icon"
+                   type="javaee:iconType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:group>
+
+  <xsd:group name="jndiEnvironmentRefsGroup">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        This group keeps the usage of the contained JNDI environment
+        reference elements consistent across Java EE deployment descriptors.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="env-entry"
+                   type="javaee:env-entryType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="ejb-ref"
+                   type="javaee:ejb-refType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="ejb-local-ref"
+                   type="javaee:ejb-local-refType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:group ref="javaee:service-refGroup"/>
+      <xsd:element name="resource-ref"
+                   type="javaee:resource-refType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="resource-env-ref"
+                   type="javaee:resource-env-refType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="message-destination-ref"
+                   type="javaee:message-destination-refType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="persistence-context-ref"
+                   type="javaee:persistence-context-refType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="persistence-unit-ref"
+                   type="javaee:persistence-unit-refType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="post-construct"
+                   type="javaee:lifecycle-callbackType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="pre-destroy"
+                   type="javaee:lifecycle-callbackType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="data-source"
+                   type="javaee:data-sourceType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="jms-connection-factory"
+                   type="javaee:jms-connection-factoryType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="jms-destination"
+                   type="javaee:jms-destinationType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="mail-session"
+                   type="javaee:mail-sessionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="connection-factory"
+                   type="javaee:connection-factory-resourceType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="administered-object"
+                   type="javaee:administered-objectType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:group>
+
+  <xsd:group name="resourceGroup">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        This group collects elements that are common to most
+        JNDI resource elements.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="javaee:resourceBaseGroup"/>
+      <xsd:element name="lookup-name"
+                   type="javaee:xsdStringType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The JNDI name to be looked up to resolve a resource reference.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+  </xsd:group>
+
+  <xsd:group name="resourceBaseGroup">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        This group collects elements that are common to all the
+        JNDI resource elements. It does not include the lookup-name
+        element, that is only applicable to some resource elements.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="mapped-name"
+                   type="javaee:xsdStringType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            A product specific name that this resource should be
+            mapped to.  The name of this resource, as defined by the
+            resource's name element or defaulted, is a name that is
+            local to the application component using the resource.
+            (It's a name in the JNDI java:comp/env namespace.)  Many
+            application servers provide a way to map these local
+            names to names of resources known to the application
+            server.  This mapped name is often a global JNDI name,
+            but may be a name of any form.
+            
+            Application servers are not required to support any
+            particular form or type of mapped name, nor the ability
+            to use mapped names.  The mapped name is
+            product-dependent and often installation-dependent.  No
+            use of a mapped name is portable.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="injection-target"
+                   type="javaee:injection-targetType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:group>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="administered-objectType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        Configuration of an administered object.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description"
+                   type="javaee:descriptionType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Description of this administered object.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="name"
+                   type="javaee:jndi-nameType">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The name element specifies the JNDI name of the
+            administered object being defined.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="interface-name"
+                   type="javaee:fully-qualified-classType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The administered object's interface type.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="class-name"
+                   type="javaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The administered object's class name.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="resource-adapter"
+                   type="javaee:string">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Resource adapter name.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="property"
+                   type="javaee:propertyType"
+                   minOccurs="0"
+                   maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Property of the administered object property.  This may be a 
+            vendor-specific property.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="connection-factory-resourceType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        Configuration of a Connector Connection Factory resource.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description"
+                   type="javaee:descriptionType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Description of this resource.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="name"
+                   type="javaee:jndi-nameType">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The name element specifies the JNDI name of the
+            resource being defined.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="interface-name"
+                   type="javaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The fully qualified class name of the connection factory 
+            interface. 
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="resource-adapter"
+                   type="javaee:string">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Resource adapter name.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="max-pool-size"
+                   type="javaee:xsdIntegerType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Maximum number of connections that should be concurrently
+            allocated for a connection pool.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="min-pool-size"
+                   type="javaee:xsdIntegerType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Minimum number of connections that should be concurrently
+            allocated for a connection pool.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="transaction-support"
+                   type="javaee:transaction-supportType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The level of transaction support the connection factory 
+            needs to support. 
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="property"
+                   type="javaee:propertyType"
+                   minOccurs="0"
+                   maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Resource property.  This may be a vendor-specific
+            property.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="data-sourceType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        Configuration of a DataSource.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description"
+                   type="javaee:descriptionType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Description of this DataSource.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="name"
+                   type="javaee:jndi-nameType">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The name element specifies the JNDI name of the
+            data source being defined.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="class-name"
+                   type="javaee:fully-qualified-classType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            DataSource, XADataSource or ConnectionPoolDataSource
+            implementation class.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="server-name"
+                   type="javaee:string"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Database server name.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="port-number"
+                   type="javaee:xsdIntegerType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Port number where a server is listening for requests.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="database-name"
+                   type="javaee:string"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Name of a database on a server.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="url"
+                   type="javaee:jdbc-urlType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            A JDBC URL. If the <code>url</code> property is specified
+            along with other standard <code>DataSource</code> properties
+            such as <code>serverName</code>, <code>databaseName</code>
+            and <code>portNumber</code>, the more specific properties will
+            take precedence and <code>url</code> will be ignored.
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="user"
+                   type="javaee:string"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            User name to use for connection authentication.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="password"
+                   type="javaee:string"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Password to use for connection authentication.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="property"
+                   type="javaee:propertyType"
+                   minOccurs="0"
+                   maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            JDBC DataSource property.  This may be a vendor-specific
+            property or a less commonly used DataSource property.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="login-timeout"
+                   type="javaee:xsdIntegerType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Sets the maximum time in seconds that this data source
+            will wait while attempting to connect to a database.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="transactional"
+                   type="javaee:xsdBooleanType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Set to false if connections should not participate in
+            transactions.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="isolation-level"
+                   type="javaee:isolation-levelType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Isolation level for connections.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="initial-pool-size"
+                   type="javaee:xsdIntegerType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Number of connections that should be created when a
+            connection pool is initialized.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="max-pool-size"
+                   type="javaee:xsdIntegerType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Maximum number of connections that should be concurrently
+            allocated for a connection pool.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="min-pool-size"
+                   type="javaee:xsdIntegerType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Minimum number of connections that should be concurrently
+            allocated for a connection pool.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="max-idle-time"
+                   type="javaee:xsdIntegerType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The number of seconds that a physical connection should
+            remain unused in the pool before the connection is
+            closed for a connection pool.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="max-statements"
+                   type="javaee:xsdIntegerType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The total number of statements that a connection pool
+            should keep open.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="descriptionType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The description type is used by a description element to
+        provide text describing the parent element.  The elements
+        that use this type should include any information that the
+        Deployment Component's Deployment File file producer wants
+        to provide to the consumer of the Deployment Component's
+        Deployment File (i.e., to the Deployer). Typically, the
+        tools used by such a Deployment File consumer will display
+        the description when processing the parent element that
+        contains the description.
+        
+        The lang attribute defines the language that the
+        description is provided in. The default value is "en" (English). 
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:extension base="javaee:xsdStringType">
+        <xsd:attribute ref="xml:lang"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+  <xsd:simpleType name="dewey-versionType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        This type defines a dewey decimal that is used
+        to describe versions of documents. 
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:restriction base="xsd:token">
+      <xsd:pattern value="\.?[0-9]+(\.[0-9]+)*"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="display-nameType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        The display-name type contains a short name that is intended
+        to be displayed by tools. It is used by display-name
+        elements.  The display name need not be unique.
+        
+        Example: 
+        
+        ...
+        <display-name xml:lang="en">
+        Employee Self Service
+        </display-name>
+        
+        The value of the xml:lang attribute is "en" (English) by default. 
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:extension base="javaee:string">
+        <xsd:attribute ref="xml:lang"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="ejb-linkType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        The ejb-linkType is used by ejb-link
+        elements in the ejb-ref or ejb-local-ref elements to specify
+        that an EJB reference is linked to enterprise bean.
+        
+        The value of the ejb-link element must be the ejb-name of an
+        enterprise bean in the same ejb-jar file or in another ejb-jar
+        file in the same Java EE application unit. 
+        
+        Alternatively, the name in the ejb-link element may be
+        composed of a path name specifying the ejb-jar containing the
+        referenced enterprise bean with the ejb-name of the target
+        bean appended and separated from the path name by "#".  The
+        path name is relative to the Deployment File containing
+        Deployment Component that is referencing the enterprise
+        bean.  This allows multiple enterprise beans with the same
+        ejb-name to be uniquely identified.
+        
+        Examples:
+        
+        <ejb-link>EmployeeRecord</ejb-link>
+        
+        <ejb-link>../products/product.jar#ProductEJB</ejb-link>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="javaee:string"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="ejb-local-refType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The ejb-local-refType is used by ejb-local-ref elements for
+        the declaration of a reference to an enterprise bean's local
+        home or to the local business interface of a 3.0 bean.
+        The declaration consists of:
+        
+        - an optional description
+        - the EJB reference name used in the code of the Deployment 
+        Component that's referencing the enterprise bean.
+        - the optional expected type of the referenced enterprise bean
+        - the optional expected local interface of the referenced 
+        enterprise bean or the local business interface of the 
+        referenced enterprise bean.
+        - the optional expected local home interface of the referenced 
+        enterprise bean. Not applicable if this ejb-local-ref refers
+        to the local business interface of a 3.0 bean.
+        - optional ejb-link information, used to specify the 
+        referenced enterprise bean
+        - optional elements to define injection of the named enterprise  
+        bean into a component field or property.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description"
+                   type="javaee:descriptionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="ejb-ref-name"
+                   type="javaee:ejb-ref-nameType"/>
+      <xsd:element name="ejb-ref-type"
+                   type="javaee:ejb-ref-typeType"
+                   minOccurs="0"/>
+      <xsd:element name="local-home"
+                   type="javaee:local-homeType"
+                   minOccurs="0"/>
+      <xsd:element name="local"
+                   type="javaee:localType"
+                   minOccurs="0"/>
+      <xsd:element name="ejb-link"
+                   type="javaee:ejb-linkType"
+                   minOccurs="0"/>
+      <xsd:group ref="javaee:resourceGroup"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="ejb-ref-nameType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        The ejb-ref-name element contains the name of an EJB
+        reference. The EJB reference is an entry in the
+        Deployment Component's environment and is relative to the
+        java:comp/env context.  The name must be unique within the
+        Deployment Component.
+        
+        It is recommended that name is prefixed with "ejb/".
+        
+        Example:
+        
+        <ejb-ref-name>ejb/Payroll</ejb-ref-name>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="javaee:jndi-nameType"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="ejb-refType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The ejb-refType is used by ejb-ref elements for the
+        declaration of a reference to an enterprise bean's home or
+        to the remote business interface of a 3.0 bean.  
+        The declaration consists of:
+        
+        - an optional description
+        - the EJB reference name used in the code of
+        the Deployment Component that's referencing the enterprise
+        bean. 
+        - the optional expected type of the referenced enterprise bean
+        - the optional remote interface of the referenced enterprise bean
+        or the remote business interface of the referenced enterprise 
+        bean
+        - the optional expected home interface of the referenced 
+        enterprise bean.  Not applicable if this ejb-ref
+        refers to the remote business interface of a 3.0 bean.
+        - optional ejb-link information, used to specify the
+        referenced enterprise bean
+        - optional elements to define injection of the named enterprise
+        bean into a component field or property
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description"
+                   type="javaee:descriptionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="ejb-ref-name"
+                   type="javaee:ejb-ref-nameType"/>
+      <xsd:element name="ejb-ref-type"
+                   type="javaee:ejb-ref-typeType"
+                   minOccurs="0"/>
+      <xsd:element name="home"
+                   type="javaee:homeType"
+                   minOccurs="0"/>
+      <xsd:element name="remote"
+                   type="javaee:remoteType"
+                   minOccurs="0"/>
+      <xsd:element name="ejb-link"
+                   type="javaee:ejb-linkType"
+                   minOccurs="0"/>
+      <xsd:group ref="javaee:resourceGroup"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="ejb-ref-typeType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The ejb-ref-typeType contains the expected type of the
+        referenced enterprise bean.
+        
+        The ejb-ref-type designates a value
+        that must be one of the following:
+        
+        Entity
+        Session
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="javaee:string">
+        <xsd:enumeration value="Entity"/>
+        <xsd:enumeration value="Session"/>
+      </xsd:restriction>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="emptyType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        This type is used to designate an empty
+        element when used. 
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="env-entryType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The env-entryType is used to declare an application's
+        environment entry. The declaration consists of an optional
+        description, the name of the environment entry, a type
+        (optional if the value is injected, otherwise required), and
+        an optional value.
+        
+        It also includes optional elements to define injection of
+        the named resource into fields or JavaBeans properties.
+        
+        If a value is not specified and injection is requested,
+        no injection will occur and no entry of the specified name
+        will be created.  This allows an initial value to be
+        specified in the source code without being incorrectly
+        changed when no override has been specified.
+        
+        If a value is not specified and no injection is requested,
+        a value must be supplied during deployment. 
+        
+        This type is used by env-entry elements.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description"
+                   type="javaee:descriptionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="env-entry-name"
+                   type="javaee:jndi-nameType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            The env-entry-name element contains the name of a
+            Deployment Component's environment entry.  The name
+            is a JNDI name relative to the java:comp/env
+            context.  The name must be unique within a 
+            Deployment Component. The uniqueness
+            constraints must be defined within the declared
+            context.
+            
+            Example:
+            
+            <env-entry-name>minAmount</env-entry-name>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="env-entry-type"
+                   type="javaee:env-entry-type-valuesType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            The env-entry-type element contains the Java language
+            type of the environment entry.  If an injection target
+            is specified for the environment entry, the type may
+            be omitted, or must match the type of the injection
+            target.  If no injection target is specified, the type
+            is required.
+            
+            Example:
+            
+            <env-entry-type>java.lang.Integer</env-entry-type>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="env-entry-value"
+                   type="javaee:xsdStringType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            The env-entry-value designates the value of a
+            Deployment Component's environment entry. The value
+            must be a String that is valid for the
+            constructor of the specified type that takes a
+            single String parameter, or for java.lang.Character,
+            a single character.
+            
+            Example:
+            
+            <env-entry-value>100.00</env-entry-value>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:group ref="javaee:resourceGroup"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="env-entry-type-valuesType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        This type contains the fully-qualified Java type of the
+        environment entry value that is expected by the
+        application's code.
+        
+        The following are the legal values of env-entry-type-valuesType:
+        
+        java.lang.Boolean
+        java.lang.Byte
+        java.lang.Character
+        java.lang.String
+        java.lang.Short
+        java.lang.Integer
+        java.lang.Long
+        java.lang.Float
+        java.lang.Double
+        		  java.lang.Class
+        		  any enumeration type (i.e. a subclass of java.lang.Enum)
+        
+        Examples:
+        
+        <env-entry-type>java.lang.Boolean</env-entry-type>
+        <env-entry-type>java.lang.Class</env-entry-type>
+        <env-entry-type>com.example.Color</env-entry-type>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="javaee:fully-qualified-classType"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="fully-qualified-classType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The elements that use this type designate the name of a
+        Java class or interface.  The name is in the form of a
+        "binary name", as defined in the JLS.  This is the form
+        of name used in Class.forName().  Tools that need the
+        canonical name (the name used in source code) will need
+        to convert this binary name to the canonical name.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="javaee:string"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="generic-booleanType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        This type defines four different values which can designate
+        boolean values. This includes values yes and no which are 
+        not designated by xsd:boolean
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="javaee:string">
+        <xsd:enumeration value="true"/>
+        <xsd:enumeration value="false"/>
+        <xsd:enumeration value="yes"/>
+        <xsd:enumeration value="no"/>
+      </xsd:restriction>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="iconType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The icon type contains small-icon and large-icon elements
+        that specify the file names for small and large GIF, JPEG,
+        or PNG icon images used to represent the parent element in a
+        GUI tool. 
+        
+        The xml:lang attribute defines the language that the
+        icon file names are provided in. Its value is "en" (English)
+        by default. 
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="small-icon"
+                   type="javaee:pathType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            The small-icon element contains the name of a file
+            containing a small (16 x 16) icon image. The file
+            name is a relative path within the Deployment
+            Component's Deployment File.
+            
+            The image may be in the GIF, JPEG, or PNG format.
+            The icon can be used by tools.
+            
+            Example:
+            
+            <small-icon>employee-service-icon16x16.jpg</small-icon>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="large-icon"
+                   type="javaee:pathType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            The large-icon element contains the name of a file
+            containing a large
+            (32 x 32) icon image. The file name is a relative 
+            path within the Deployment Component's Deployment
+            File.
+            
+            The image may be in the GIF, JPEG, or PNG format.
+            The icon can be used by tools.
+            
+            Example:
+            
+            <large-icon>employee-service-icon32x32.jpg</large-icon>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute ref="xml:lang"/>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="injection-targetType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        An injection target specifies a class and a name within
+        that class into which a resource should be injected.
+        
+        The injection target class specifies the fully qualified
+        class name that is the target of the injection.  The
+        Java EE specifications describe which classes can be an
+        injection target.
+        
+        The injection target name specifies the target within
+        the specified class.  The target is first looked for as a
+        JavaBeans property name.  If not found, the target is
+        looked for as a field name.
+        
+        The specified resource will be injected into the target
+        during initialization of the class by either calling the
+        set method for the target property or by setting a value
+        into the named field.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="injection-target-class"
+                   type="javaee:fully-qualified-classType"/>
+      <xsd:element name="injection-target-name"
+                   type="javaee:java-identifierType"/>
+    </xsd:sequence>
+  </xsd:complexType>
+
+  <xsd:simpleType name="isolation-levelType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        	The following transaction isolation levels are allowed
+        	(see documentation for the java.sql.Connection interface):
+        TRANSACTION_READ_UNCOMMITTED
+        TRANSACTION_READ_COMMITTED
+        TRANSACTION_REPEATABLE_READ
+        TRANSACTION_SERIALIZABLE
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="TRANSACTION_READ_UNCOMMITTED"/>
+      <xsd:enumeration value="TRANSACTION_READ_COMMITTED"/>
+      <xsd:enumeration value="TRANSACTION_REPEATABLE_READ"/>
+      <xsd:enumeration value="TRANSACTION_SERIALIZABLE"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="java-identifierType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The java-identifierType defines a Java identifier.
+        The users of this type should further verify that 
+        the content does not contain Java reserved keywords.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="javaee:string">
+        <xsd:pattern value="($|_|\p{L})(\p{L}|\p{Nd}|_|$)*"/>
+      </xsd:restriction>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="java-typeType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        This is a generic type that designates a Java primitive
+        type or a fully qualified name of a Java interface/type,
+        or an array of such types.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="javaee:string">
+        <xsd:pattern value="[^\p{Z}]*"/>
+      </xsd:restriction>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="jdbc-urlType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        The jdbc-urlType contains the url pattern of the mapping.
+        It must follow the rules specified in Section 9.3 of the
+        JDBC Specification where the format is:
+        
+        jdbc:<subprotocol>:<subname>
+        
+        Example:
+        
+        <url>jdbc:mysql://localhost:3307/testdb</url>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="javaee:string">
+        <xsd:pattern value="jdbc:(.*):(.*)"/>
+      </xsd:restriction>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="jms-connection-factoryType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        Configuration of a JMS Connection Factory.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description"
+                   type="javaee:descriptionType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Description of this JMS Connection Factory.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="name"
+                   type="javaee:jndi-nameType">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The name element specifies the JNDI name of the
+            JMS connection factory being defined.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="interface-name"
+                   type="javaee:fully-qualified-classType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Fully-qualified name of the JMS connection factory
+            interface.  Permitted values are javax.jms.ConnectionFactory,
+            javax.jms.QueueConnectionFactory, or 
+            javax.jms.TopicConnectionFactory.  If not specified,
+            javax.jms.ConnectionFactory will be used.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="class-name"
+                   type="javaee:fully-qualified-classType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Fully-qualified name of the JMS connection factory
+            implementation class.  Ignored if a resource adapter  
+            is used.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="resource-adapter"
+                   type="javaee:string"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Resource adapter name.  If not specified, the application
+            server will define the default behavior, which may or may
+            not involve the use of a resource adapter.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="user"
+                   type="javaee:string"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            User name to use for connection authentication.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="password"
+                   type="javaee:string"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Password to use for connection authentication.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="client-id"
+                   type="javaee:string"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Client id to use for connection.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="property"
+                   type="javaee:propertyType"
+                   minOccurs="0"
+                   maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            JMS Connection Factory property.  This may be a vendor-specific
+            property or a less commonly used ConnectionFactory property.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="transactional"
+                   type="javaee:xsdBooleanType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Set to false if connections should not participate in
+            transactions.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="max-pool-size"
+                   type="javaee:xsdIntegerType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Maximum number of connections that should be concurrently
+            allocated for a connection pool.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="min-pool-size"
+                   type="javaee:xsdIntegerType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Minimum number of connections that should be concurrently
+            allocated for a connection pool.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="jms-destinationType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        Configuration of a JMS Destination.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description"
+                   type="javaee:descriptionType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Description of this JMS Destination.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="name"
+                   type="javaee:jndi-nameType">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The name element specifies the JNDI name of the
+            JMS destination being defined.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="interface-name"
+                   type="javaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Fully-qualified name of the JMS destination interface.
+            Permitted values are javax.jms.Queue and javax.jms.Topic
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="class-name"
+                   type="javaee:fully-qualified-classType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Fully-qualified name of the JMS destination implementation
+            class.  Ignored if a resource adapter is used unless the
+            resource adapter defines more than one destination implementation
+            class for the specified interface.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="resource-adapter"
+                   type="javaee:string"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Resource adapter name.  If not specified, the application
+            server will define the default behavior, which may or may
+            not involve the use of a resource adapter.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="destination-name"
+                   type="javaee:string"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Name of the queue or topic.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="property"
+                   type="javaee:propertyType"
+                   minOccurs="0"
+                   maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            JMS Destination property.  This may be a vendor-specific
+            property or a less commonly used Destination property.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="jndi-nameType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The jndi-nameType type designates a JNDI name in the
+        Deployment Component's environment and is relative to the
+        java:comp/env context.  A JNDI name must be unique within the
+        Deployment Component.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="javaee:string"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="homeType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        The homeType defines the fully-qualified name of
+        an enterprise bean's home interface. 
+        
+        Example:
+        
+        <home>com.aardvark.payroll.PayrollHome</home>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="javaee:fully-qualified-classType"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="lifecycle-callbackType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The lifecycle-callback type specifies a method on a
+        class to be called when a lifecycle event occurs.
+        Note that each class may have only one lifecycle callback
+        method for any given event and that the method may not
+        be overloaded.
+        
+        If the lifefycle-callback-class element is missing then
+        the class defining the callback is assumed to be the
+        component class in scope at the place in the descriptor
+        in which the callback definition appears.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="lifecycle-callback-class"
+                   type="javaee:fully-qualified-classType"
+                   minOccurs="0"/>
+      <xsd:element name="lifecycle-callback-method"
+                   type="javaee:java-identifierType"/>
+    </xsd:sequence>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="listenerType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The listenerType indicates the deployment properties for a web
+        application listener bean.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="javaee:descriptionGroup"/>
+      <xsd:element name="listener-class"
+                   type="javaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The listener-class element declares a class in the
+            application must be registered as a web
+            application listener bean. The value is the fully
+            qualified classname of the listener class.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="localType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The localType defines the fully-qualified name of an
+        enterprise bean's local interface.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="javaee:fully-qualified-classType"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="local-homeType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The local-homeType defines the fully-qualified
+        name of an enterprise bean's local home interface.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="javaee:fully-qualified-classType"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="mail-sessionType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        Configuration of a Mail Session resource.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description"
+                   type="javaee:descriptionType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Description of this Mail Session resource.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="name"
+                   type="javaee:jndi-nameType">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The name element specifies the JNDI name of the
+            Mail Session resource being defined.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="store-protocol"
+                   type="javaee:string"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Storage protocol.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="store-protocol-class"
+                   type="javaee:fully-qualified-classType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Service provider store protocol implementation class
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="transport-protocol"
+                   type="javaee:string"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Transport protocol.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="transport-protocol-class"
+                   type="javaee:fully-qualified-classType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Service provider transport protocol implementation class
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="host"
+                   type="javaee:string"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Mail server host name.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="user"
+                   type="javaee:string"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Mail server user name.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="password"
+                   type="javaee:string"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Password.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="from"
+                   type="javaee:string"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Email address to indicate the message sender.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="property"
+                   type="javaee:propertyType"
+                   minOccurs="0"
+                   maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Mail server property.  This may be a vendor-specific
+            property.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="param-valueType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        This type is a general type that can be used to declare
+        parameter/value lists.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description"
+                   type="javaee:descriptionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="param-name"
+                   type="javaee:string">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The param-name element contains the name of a
+            parameter.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="param-value"
+                   type="javaee:xsdStringType">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The param-value element contains the value of a
+            parameter.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="pathType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The elements that use this type designate either a relative
+        path or an absolute path starting with a "/".
+        
+        In elements that specify a pathname to a file within the
+        same Deployment File, relative filenames (i.e., those not
+        starting with "/") are considered relative to the root of
+        the Deployment File's namespace.  Absolute filenames (i.e.,
+        those starting with "/") also specify names in the root of
+        the Deployment File's namespace.  In general, relative names
+        are preferred.  The exception is .war files where absolute
+        names are preferred for consistency with the Servlet API.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="javaee:string"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="persistence-context-refType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        The persistence-context-ref element contains a declaration
+        of Deployment Component's reference to a persistence context
+        associated within a Deployment Component's
+        environment. It consists of:
+        
+        - an optional description
+        - the persistence context reference name
+        - an optional persistence unit name.  If not specified,
+        the default persistence unit is assumed.
+        - an optional specification as to whether
+        the persistence context type is Transaction or
+        Extended.  If not specified, Transaction is assumed.
+        - an optional specification as to whether
+        the persistence context synchronization with the current
+        transaction is Synchronized or Unsynchronized. If not
+        specified, Synchronized is assumed.
+        - an optional list of persistence properties
+        - optional injection targets
+        
+        Examples:
+        
+        <persistence-context-ref>
+        <persistence-context-ref-name>myPersistenceContext
+        </persistence-context-ref-name>
+        </persistence-context-ref>
+        
+        <persistence-context-ref>
+        <persistence-context-ref-name>myPersistenceContext
+        </persistence-context-ref-name>
+        <persistence-unit-name>PersistenceUnit1
+        </persistence-unit-name>
+        <persistence-context-type>Extended</persistence-context-type>
+        </persistence-context-ref>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description"
+                   type="javaee:descriptionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="persistence-context-ref-name"
+                   type="javaee:jndi-nameType">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The persistence-context-ref-name element specifies
+            the name of a persistence context reference; its
+            value is the environment entry name used in
+            Deployment Component code.  The name is a JNDI name
+            relative to the java:comp/env context.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="persistence-unit-name"
+                   type="javaee:string"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The Application Assembler(or BeanProvider) may use the
+            following syntax to avoid the need to rename persistence
+            units to have unique names within a Java EE application.
+            
+            The Application Assembler specifies the pathname of the
+            root of the persistence.xml file for the referenced
+            persistence unit and appends the name of the persistence
+            unit separated from the pathname by #. The pathname is
+            relative to the referencing application component jar file. 
+            In this manner, multiple persistence units with the same
+            persistence unit name may be uniquely identified when the 
+            Application Assembler cannot change persistence unit names.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="persistence-context-type"
+                   type="javaee:persistence-context-typeType"
+                   minOccurs="0"/>
+      <xsd:element name="persistence-context-synchronization"
+                   type="javaee:persistence-context-synchronizationType"
+                   minOccurs="0"/>
+      <xsd:element name="persistence-property"
+                   type="javaee:propertyType"
+                   minOccurs="0"
+                   maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Used to specify properties for the container or persistence
+            provider.  Vendor-specific properties may be included in
+            the set of properties.  Properties that are not recognized
+            by a vendor must be ignored.  Entries that make use of the 
+            namespace javax.persistence and its subnamespaces must not
+            be used for vendor-specific properties.  The namespace
+            javax.persistence is reserved for use by the specification.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:group ref="javaee:resourceBaseGroup"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="persistence-context-synchronizationType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The persistence-context-synchronizationType specifies 
+        whether a container-managed persistence context is automatically
+        synchronized with the current transaction.
+        
+        The value of the persistence-context-synchronization element 
+        must be one of the following:
+        Synchronized
+        Unsynchronized
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="javaee:string">
+        <xsd:enumeration value="Synchronized"/>
+        <xsd:enumeration value="Unsynchronized"/>
+      </xsd:restriction>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="persistence-context-typeType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The persistence-context-typeType specifies the transactional
+        nature of a persistence context reference.  
+        
+        The value of the persistence-context-type element must be
+        one of the following:
+        Transaction
+        Extended
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="javaee:string">
+        <xsd:enumeration value="Transaction"/>
+        <xsd:enumeration value="Extended"/>
+      </xsd:restriction>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="propertyType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        Specifies a name/value pair.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="name"
+                   type="javaee:xsdStringType">
+      </xsd:element>
+      <xsd:element name="value"
+                   type="javaee:xsdStringType">
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="persistence-unit-refType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        The persistence-unit-ref element contains a declaration
+        of Deployment Component's reference to a persistence unit
+        associated within a Deployment Component's
+        environment. It consists of:
+        
+        - an optional description
+        - the persistence unit reference name
+        - an optional persistence unit name.  If not specified,
+        the default persistence unit is assumed.
+        - optional injection targets
+        
+        Examples:
+        
+        <persistence-unit-ref>
+        <persistence-unit-ref-name>myPersistenceUnit
+        </persistence-unit-ref-name>
+        </persistence-unit-ref>
+        
+        <persistence-unit-ref>
+        <persistence-unit-ref-name>myPersistenceUnit
+        </persistence-unit-ref-name>
+        <persistence-unit-name>PersistenceUnit1
+        </persistence-unit-name>
+        </persistence-unit-ref>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description"
+                   type="javaee:descriptionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="persistence-unit-ref-name"
+                   type="javaee:jndi-nameType">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The persistence-unit-ref-name element specifies
+            the name of a persistence unit reference; its
+            value is the environment entry name used in
+            Deployment Component code.  The name is a JNDI name
+            relative to the java:comp/env context.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="persistence-unit-name"
+                   type="javaee:string"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The Application Assembler(or BeanProvider) may use the
+            following syntax to avoid the need to rename persistence
+            units to have unique names within a Java EE application.
+            
+            The Application Assembler specifies the pathname of the
+            root of the persistence.xml file for the referenced
+            persistence unit and appends the name of the persistence
+            unit separated from the pathname by #. The pathname is
+            relative to the referencing application component jar file. 
+            In this manner, multiple persistence units with the same
+            persistence unit name may be uniquely identified when the 
+            Application Assembler cannot change persistence unit names.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:group ref="javaee:resourceBaseGroup"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="remoteType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        The remote element contains the fully-qualified name
+        of the enterprise bean's remote interface.
+        
+        Example:
+        
+        <remote>com.wombat.empl.EmployeeService</remote>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="javaee:fully-qualified-classType"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="resource-env-refType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        The resource-env-refType is used to define
+        resource-env-ref elements.  It contains a declaration of a
+        Deployment Component's reference to an administered object
+        associated with a resource in the Deployment Component's
+        environment.  It consists of an optional description, the
+        resource environment reference name, and an optional
+        indication of the resource environment reference type
+        expected by the Deployment Component code.
+        
+        It also includes optional elements to define injection of
+        the named resource into fields or JavaBeans properties.
+        
+        The resource environment type must be supplied unless an
+        injection target is specified, in which case the type
+        of the target is used.  If both are specified, the type
+        must be assignment compatible with the type of the injection
+        target.
+        
+        Example:
+        
+        <resource-env-ref>
+        <resource-env-ref-name>jms/StockQueue
+        </resource-env-ref-name>
+        <resource-env-ref-type>javax.jms.Queue
+        </resource-env-ref-type>
+        </resource-env-ref>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description"
+                   type="javaee:descriptionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="resource-env-ref-name"
+                   type="javaee:jndi-nameType">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The resource-env-ref-name element specifies the name
+            of a resource environment reference; its value is
+            the environment entry name used in
+            the Deployment Component code.  The name is a JNDI 
+            name relative to the java:comp/env context and must 
+            be unique within a Deployment Component.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="resource-env-ref-type"
+                   type="javaee:fully-qualified-classType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The resource-env-ref-type element specifies the type
+            of a resource environment reference.  It is the
+            fully qualified name of a Java language class or
+            interface.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:group ref="javaee:resourceGroup"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="resource-refType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        The resource-refType contains a declaration of a
+        Deployment Component's reference to an external resource. It
+        consists of an optional description, the resource manager
+        connection factory reference name, an optional indication of
+        the resource manager connection factory type expected by the
+        Deployment Component code, an optional type of authentication
+        (Application or Container), and an optional specification of
+        the shareability of connections obtained from the resource
+        (Shareable or Unshareable).
+        
+        It also includes optional elements to define injection of
+        the named resource into fields or JavaBeans properties.
+        
+        The connection factory type must be supplied unless an
+        injection target is specified, in which case the type
+        of the target is used.  If both are specified, the type
+        must be assignment compatible with the type of the injection
+        target.
+        
+        Example:
+        
+        <resource-ref>
+        <res-ref-name>jdbc/EmployeeAppDB</res-ref-name>
+        <res-type>javax.sql.DataSource</res-type>
+        <res-auth>Container</res-auth>
+        <res-sharing-scope>Shareable</res-sharing-scope>
+        </resource-ref>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description"
+                   type="javaee:descriptionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="res-ref-name"
+                   type="javaee:jndi-nameType">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The res-ref-name element specifies the name of a
+            resource manager connection factory reference.
+            The name is a JNDI name relative to the
+            java:comp/env context.  
+            The name must be unique within a Deployment File. 
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="res-type"
+                   type="javaee:fully-qualified-classType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The res-type element specifies the type of the data
+            source. The type is specified by the fully qualified
+            Java language class or interface
+            expected to be implemented by the data source.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="res-auth"
+                   type="javaee:res-authType"
+                   minOccurs="0"/>
+      <xsd:element name="res-sharing-scope"
+                   type="javaee:res-sharing-scopeType"
+                   minOccurs="0"/>
+      <xsd:group ref="javaee:resourceGroup"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="res-authType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The res-authType specifies whether the Deployment Component
+        code signs on programmatically to the resource manager, or
+        whether the Container will sign on to the resource manager
+        on behalf of the Deployment Component. In the latter case,
+        the Container uses information that is supplied by the
+        Deployer.
+        
+        The value must be one of the two following:
+        
+        Application
+        Container
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="javaee:string">
+        <xsd:enumeration value="Application"/>
+        <xsd:enumeration value="Container"/>
+      </xsd:restriction>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="res-sharing-scopeType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The res-sharing-scope type specifies whether connections
+        obtained through the given resource manager connection
+        factory reference can be shared. The value, if specified,
+        must be one of the two following:
+        
+        Shareable
+        Unshareable
+        
+        The default value is Shareable.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="javaee:string">
+        <xsd:enumeration value="Shareable"/>
+        <xsd:enumeration value="Unshareable"/>
+      </xsd:restriction>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="run-asType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The run-asType specifies the run-as identity to be
+        used for the execution of a component. It contains an 
+        optional description, and the name of a security role.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description"
+                   type="javaee:descriptionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="role-name"
+                   type="javaee:role-nameType"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="role-nameType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The role-nameType designates the name of a security role.
+        
+        The name must conform to the lexical rules for a token.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="javaee:string"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="security-roleType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        The security-roleType contains the definition of a security
+        role. The definition consists of an optional description of
+        the security role, and the security role name.
+        
+        Example:
+        
+        <security-role>
+        <description>
+        This role includes all employees who are authorized
+        to access the employee service application.
+        </description>
+        <role-name>employee</role-name>
+        </security-role>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description"
+                   type="javaee:descriptionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="role-name"
+                   type="javaee:role-nameType"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="security-role-refType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The security-role-refType contains the declaration of a
+        security role reference in a component's or a
+        Deployment Component's code. The declaration consists of an
+        optional description, the security role name used in the
+        code, and an optional link to a security role. If the
+        security role is not specified, the Deployer must choose an
+        appropriate security role.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description"
+                   type="javaee:descriptionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="role-name"
+                   type="javaee:role-nameType">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The value of the role-name element must be the String used
+            as the parameter to the 
+            EJBContext.isCallerInRole(String roleName) method or the
+            HttpServletRequest.isUserInRole(String role) method.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="role-link"
+                   type="javaee:role-nameType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The role-link element is a reference to a defined
+            security role. The role-link element must contain
+            the name of one of the security roles defined in the
+            security-role elements.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="xsdQNameType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        This type adds an "id" attribute to xsd:QName.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:extension base="xsd:QName">
+        <xsd:attribute name="id"
+                       type="xsd:ID"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="xsdBooleanType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        This type adds an "id" attribute to xsd:boolean.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:extension base="xsd:boolean">
+        <xsd:attribute name="id"
+                       type="xsd:ID"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="xsdNMTOKENType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        This type adds an "id" attribute to xsd:NMTOKEN.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:extension base="xsd:NMTOKEN">
+        <xsd:attribute name="id"
+                       type="xsd:ID"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="xsdAnyURIType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        This type adds an "id" attribute to xsd:anyURI.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:extension base="xsd:anyURI">
+        <xsd:attribute name="id"
+                       type="xsd:ID"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="xsdIntegerType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        This type adds an "id" attribute to xsd:integer.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:extension base="xsd:integer">
+        <xsd:attribute name="id"
+                       type="xsd:ID"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="xsdPositiveIntegerType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        This type adds an "id" attribute to xsd:positiveInteger.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:extension base="xsd:positiveInteger">
+        <xsd:attribute name="id"
+                       type="xsd:ID"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="xsdNonNegativeIntegerType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        This type adds an "id" attribute to xsd:nonNegativeInteger.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:extension base="xsd:nonNegativeInteger">
+        <xsd:attribute name="id"
+                       type="xsd:ID"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="xsdStringType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        This type adds an "id" attribute to xsd:string.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:extension base="xsd:string">
+        <xsd:attribute name="id"
+                       type="xsd:ID"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="string">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        This is a special string datatype that is defined by Java EE as
+        a base type for defining collapsed strings. When schemas
+        require trailing/leading space elimination as well as
+        collapsing the existing whitespace, this base type may be
+        used.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:extension base="xsd:token">
+        <xsd:attribute name="id"
+                       type="xsd:ID"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="true-falseType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        This simple type designates a boolean with only two
+        permissible values
+        
+        - true
+        - false
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="javaee:xsdBooleanType">
+        <xsd:pattern value="(true|false)"/>
+      </xsd:restriction>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="url-patternType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The url-patternType contains the url pattern of the mapping.
+        It must follow the rules specified in Section 11.2 of the
+        Servlet API Specification. This pattern is assumed to be in
+        URL-decoded form and must not contain CR(#xD) or LF(#xA).
+        If it contains those characters, the container must inform
+        the developer with a descriptive error message.
+        The container must preserve all characters including whitespaces.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:extension base="xsd:string"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="message-destinationType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        The message-destinationType specifies a message
+        destination. The logical destination described by this
+        element is mapped to a physical destination by the Deployer.
+        
+        The message destination element contains: 
+        
+        - an optional description
+        - an optional display-name
+        - an optional icon
+        - a message destination name which must be unique
+        among message destination names within the same 
+        Deployment File. 
+        - an optional mapped name
+        - an optional lookup name
+        
+        Example: 
+        
+        <message-destination>
+        <message-destination-name>CorporateStocks
+        </message-destination-name>
+        </message-destination>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="javaee:descriptionGroup"/>
+      <xsd:element name="message-destination-name"
+                   type="javaee:string">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The message-destination-name element specifies a
+            name for a message destination.  This name must be
+            unique among the names of message destinations
+            within the Deployment File.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="mapped-name"
+                   type="javaee:xsdStringType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            A product specific name that this message destination
+            should be mapped to.  Each message-destination-ref
+            element that references this message destination will
+            define a name in the namespace of the referencing
+            component or in one of the other predefined namespaces. 
+            Many application servers provide a way to map these
+            local names to names of resources known to the
+            application server.  This mapped name is often a global
+            JNDI name, but may be a name of any form.  Each of the
+            local names should be mapped to this same global name.
+            
+            Application servers are not required to support any
+            particular form or type of mapped name, nor the ability
+            to use mapped names.  The mapped name is
+            product-dependent and often installation-dependent.  No
+            use of a mapped name is portable.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="lookup-name"
+                   type="javaee:xsdStringType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The JNDI name to be looked up to resolve the message destination.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="message-destination-refType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        The message-destination-ref element contains a declaration
+        of Deployment Component's reference to a message destination
+        associated with a resource in Deployment Component's
+        environment. It consists of:
+        
+        - an optional description
+        - the message destination reference name
+        - an optional message destination type
+        - an optional specification as to whether
+        the destination is used for 
+        consuming or producing messages, or both.
+        if not specified, "both" is assumed.
+        - an optional link to the message destination
+        - optional injection targets
+        
+        The message destination type must be supplied unless an
+        injection target is specified, in which case the type
+        of the target is used.  If both are specified, the type
+        must be assignment compatible with the type of the injection
+        target.
+        
+        Examples:
+        
+        <message-destination-ref>
+        <message-destination-ref-name>jms/StockQueue
+        </message-destination-ref-name>
+        <message-destination-type>javax.jms.Queue
+        </message-destination-type>
+        <message-destination-usage>Consumes
+        </message-destination-usage>
+        <message-destination-link>CorporateStocks
+        </message-destination-link>
+        </message-destination-ref>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description"
+                   type="javaee:descriptionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="message-destination-ref-name"
+                   type="javaee:jndi-nameType">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The message-destination-ref-name element specifies
+            the name of a message destination reference; its
+            value is the environment entry name used in
+            Deployment Component code.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="message-destination-type"
+                   type="javaee:message-destination-typeType"
+                   minOccurs="0"/>
+      <xsd:element name="message-destination-usage"
+                   type="javaee:message-destination-usageType"
+                   minOccurs="0"/>
+      <xsd:element name="message-destination-link"
+                   type="javaee:message-destination-linkType"
+                   minOccurs="0"/>
+      <xsd:group ref="javaee:resourceGroup"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="message-destination-usageType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The message-destination-usageType specifies the use of the
+        message destination indicated by the reference.  The value
+        indicates whether messages are consumed from the message
+        destination, produced for the destination, or both.  The
+        Assembler makes use of this information in linking producers
+        of a destination with its consumers.
+        
+        The value of the message-destination-usage element must be
+        one of the following:
+        Consumes
+        Produces
+        ConsumesProduces
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="javaee:string">
+        <xsd:enumeration value="Consumes"/>
+        <xsd:enumeration value="Produces"/>
+        <xsd:enumeration value="ConsumesProduces"/>
+      </xsd:restriction>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="message-destination-typeType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        The message-destination-typeType specifies the type of
+        the destination. The type is specified by the Java interface
+        expected to be implemented by the destination.
+        
+        Example: 
+        
+        <message-destination-type>javax.jms.Queue
+        </message-destination-type>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="javaee:fully-qualified-classType"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="message-destination-linkType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The message-destination-linkType is used to link a message
+        destination reference or message-driven bean to a message
+        destination.
+        
+        The Assembler sets the value to reflect the flow of messages
+        between producers and consumers in the application.
+        
+        The value must be the message-destination-name of a message
+        destination in the same Deployment File or in another
+        Deployment File in the same Java EE application unit.
+        
+        Alternatively, the value may be composed of a path name
+        specifying a Deployment File containing the referenced
+        message destination with the message-destination-name of the
+        destination appended and separated from the path name by
+        "#". The path name is relative to the Deployment File
+        containing Deployment Component that is referencing the
+        message destination.  This allows multiple message
+        destinations with the same name to be uniquely identified.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="javaee:string"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="transaction-supportType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The transaction-supportType specifies the level of
+        transaction support provided by the resource adapter. It is
+        used by transaction-support elements.
+        
+        The value must be one of the following:
+        
+        NoTransaction
+        LocalTransaction
+        XATransaction
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="javaee:string">
+        <xsd:enumeration value="NoTransaction"/>
+        <xsd:enumeration value="LocalTransaction"/>
+        <xsd:enumeration value="XATransaction"/>
+      </xsd:restriction>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+</xsd:schema>

--- a/impl/src/main/resources/org/apache/myfaces/resource/javaee_web_services_client_1_4.xsd
+++ b/impl/src/main/resources/org/apache/myfaces/resource/javaee_web_services_client_1_4.xsd
@@ -1,0 +1,737 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns="http://www.w3.org/2001/XMLSchema"
+            targetNamespace="http://xmlns.jcp.org/xml/ns/javaee"
+            xmlns:javaee="http://xmlns.jcp.org/xml/ns/javaee"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            elementFormDefault="qualified"
+            attributeFormDefault="unqualified"
+            version="1.4">
+  <xsd:annotation>
+    <xsd:documentation>
+
+      DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+      
+      Copyright (c) 2009-2013 Oracle and/or its affiliates. All rights reserved.
+      
+      The contents of this file are subject to the terms of either the GNU
+      General Public License Version 2 only ("GPL") or the Common Development
+      and Distribution License("CDDL") (collectively, the "License").  You
+      may not use this file except in compliance with the License.  You can
+      obtain a copy of the License at
+      https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
+      or packager/legal/LICENSE.txt.  See the License for the specific
+      language governing permissions and limitations under the License.
+      
+      When distributing the software, include this License Header Notice in each
+      file and include the License file at packager/legal/LICENSE.txt.
+      
+      GPL Classpath Exception:
+      Oracle designates this particular file as subject to the "Classpath"
+      exception as provided by Oracle in the GPL Version 2 section of the License
+      file that accompanied this code.
+      
+      Modifications:
+      If applicable, add the following below the License Header, with the fields
+      enclosed by brackets [] replaced by your own identifying information:
+      "Portions Copyright [year] [name of copyright owner]"
+      
+      Contributor(s):
+      If you wish your version of this file to be governed by only the CDDL or
+      only the GPL Version 2, indicate your decision by adding "[Contributor]
+      elects to include this software in this distribution under the [CDDL or GPL
+      Version 2] license."  If you don't indicate a single choice of license, a
+      recipient has the option to distribute your version of this file under
+      either the CDDL, the GPL Version 2 or to extend the choice of license to
+      its licensees as provided above.  However, if you add GPL Version 2 code
+      and therefore, elected the GPL Version 2 license, then the option applies
+      only if the new code is made subject to such option by the copyright
+      holder.
+      
+    </xsd:documentation>
+  </xsd:annotation>
+
+  <xsd:annotation>
+    <xsd:documentation>
+
+      (C) Copyright International Business Machines Corporation 2002
+      
+    </xsd:documentation>
+  </xsd:annotation>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="service-refType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The service-ref element declares a reference to a Web
+        service. It contains optional description, display name and
+        icons, a declaration of the required Service interface,
+        an optional WSDL document location, an optional set
+        of JAX-RPC mappings, an optional QName for the service element,
+        an optional set of Service Endpoint Interfaces to be resolved 
+        by the container to a WSDL port, and an optional set of handlers.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="javaee:descriptionGroup"/>
+      <xsd:element name="service-ref-name"
+                   type="javaee:jndi-nameType">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The service-ref-name element declares logical name that the
+            components in the module use to look up the Web service. It 
+            is recommended that all service reference names start with 
+            "service/".
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="service-interface"
+                   type="javaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The service-interface element declares the fully qualified class
+            name of the JAX-RPC Service interface the client depends on. 
+            In most cases the value will be javax.xml.rpc.Service.  A JAX-RPC
+            generated Service Interface class may also be specified.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="service-ref-type"
+                   type="javaee:fully-qualified-classType"
+                   minOccurs="0"
+                   maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The service-ref-type element declares the type of the service-ref 
+            element that is injected or returned when a JNDI lookup is done.
+            This must be either a fully qualified name of Service class or 
+            the fully qualified name of service endpoint interface class. 
+            This is only used with JAX-WS runtime where the corresponding 
+            @WebServiceRef annotation can be used to denote both a Service
+            or a Port.
+            
+            If this is not specified, then the type of service-ref element 
+            that is injected or returned when a JNDI lookup is done is 
+            always a Service interface/class.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="wsdl-file"
+                   type="javaee:xsdAnyURIType"
+                   minOccurs="0"
+                   maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The wsdl-file element contains the URI location of a WSDL
+            file. The location is relative to the root of the module.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="jaxrpc-mapping-file"
+                   type="javaee:pathType"
+                   minOccurs="0"
+                   maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The jaxrpc-mapping-file element contains the name of a file that
+            describes the JAX-RPC mapping between the Java interaces used by
+            the application and the WSDL description in the wsdl-file.  The 
+            file name is a relative path within the module file.
+            
+            This is not required when JAX-WS based runtime is used.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="service-qname"
+                   type="javaee:xsdQNameType"
+                   minOccurs="0"
+                   maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The service-qname element declares the specific WSDL service
+            element that is being refered to.  It is not specified if no
+            wsdl-file is declared.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="port-component-ref"
+                   type="javaee:port-component-refType"
+                   minOccurs="0"
+                   maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The port-component-ref element declares a client dependency
+            on the container for resolving a Service Endpoint Interface
+            to a WSDL port. It optionally associates the Service Endpoint
+            Interface with a particular port-component. This is only used
+            by the container for a Service.getPort(Class) method call.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:choice>
+        <xsd:element name="handler"
+                     type="javaee:handlerType"
+                     minOccurs="0"
+                     maxOccurs="unbounded">
+          <xsd:annotation>
+            <xsd:documentation>
+
+              	Declares the handler for a port-component. Handlers can
+              	access the init-param name/value pairs using the
+              	HandlerInfo interface. If port-name is not specified, the
+              	handler is assumed to be associated with all ports of the
+              	service.
+              
+              	To be used with JAX-RPC based runtime only.
+              
+            </xsd:documentation>
+          </xsd:annotation>
+        </xsd:element>
+        <xsd:element name="handler-chains"
+                     type="javaee:handler-chainsType"
+                     minOccurs="0"
+                     maxOccurs="1">
+          <xsd:annotation>
+            <xsd:documentation>
+
+              	 To be used with JAX-WS based runtime only.
+              
+            </xsd:documentation>
+          </xsd:annotation>
+        </xsd:element>
+      </xsd:choice>
+      <xsd:group ref="javaee:resourceGroup"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="port-component-refType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The port-component-ref element declares a client dependency
+        on the container for resolving a Service Endpoint Interface
+        to a WSDL port. It optionally associates the Service Endpoint
+        Interface with a particular port-component. This is only used
+        by the container for a Service.getPort(Class) method call.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="service-endpoint-interface"
+                   type="javaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The service-endpoint-interface element defines a fully qualified
+            Java class that represents the Service Endpoint Interface of a
+            WSDL port.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="enable-mtom"
+                   type="javaee:true-falseType"
+                   minOccurs="0"
+                   maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Used to enable or disable SOAP MTOM/XOP mechanism on the client
+            side for a port-component. 
+            
+            Not to be specified for JAX-RPC runtime
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="mtom-threshold"
+                   type="javaee:xsdNonNegativeIntegerType"
+                   minOccurs="0"
+                   maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            When MTOM is enabled, binary data above this size in bytes
+            should be XOP encoded or sent as attachment. Default value is 0.
+            
+            Not to be specified for JAX-RPC runtime
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="addressing"
+                   type="javaee:addressingType"
+                   minOccurs="0"
+                   maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            This specifies the WS-Addressing requirements for a JAX-WS
+            web service. It corresponds to javax.xml.ws.soap.Addressing
+            annotation or its feature javax.xml.ws.soap.AddressingFeature.
+            
+            See the addressingType for more information.
+            
+            Not to be specified for JAX-RPC runtime
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="respect-binding"
+                   type="javaee:respect-bindingType"
+                   minOccurs="0"
+                   maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Corresponds to the javax.xml.ws.RespectBinding annotation
+            or its corresponding javax.xml.ws.RespectBindingFeature web
+            service feature. This is used to control whether a JAX-WS
+            implementation must respect/honor the contents of the
+            wsdl:binding in the WSDL that is associated with the service.
+            
+            Not to be specified for JAX-RPC runtime
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="port-component-link"
+                   type="javaee:string"
+                   minOccurs="0"
+                   maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The port-component-link element links a port-component-ref
+            to a specific port-component required to be made available
+            by a service reference.
+            
+            The value of a port-component-link must be the
+            port-component-name of a port-component in the same module
+            or another module in the same application unit. The syntax
+            for specification follows the syntax defined for ejb-link
+            in the EJB 2.0 specification.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="handler-chainsType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The handler-chains element defines the handlerchains associated with this
+        service or service endpoint.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="handler-chain"
+                   type="javaee:handler-chainType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="handler-chainType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The handler-chain element defines the handlerchain. 
+        Handlerchain can be defined such that the handlers in the
+        handlerchain operate,all ports of a service, on a specific
+        port or on a list of protocol-bindings. The choice of elements
+        service-name-pattern, port-name-pattern and protocol-bindings
+        are used to specify whether the handlers in handler-chain are
+        for a service, port or protocol binding. If none of these 
+        choices are specified with the handler-chain element then the
+        handlers specified in the handler-chain will be applied on 
+        everything.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:choice minOccurs="0"
+                  maxOccurs="1">
+        <xsd:element name="service-name-pattern"
+                     type="javaee:qname-pattern"/>
+        <xsd:element name="port-name-pattern"
+                     type="javaee:qname-pattern"/>
+        <xsd:element name="protocol-bindings"
+                     type="javaee:protocol-bindingListType"/>
+      </xsd:choice>
+      <xsd:element name="handler"
+                   type="javaee:handlerType"
+                   minOccurs="1"
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+  <xsd:simpleType name="protocol-bindingListType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        Defines the type used for specifying a list of
+        protocol-bindingType(s). For e.g.
+        
+        ##SOAP11_HTTP ##SOAP12_HTTP ##XML_HTTP
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:list itemType="javaee:protocol-bindingType"/>
+  </xsd:simpleType>
+
+  <xsd:simpleType name="protocol-bindingType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        Defines the type used for specifying the URI for the
+        protocol binding used by the port-component.  For
+        portability one could use one of the following tokens that
+        alias the standard binding types: 
+        
+        ##SOAP11_HTTP
+        ##SOAP11_HTTP_MTOM
+        ##SOAP12_HTTP
+        ##SOAP12_HTTP_MTOM
+        ##XML_HTTP
+        
+        Other specifications could define tokens that start with ##
+        to alias new standard binding URIs that are introduced.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:union memberTypes="xsd:anyURI javaee:protocol-URIAliasType"/>
+  </xsd:simpleType>
+
+  <xsd:simpleType name="protocol-URIAliasType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        Defines the type that is used for specifying tokens that
+        start with ## which are used to alias existing standard
+        protocol bindings and support aliases for new standard
+        binding URIs that are introduced in future specifications.
+        
+        The following tokens alias the standard protocol binding
+        URIs:
+        
+        ##SOAP11_HTTP = "http://schemas.xmlsoap.org/wsdl/soap/http"
+        ##SOAP11_HTTP_MTOM = 
+        "http://schemas.xmlsoap.org/wsdl/soap/http?mtom=true"
+        ##SOAP12_HTTP = "http://www.w3.org/2003/05/soap/bindings/HTTP/"
+        ##SOAP12_HTTP_MTOM = 
+        "http://www.w3.org/2003/05/soap/bindings/HTTP/?mtom=true"
+        ##XML_HTTP = "http://www.w3.org/2004/08/wsdl/http"
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:restriction base="xsd:token">
+      <xsd:pattern value="##.+"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+  <xsd:simpleType name="qname-pattern">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        This is used to specify the QName pattern in the
+        attribute service-name-pattern and port-name-pattern in
+        the handler-chain element
+        
+        For example, the various forms acceptable here for
+        service-name-pattern attribute in handler-chain element
+        are :
+        
+        Exact Name: service-name-pattern="ns1:EchoService"
+        
+        	 In this case, handlers specified in this
+        	 handler-chain element will apply to all ports with
+        	 this exact service name. The namespace prefix must
+        	 have been declared in a namespace declaration
+        	 attribute in either the start-tag of the element
+        	 where the prefix is used or in an an ancestor 
+        	 element (i.e. an element in whose content the 
+        	 prefixed markup occurs)
+        	 
+        
+        Pattern : service-name-pattern="ns1:EchoService*"
+        
+        	 In this case, handlers specified in this
+        	 handler-chain element will apply to all ports whose
+        	 Service names are like EchoService1, EchoServiceFoo
+        	 etc. The namespace prefix must have been declared in
+        	 a namespace declaration attribute in either the
+        	 start-tag of the element where the prefix is used or
+        	 in an an ancestor element (i.e. an element in whose 
+        	 content the prefixed markup occurs)
+        
+        Wild Card : service-name-pattern="*"
+        
+        	In this case, handlers specified in this handler-chain
+        	element will apply to ports of all service names.
+        
+        The same can be applied to port-name attribute in
+        handler-chain element.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:restriction base="xsd:token">
+      <xsd:pattern value="\*|([\i-[:]][\c-[:]]*:)?[\i-[:]][\c-[:]]*\*?"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="addressingType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        This specifies the WS-Addressing requirements for a JAX-WS web service.
+        It corresponds to javax.xml.ws.soap.Addressing annotation or its
+        feature javax.xml.ws.soap.AddressingFeature.
+        
+        If the "enabled" element is "true", WS-Addressing is enabled.
+        It means that the endpoint supports WS-Addressing but does not require
+        its use. The default value for "enabled" is "true".
+        
+        If the WS-Addressing is enabled and the "required" element is "true",
+        it means that the endpoint requires WS-Addressing. The default value
+        for "required" is "false".
+        
+        If WS-Addressing is enabled, the "responses" element determines
+        if an endpoint requires the use of only anonymous responses,
+        or only non-anonymous responses, or all. The value of the "responses"
+        element must be one of the following:
+        
+        ANONYMOUS
+        NON_ANONYMOUS
+        ALL
+        
+        The default value for the "responses" is ALL.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="enabled"
+                   type="javaee:true-falseType"
+                   minOccurs="0"
+                   maxOccurs="1"/>
+      <xsd:element name="required"
+                   type="javaee:true-falseType"
+                   minOccurs="0"
+                   maxOccurs="1"/>
+      <xsd:element name="responses"
+                   type="javaee:addressing-responsesType"
+                   minOccurs="0"
+                   maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="addressing-responsesType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        If WS-Addressing is enabled, this type determines if an endpoint
+        requires the use of only anonymous responses, or only non-anonymous
+        responses, or all.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="javaee:string">
+        <xsd:enumeration value="ANONYMOUS"/>
+        <xsd:enumeration value="NON_ANONYMOUS"/>
+        <xsd:enumeration value="ALL"/>
+      </xsd:restriction>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="respect-bindingType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        Corresponds to the javax.xml.ws.RespectBinding annotation
+        or its corresponding javax.xml.ws.RespectBindingFeature web
+        service feature. This is used to control whether a JAX-WS
+        implementation must respect/honor the contents of the
+        wsdl:binding in the WSDL that is associated with the service.
+        
+        If the "enabled" element is "true", wsdl:binding in the
+        associated WSDL, if any, must be respected/honored.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="enabled"
+                   type="javaee:true-falseType"
+                   minOccurs="0"
+                   maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="handlerType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        Declares the handler for a port-component, service-ref. Handlers can
+        access the init-param name/value pairs using the HandlerInfo interface.
+        
+        Used in: port-component, service-ref
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="javaee:descriptionGroup"/>
+      <xsd:element name="handler-name"
+                   type="javaee:string">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Defines the name of the handler. The name must be unique within the
+            module.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="handler-class"
+                   type="javaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Defines a fully qualified class name for the handler implementation.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="init-param"
+                   type="javaee:param-valueType"
+                   minOccurs="0"
+                   maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Not to be specified for JAX-WS runtime
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="soap-header"
+                   type="javaee:xsdQNameType"
+                   minOccurs="0"
+                   maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Defines the QName of a SOAP header that will be processed by the
+            handler.
+            
+            Not to be specified for JAX-WS runtime
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="soap-role"
+                   type="javaee:string"
+                   minOccurs="0"
+                   maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The soap-role element contains a SOAP actor definition that the
+            Handler will play as a role.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="port-name"
+                   type="javaee:string"
+                   minOccurs="0"
+                   maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The port-name element defines the WSDL port-name that a
+            handler should be associated with. If port-name is not
+            specified, the handler is assumed to be associated with
+            all ports of the service.
+            
+            Not to be specified for JAX-WS runtime
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+  <xsd:group name="service-refGroup">
+    <xsd:sequence>
+      <xsd:element name="service-ref"
+                   type="javaee:service-refType"
+                   minOccurs="0"
+                   maxOccurs="unbounded">
+        <xsd:key name="service-ref_handler-name-key">
+          <xsd:annotation>
+            <xsd:documentation>
+
+              Defines the name of the handler. The name must be unique
+              within the module.
+              
+            </xsd:documentation>
+          </xsd:annotation>
+          <xsd:selector xpath="javaee:handler"/>
+          <xsd:field xpath="javaee:handler-name"/>
+        </xsd:key>
+      </xsd:element>
+    </xsd:sequence>
+  </xsd:group>
+
+</xsd:schema>

--- a/impl/src/main/resources/org/apache/myfaces/resource/web-facelettaglibrary_2_2.xsd
+++ b/impl/src/main/resources/org/apache/myfaces/resource/web-facelettaglibrary_2_2.xsd
@@ -1,0 +1,684 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema targetNamespace="http://xmlns.jcp.org/xml/ns/javaee"
+            xmlns:javaee="http://xmlns.jcp.org/xml/ns/javaee"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns:xml="http://www.w3.org/XML/1998/namespace"
+            elementFormDefault="qualified"
+            attributeFormDefault="unqualified"
+            version="2.2">
+  <xsd:include schemaLocation="javaee_7.xsd"/>
+
+  <xsd:annotation>
+    <xsd:documentation>
+
+      DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+      
+      Copyright (c) 2011-2013 Oracle and/or its affiliates. All rights reserved.
+      
+      The contents of this file are subject to the terms of either the GNU
+      General Public License Version 2 only ("GPL") or the Common Development
+      and Distribution License("CDDL") (collectively, the "License").  You
+      may not use this file except in compliance with the License.  You can
+      obtain a copy of the License at
+      https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
+      or packager/legal/LICENSE.txt.  See the License for the specific
+      language governing permissions and limitations under the License.
+      
+      When distributing the software, include this License Header Notice in each
+      file and include the License file at packager/legal/LICENSE.txt.
+      
+      GPL Classpath Exception:
+      Oracle designates this particular file as subject to the "Classpath"
+      exception as provided by Oracle in the GPL Version 2 section of the License
+      file that accompanied this code.
+      
+      Modifications:
+      If applicable, add the following below the License Header, with the fields
+      enclosed by brackets [] replaced by your own identifying information:
+      "Portions Copyright [year] [name of copyright owner]"
+      
+      Contributor(s):
+      If you wish your version of this file to be governed by only the CDDL or
+      only the GPL Version 2, indicate your decision by adding "[Contributor]
+      elects to include this software in this distribution under the [CDDL or GPL
+      Version 2] license."  If you don't indicate a single choice of license, a
+      recipient has the option to distribute your version of this file under
+      either the CDDL, the GPL Version 2 or to extend the choice of license to
+      its licensees as provided above.  However, if you add GPL Version 2 code
+      and therefore, elected the GPL Version 2 license, then the option applies
+      only if the new code is made subject to such option by the copyright
+      holder.
+      
+    </xsd:documentation>
+  </xsd:annotation>
+
+  <xsd:annotation>
+    <xsd:documentation>
+      <![CDATA[[
+      <p>The XML Schema for the Tag Libraries in the JavaServer Faces
+      Standard Facelets View Declaration Language (Facelets VDL)
+      (Version 2.2).</p>
+      
+      <p>JSF 2.2 Facelet Tag Libraries that wish to conform to this
+      schema must declare it in the following manner.</p>
+      
+      &lt;facelet-taglib xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-facelettaglibary_2_2.xsd"
+      version="2.2"&gt;
+      
+      ...
+      
+      &lt;/facelet-taglib&gt;</pre>
+      
+      <p>The instance documents may indicate the published
+      version of the schema using xsi:schemaLocation attribute
+      for javaee namespace with the following location:</p>
+      
+      <p>http://xmlns.jcp.org/xml/ns/javaee/web-facelettaglibary_2_2.xsd</p>
+      
+      ]]>
+    </xsd:documentation>
+  </xsd:annotation>
+
+
+<!-- **************************************************** -->
+
+  <xsd:element name="facelet-taglib"
+               type="javaee:facelet-taglibType">
+    <xsd:unique name="facelet-taglib-tagname-uniqueness">
+      <xsd:annotation>
+        <xsd:documentation><![CDATA[<p>
+
+          tag-names must be unique within a document.
+          
+        </p>]]></xsd:documentation>
+      </xsd:annotation>
+      <xsd:selector xpath="javaee:tag"/>
+      <xsd:field xpath="javaee:tag-name"/>
+    </xsd:unique>
+    <xsd:unique name="faces-config-behavior-ID-uniqueness">
+      <xsd:annotation>
+        <xsd:documentation><![CDATA[<p>
+
+          Behavior IDs must be unique within a document.
+          
+        </p>]]></xsd:documentation>
+      </xsd:annotation>
+      <xsd:selector xpath="javaee:behavior"/>
+      <xsd:field xpath="javaee:behavior-id"/>
+    </xsd:unique>
+    <xsd:unique name="faces-config-converter-ID-uniqueness">
+      <xsd:annotation>
+        <xsd:documentation><![CDATA[<p>
+
+          Converter IDs must be unique within a document.
+          
+        </p>]]></xsd:documentation>
+      </xsd:annotation>
+      <xsd:selector xpath="javaee:converter"/>
+      <xsd:field xpath="javaee:converter-id"/>
+    </xsd:unique>
+    <xsd:unique name="faces-config-validator-ID-uniqueness">
+      <xsd:annotation>
+        <xsd:documentation><![CDATA[<p>
+
+          Validator IDs must be unique within a document.
+          
+        </p>]]></xsd:documentation>
+      </xsd:annotation>
+      <xsd:selector xpath="javaee:validator"/>
+      <xsd:field xpath="javaee:validator-id"/>
+    </xsd:unique>
+  </xsd:element>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="facelet-taglibType">
+    <xsd:annotation>
+      <xsd:documentation><![CDATA[<p>
+
+        The top level XML element in a facelet tag library XML file.
+        
+      </p>]]></xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="javaee:descriptionGroup"/>
+      <xsd:choice>
+        <xsd:element name="library-class"
+                     type="javaee:fully-qualified-classType"/>
+        <xsd:sequence>
+          <xsd:element name="namespace"
+                       type="javaee:string"/>
+          <xsd:element minOccurs="0" maxOccurs="1" name="short-name"
+                       type="javaee:string">
+            <xsd:annotation>
+              <xsd:documentation><![CDATA[<p>
+              
+              An advisory short name for usages of tags from this tag library.
+              
+              </p>]]></xsd:documentation>
+            </xsd:annotation>
+          </xsd:element>
+          <xsd:element minOccurs="0"
+                       maxOccurs="1"
+                       name="composite-library-name"
+                       type="javaee:string"/>
+          <xsd:choice minOccurs="0"
+                      maxOccurs="unbounded">
+            <xsd:element name="tag"
+                         type="javaee:facelet-taglib-tagType"/>
+            <xsd:element name="function"
+                         type="javaee:facelet-taglib-functionType"/>
+          </xsd:choice>
+        </xsd:sequence>
+      </xsd:choice>
+      <xsd:element name="taglib-extension"
+                   type="javaee:facelet-taglib-extensionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+    <xsd:attribute name="version"
+                   type="javaee:facelet-taglib-versionType"
+                   use="required"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="facelet-taglib-extensionType">
+    <xsd:annotation>
+      <xsd:documentation><![CDATA[<p>
+
+        Extension element for facelet-taglib. It may contain
+        implementation specific content.
+        
+      </p>]]></xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:any namespace="##any"
+               processContents="lax"
+               minOccurs="0"
+               maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="facelet-taglib-tagType">
+    <xsd:annotation>
+      <xsd:documentation><![CDATA[
+
+        <p>If the tag library XML
+        file contains individual tag declarations rather than pointing
+        to a library-class or a declaring a composite-library name, the
+        individual tags are enclosed in tag elements.</p>
+
+      ]]></xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="javaee:descriptionGroup"/>
+      <xsd:element name="tag-name"
+                   type="javaee:facelet-taglib-canonical-nameType"/>
+      <xsd:choice>
+        <xsd:element name="handler-class"
+                     type="javaee:fully-qualified-classType"/>
+        <xsd:element name="behavior"
+                     type="javaee:facelet-taglib-tag-behaviorType"/>
+        <xsd:element name="component"
+                     type="javaee:facelet-taglib-tag-componentType"/>
+        <xsd:element name="converter"
+                     type="javaee:facelet-taglib-tag-converterType"/>
+        <xsd:element name="validator"
+                     type="javaee:facelet-taglib-tag-validatorType"/>
+        <xsd:element name="source"
+                     type="javaee:string"/>
+      </xsd:choice>
+      <xsd:element name="attribute"
+                   type="javaee:facelet-taglib-tag-attributeType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="tag-extension"
+                   type="javaee:facelet-taglib-tag-extensionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="facelet-taglib-tag-attributeType">
+    <xsd:annotation>
+      <xsd:documentation><![CDATA[<p>
+
+        <p>The attribute element defines an attribute for the nesting
+        tag. The attribute element may have several subelements
+        defining:</p>
+        
+        <dl>
+
+          <dt>description</dt><dd><p> a description of the attribute
+	  </p></dd>
+
+	  <dt>name</dt><dd><p> the name of the attribute
+	  </p></dd>
+        
+	  <dt>required</dt><dd><p> whether the attribute is required or
+        optional
+	  </p></dd>
+
+          <dt>type</dt><dd><p> the type of the attribute
+	  </p></dd>
+
+        </dl>
+        
+      </p>]]></xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="javaee:descriptionGroup"/>
+      <xsd:element name="name"
+                   type="javaee:xsdNMTOKENType"/>
+      <xsd:element name="required"
+                   type="javaee:generic-booleanType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation><![CDATA[
+
+            <p>Defines if the nesting attribute is required or
+            optional.</p>
+            
+            <p>If not present then the default is "false", i.e
+            the attribute is optional.</p>
+            
+          ]]></xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:choice>
+        <xsd:element name="type"
+                     type="javaee:fully-qualified-classType"
+                     minOccurs="0">
+          <xsd:annotation>
+            <xsd:documentation><![CDATA[<p>
+
+              Defines the Java type of the attributes
+              value. If this element is omitted, the
+              expected type is assumed to be
+              "java.lang.Object".</p>
+              
+            ]]></xsd:documentation>
+          </xsd:annotation>
+        </xsd:element>
+        <xsd:element name="method-signature"
+                     type="javaee:string"
+                     minOccurs="0">
+          <xsd:annotation>
+            <xsd:documentation><![CDATA[<p>
+
+              Defines the method signature for a MethodExpression-
+              enabled attribute.  The syntax of the method-signature
+              element is as follows (taken from the function-signature
+              EBNF in web-jsptaglibrary_2_1.xsd):</p>
+
+<code>
+
+<p>MethodSignature ::= ReturnType S MethodName S? '(' S? Parameters? S? ')'</p>
+
+<p>ReturnType        ::= Type</p>
+
+<p>MethodName        ::= Identifier</p>
+
+<p>Parameters        ::= Parameter | ( Parameter S? ',' S? Parameters )</p>
+
+<p>Parameter         ::= Type</p>
+
+</code>
+
+<p>Where:</p>
+
+<ul>
+
+	  <li><p><code>Type</code> is a basic type or a fully qualified
+	  Java class name (including package name), as per the 'Type'
+	  production in the Java Language Specification, Second Edition,
+	  Chapter 18.</p></li>
+
+	  <li><p><code>Identifier</code> is a Java identifier, as per the
+	  'Identifier' production in the Java Language Specification,
+	  Second Edition, Chapter 18.</p></li>
+
+</ul>
+
+<p>Example:</p>
+
+<p><code>java.lang.String nickName( java.lang.String, int )</code></p>
+
+]]></xsd:documentation>
+          </xsd:annotation>
+        </xsd:element>
+      </xsd:choice>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="facelet-taglib-tag-extensionType">
+    <xsd:annotation>
+      <xsd:documentation><![CDATA[<p>
+
+        Extension element for tag It may contain
+        implementation specific content.
+        
+      </p>]]></xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:any namespace="##any"
+               processContents="lax"
+               minOccurs="0"
+               maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="facelet-taglib-functionType">
+    <xsd:annotation>
+      <xsd:documentation><![CDATA[<p>
+
+        If the tag library XML file contains individual function
+        declarations rather than pointing to a library-class or a
+        declaring a composite-library name, the individual functions are
+        enclosed in function elements.
+        
+      </p>]]></xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="javaee:descriptionGroup"/>
+      <xsd:element name="function-name"
+                   type="javaee:string"/>
+      <xsd:element name="function-class"
+                   type="javaee:fully-qualified-classType"/>
+      <xsd:element name="function-signature"
+                   type="javaee:string"/>
+    </xsd:sequence>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="facelet-taglib-tag-behaviorType">
+    <xsd:annotation>
+      <xsd:documentation><![CDATA[<p>
+
+        Within a tag element, the behavior element encapsulates
+        information specific to a JSF Behavior.
+        
+      </p>]]></xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="javaee:descriptionGroup"/>
+      <xsd:element minOccurs="1"
+                   maxOccurs="1"
+                   name="behavior-id"
+                   type="javaee:string"/>
+      <xsd:element minOccurs="0"
+                   maxOccurs="1"
+                   name="handler-class"
+                   type="javaee:fully-qualified-classType"/>
+      <xsd:element name="behavior-extension"
+                   type="javaee:facelet-taglib-tag-behavior-extensionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="facelet-taglib-tag-behavior-extensionType">
+    <xsd:annotation>
+      <xsd:documentation><![CDATA[<p>
+
+        Extension element for behavior. It may contain
+        implementation specific content.
+        
+      </p>]]></xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:any namespace="##any"
+               processContents="lax"
+               minOccurs="0"
+               maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="facelet-taglib-tag-componentType">
+    <xsd:annotation>
+      <xsd:documentation><![CDATA[
+
+      <p><span class="changed_modified_2_2">Within</span> a tag element,
+      the component element encapsulates information specific to a JSF
+      UIComponent.</p>
+
+<div class="changed_added_2_2">
+
+<p>This element must have exactly one of
+<code>&lt;component-type&gt;</code>, <code>&lt;resource-id&gt;</code>,
+or <code>&lt;handler-class&gt;</code> among its child elements.</p>
+
+</div>
+       
+      ]]></xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="javaee:descriptionGroup"/>
+      <xsd:choice minOccurs="0"
+                  maxOccurs="unbounded">
+          <xsd:element name="component-type"
+                       type="javaee:string"/>
+          <xsd:element name="resource-id"
+                       type="javaee:string">
+            <xsd:annotation>
+              <xsd:documentation><![CDATA[
+
+              <p class="changed_added_2_2">A valid resource identifier
+              as specified in the spec prose document section
+              2.6.1.3.  For example:</p>
+
+          <p><code>&lt;resource-id&gt;myCC/ccName.xhtml&lt;/resource-id&gt;</code></p>
+
+              ]]></xsd:documentation>
+            </xsd:annotation>
+          </xsd:element>
+          <xsd:element name="handler-class"
+                       type="javaee:fully-qualified-classType"/>
+      </xsd:choice>
+      <xsd:element minOccurs="0"
+                   maxOccurs="1"
+                   name="renderer-type"
+                   type="javaee:string"/>
+      <xsd:element name="component-extension"
+                   type="javaee:facelet-taglib-tag-component-extensionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="facelet-taglib-tag-component-extensionType">
+    <xsd:annotation>
+      <xsd:documentation><![CDATA[<p>
+
+        Extension element for component It may contain
+        implementation specific content.
+        
+      </p>]]></xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:any namespace="##any"
+               processContents="lax"
+               minOccurs="0"
+               maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="facelet-taglib-tag-converterType">
+    <xsd:annotation>
+      <xsd:documentation><![CDATA[<p>
+
+        Within a tag element, the converter element encapsulates
+        information specific to a JSF Converter.
+        
+      </p>]]></xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="javaee:descriptionGroup"/>
+      <xsd:element minOccurs="1"
+                   maxOccurs="1"
+                   name="converter-id"
+                   type="javaee:string"/>
+      <xsd:element minOccurs="0"
+                   maxOccurs="1"
+                   name="handler-class"
+                   type="javaee:fully-qualified-classType"/>
+      <xsd:element name="converter-extension"
+                   type="javaee:facelet-taglib-tag-converter-extensionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="facelet-taglib-tag-converter-extensionType">
+    <xsd:annotation>
+      <xsd:documentation><![CDATA[<p>
+
+        Extension element for converter It may contain
+        implementation specific content.
+        
+      </p>]]></xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:any namespace="##any"
+               processContents="lax"
+               minOccurs="0"
+               maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="facelet-taglib-tag-validatorType">
+    <xsd:annotation>
+      <xsd:documentation><![CDATA[<p>
+
+        Within a tag element, the validator element encapsulates
+        information specific to a JSF Validator.
+        
+      </p>]]></xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="javaee:descriptionGroup"/>
+      <xsd:element minOccurs="1"
+                   maxOccurs="1"
+                   name="validator-id"
+                   type="javaee:string"/>
+      <xsd:element minOccurs="0"
+                   maxOccurs="1"
+                   name="handler-class"
+                   type="javaee:fully-qualified-classType"/>
+      <xsd:element name="validator-extension"
+                   type="javaee:facelet-taglib-tag-validator-extensionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="facelet-taglib-tag-validator-extensionType">
+    <xsd:annotation>
+      <xsd:documentation><![CDATA[<p>
+
+        Extension element for validator It may contain
+        implementation specific content.
+        
+      </p>]]></xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:any namespace="##any"
+               processContents="lax"
+               minOccurs="0"
+               maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+  <xsd:simpleType name="facelet-taglib-versionType">
+    <xsd:annotation>
+      <xsd:documentation><![CDATA[<p>
+
+        This type contains the recognized versions of
+        facelet-taglib supported.
+        
+      </p>]]></xsd:documentation>
+    </xsd:annotation>
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="2.2"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="facelet-taglib-canonical-nameType">
+    <xsd:annotation>
+      <xsd:documentation><![CDATA[<p>
+
+        <p>Defines the canonical name of a tag or attribute being
+        defined.</p>
+        
+        <p>The name must conform to the lexical rules for an NCName</p>
+        
+      </p>]]></xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:extension base="xsd:NCName">
+        <xsd:attribute name="id"
+                       type="xsd:ID"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+</xsd:schema>

--- a/impl/src/main/resources/org/apache/myfaces/resource/web-facelettaglibrary_2_3.xsd
+++ b/impl/src/main/resources/org/apache/myfaces/resource/web-facelettaglibrary_2_3.xsd
@@ -1,0 +1,776 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema targetNamespace="http://xmlns.jcp.org/xml/ns/javaee"
+            xmlns:javaee="http://xmlns.jcp.org/xml/ns/javaee"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns:xml="http://www.w3.org/XML/1998/namespace"
+            elementFormDefault="qualified"
+            attributeFormDefault="unqualified"
+            version="2.3">
+  <xsd:include schemaLocation="javaee_8.xsd"/>
+
+  <xsd:annotation>
+    <xsd:documentation>
+
+      DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+      
+      Copyright (c) 2011-2015 Oracle and/or its affiliates. All rights reserved.
+      
+      The contents of this file are subject to the terms of either the GNU
+      General Public License Version 2 only ("GPL") or the Common Development
+      and Distribution License("CDDL") (collectively, the "License").  You
+      may not use this file except in compliance with the License.  You can
+      obtain a copy of the License at
+      https://glassfish.java.net/public/CDDL+GPL_1_1.html
+      or packager/legal/LICENSE.txt.  See the License for the specific
+      language governing permissions and limitations under the License.
+      
+      When distributing the software, include this License Header Notice in each
+      file and include the License file at packager/legal/LICENSE.txt.
+      
+      GPL Classpath Exception:
+      Oracle designates this particular file as subject to the "Classpath"
+      exception as provided by Oracle in the GPL Version 2 section of the License
+      file that accompanied this code.
+      
+      Modifications:
+      If applicable, add the following below the License Header, with the fields
+      enclosed by brackets [] replaced by your own identifying information:
+      "Portions Copyright [year] [name of copyright owner]"
+      
+      Contributor(s):
+      If you wish your version of this file to be governed by only the CDDL or
+      only the GPL Version 2, indicate your decision by adding "[Contributor]
+      elects to include this software in this distribution under the [CDDL or GPL
+      Version 2] license."  If you don't indicate a single choice of license, a
+      recipient has the option to distribute your version of this file under
+      either the CDDL, the GPL Version 2 or to extend the choice of license to
+      its licensees as provided above.  However, if you add GPL Version 2 code
+      and therefore, elected the GPL Version 2 license, then the option applies
+      only if the new code is made subject to such option by the copyright
+      holder.
+      
+    </xsd:documentation>
+  </xsd:annotation>
+
+  <xsd:annotation>
+    <xsd:documentation>
+      <![CDATA[
+      [
+      <p>The XML Schema for the Tag Libraries in the JavaServer Faces
+      Standard Facelets View Declaration Language (Facelets VDL)
+      (Version 2.3).</p>
+      
+      <p>JSF 2.3 Facelet Tag Libraries that wish to conform to this
+      schema must declare it in the following manner.</p>
+      
+      &lt;facelet-taglib xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-facelettaglibary_2_3.xsd"
+      version="2.3"&gt;
+      
+      ...
+      
+      &lt;/facelet-taglib&gt;</pre>
+      
+      <p>The instance documents may indicate the published
+      version of the schema using xsi:schemaLocation attribute
+      for javaee namespace with the following location:</p>
+      
+      <p>http://xmlns.jcp.org/xml/ns/javaee/web-facelettaglibary_2_3.xsd</p>
+      
+      ]]>
+    </xsd:documentation>
+  </xsd:annotation>
+
+
+<!-- **************************************************** -->
+
+  <xsd:element name="facelet-taglib"
+               type="javaee:facelet-taglibType">
+    <xsd:unique name="facelet-taglib-tagname-uniqueness">
+      <xsd:annotation>
+        <xsd:documentation>
+          <![CDATA[
+          <p>
+          
+          tag-names must be unique within a document.
+          
+          </p>
+          ]]>
+        </xsd:documentation>
+      </xsd:annotation>
+      <xsd:selector xpath="javaee:tag"/>
+      <xsd:field xpath="javaee:tag-name"/>
+    </xsd:unique>
+    <xsd:unique name="faces-config-behavior-ID-uniqueness">
+      <xsd:annotation>
+        <xsd:documentation>
+          <![CDATA[
+          <p>
+          
+          Behavior IDs must be unique within a document.
+          
+          </p>
+          ]]>
+        </xsd:documentation>
+      </xsd:annotation>
+      <xsd:selector xpath="javaee:behavior"/>
+      <xsd:field xpath="javaee:behavior-id"/>
+    </xsd:unique>
+    <xsd:unique name="faces-config-converter-ID-uniqueness">
+      <xsd:annotation>
+        <xsd:documentation>
+          <![CDATA[
+          <p>
+          
+          Converter IDs must be unique within a document.
+          
+          </p>
+          ]]>
+        </xsd:documentation>
+      </xsd:annotation>
+      <xsd:selector xpath="javaee:converter"/>
+      <xsd:field xpath="javaee:converter-id"/>
+    </xsd:unique>
+    <xsd:unique name="faces-config-validator-ID-uniqueness">
+      <xsd:annotation>
+        <xsd:documentation>
+          <![CDATA[
+          <p>
+          
+          Validator IDs must be unique within a document.
+          
+          </p>
+          ]]>
+        </xsd:documentation>
+      </xsd:annotation>
+      <xsd:selector xpath="javaee:validator"/>
+      <xsd:field xpath="javaee:validator-id"/>
+    </xsd:unique>
+  </xsd:element>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="facelet-taglibType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p>
+        
+        The top level XML element in a facelet tag library XML file.
+        
+        </p>
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="javaee:descriptionGroup"/>
+      <xsd:choice>
+        <xsd:element name="library-class"
+                     type="javaee:fully-qualified-classType"/>
+        <xsd:sequence>
+          <xsd:element name="namespace"
+                       type="javaee:string"/>
+          <xsd:element minOccurs="0"
+                       maxOccurs="1"
+                       name="short-name"
+                       type="javaee:string">
+            <xsd:annotation>
+              <xsd:documentation>
+                <![CDATA[
+                <p>
+                
+                An advisory short name for usages of tags from this tag library.
+                
+                </p>
+                ]]>
+              </xsd:documentation>
+            </xsd:annotation>
+          </xsd:element>
+          <xsd:element minOccurs="0"
+                       maxOccurs="1"
+                       name="composite-library-name"
+                       type="javaee:string"/>
+          <xsd:choice minOccurs="0"
+                      maxOccurs="unbounded">
+            <xsd:element name="tag"
+                         type="javaee:facelet-taglib-tagType"/>
+            <xsd:element name="function"
+                         type="javaee:facelet-taglib-functionType"/>
+          </xsd:choice>
+        </xsd:sequence>
+      </xsd:choice>
+      <xsd:element name="taglib-extension"
+                   type="javaee:facelet-taglib-extensionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+    <xsd:attribute name="version"
+                   type="javaee:facelet-taglib-versionType"
+                   use="required"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="facelet-taglib-extensionType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p>
+        
+        Extension element for facelet-taglib. It may contain
+        implementation specific content.
+        
+        </p>
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:any namespace="##any"
+               processContents="lax"
+               minOccurs="0"
+               maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="facelet-taglib-tagType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p>If the tag library XML
+        file contains individual tag declarations rather than pointing
+        to a library-class or a declaring a composite-library name, the
+        individual tags are enclosed in tag elements.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="javaee:descriptionGroup"/>
+      <xsd:element name="tag-name"
+                   type="javaee:facelet-taglib-canonical-nameType"/>
+      <xsd:choice>
+        <xsd:element name="handler-class"
+                     type="javaee:fully-qualified-classType"/>
+        <xsd:element name="behavior"
+                     type="javaee:facelet-taglib-tag-behaviorType"/>
+        <xsd:element name="component"
+                     type="javaee:facelet-taglib-tag-componentType"/>
+        <xsd:element name="converter"
+                     type="javaee:facelet-taglib-tag-converterType"/>
+        <xsd:element name="validator"
+                     type="javaee:facelet-taglib-tag-validatorType"/>
+        <xsd:element name="source"
+                     type="javaee:string"/>
+      </xsd:choice>
+      <xsd:element name="attribute"
+                   type="javaee:facelet-taglib-tag-attributeType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="tag-extension"
+                   type="javaee:facelet-taglib-tag-extensionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="facelet-taglib-tag-attributeType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p>
+        
+        <p>The attribute element defines an attribute for the nesting
+        tag. The attribute element may have several subelements
+        defining:</p>
+        
+        <dl>
+        
+        <dt>description</dt><dd><p> a description of the attribute
+        </p></dd>
+        
+        <dt>name</dt><dd><p> the name of the attribute
+        </p></dd>
+        
+        <dt>required</dt><dd><p> whether the attribute is required or
+        optional
+        </p></dd>
+        
+        <dt>type</dt><dd><p> the type of the attribute
+        </p></dd>
+        
+        </dl>
+        
+        </p>
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="javaee:descriptionGroup"/>
+      <xsd:element name="name"
+                   type="javaee:xsdNMTOKENType"/>
+      <xsd:element name="required"
+                   type="javaee:generic-booleanType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p>Defines if the nesting attribute is required or
+            optional.</p>
+            
+            <p>If not present then the default is "false", i.e
+            the attribute is optional.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:choice>
+        <xsd:element name="type"
+                     type="javaee:fully-qualified-classType"
+                     minOccurs="0">
+          <xsd:annotation>
+            <xsd:documentation>
+              <![CDATA[
+              <p>
+              
+              Defines the Java type of the attributes
+              value. If this element is omitted, the
+              expected type is assumed to be
+              "java.lang.Object".</p>
+              
+              ]]>
+            </xsd:documentation>
+          </xsd:annotation>
+        </xsd:element>
+        <xsd:element name="method-signature"
+                     type="javaee:string"
+                     minOccurs="0">
+          <xsd:annotation>
+            <xsd:documentation>
+              <![CDATA[
+              <p>
+              
+              Defines the method signature for a MethodExpression-
+              enabled attribute.  The syntax of the method-signature
+              element is as follows (taken from the function-signature
+              EBNF in web-jsptaglibrary_2_1.xsd):</p>
+              
+              <code>
+              
+              <p>MethodSignature ::= ReturnType S MethodName S? '(' S? Parameters? S? ')'</p>
+              
+              <p>ReturnType        ::= Type</p>
+              
+              <p>MethodName        ::= Identifier</p>
+              
+              <p>Parameters        ::= Parameter | ( Parameter S? ',' S? Parameters )</p>
+              
+              <p>Parameter         ::= Type</p>
+              
+              </code>
+              
+              <p>Where:</p>
+              
+              <ul>
+              
+              <li><p><code>Type</code> is a basic type or a fully qualified
+              Java class name (including package name), as per the 'Type'
+              production in the Java Language Specification, Second Edition,
+              Chapter 18.</p></li>
+              
+              <li><p><code>Identifier</code> is a Java identifier, as per the
+              'Identifier' production in the Java Language Specification,
+              Second Edition, Chapter 18.</p></li>
+              
+              </ul>
+              
+              <p>Example:</p>
+              
+              <p><code>java.lang.String nickName( java.lang.String, int )</code></p>
+              
+              ]]>
+            </xsd:documentation>
+          </xsd:annotation>
+        </xsd:element>
+      </xsd:choice>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="facelet-taglib-tag-extensionType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p>
+        
+        Extension element for tag It may contain
+        implementation specific content.
+        
+        </p>
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:any namespace="##any"
+               processContents="lax"
+               minOccurs="0"
+               maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="facelet-taglib-functionType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p>
+        
+        If the tag library XML file contains individual function
+        declarations rather than pointing to a library-class or a
+        declaring a composite-library name, the individual functions are
+        enclosed in function elements.
+        
+        </p>
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="javaee:descriptionGroup"/>
+      <xsd:element name="function-name"
+                   type="javaee:string"/>
+      <xsd:element name="function-class"
+                   type="javaee:fully-qualified-classType"/>
+      <xsd:element name="function-signature"
+                   type="javaee:string"/>
+    </xsd:sequence>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="facelet-taglib-tag-behaviorType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p>
+        
+        Within a tag element, the behavior element encapsulates
+        information specific to a JSF Behavior.
+        
+        </p>
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="javaee:descriptionGroup"/>
+      <xsd:element minOccurs="1"
+                   maxOccurs="1"
+                   name="behavior-id"
+                   type="javaee:string"/>
+      <xsd:element minOccurs="0"
+                   maxOccurs="1"
+                   name="handler-class"
+                   type="javaee:fully-qualified-classType"/>
+      <xsd:element name="behavior-extension"
+                   type="javaee:facelet-taglib-tag-behavior-extensionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="facelet-taglib-tag-behavior-extensionType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p>
+        
+        Extension element for behavior. It may contain
+        implementation specific content.
+        
+        </p>
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:any namespace="##any"
+               processContents="lax"
+               minOccurs="0"
+               maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="facelet-taglib-tag-componentType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p><span class="changed_modified_2_2
+        changed_modified_2_3">Within</span> a tag element, the component
+        element encapsulates information specific to a JSF
+        UIComponent.</p>
+        
+        <div class="changed_added_2_2 changed_deleted_2_3">
+        
+        <p>As of 2.3 of the specification, this requirement is no longer
+        present: This element must have exactly one of
+        <code>&lt;component-type&gt;</code>, <code>&lt;resource-id&gt;</code>,
+        or <code>&lt;handler-class&gt;</code> among its child elements.</p>
+        
+        </div>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="javaee:descriptionGroup"/>
+      <xsd:element name="component-type"
+                   type="javaee:string"/>
+      <xsd:element minOccurs="0"
+                   maxOccurs="1"
+                   name="renderer-type"
+                   type="javaee:string"/>
+      <xsd:element minOccurs="0"
+                   maxOccurs="1"
+                   name="handler-class"
+                   type="javaee:fully-qualified-classType"/>
+      <xsd:element minOccurs="0"
+                   maxOccurs="1"
+                   name="resource-id"
+                   type="javaee:string">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p class="changed_added_2_2">A valid resource identifier
+            as specified in the spec prose document section
+            2.6.1.3.  For example:</p>
+            
+            <p><code>&lt;resource-id&gt;myCC/ccName.xhtml&lt;/resource-id&gt;</code></p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="component-extension"
+                   type="javaee:facelet-taglib-tag-component-extensionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="facelet-taglib-tag-component-extensionType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p>
+        
+        Extension element for component It may contain
+        implementation specific content.
+        
+        </p>
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:any namespace="##any"
+               processContents="lax"
+               minOccurs="0"
+               maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="facelet-taglib-tag-converterType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p>
+        
+        Within a tag element, the converter element encapsulates
+        information specific to a JSF Converter.
+        
+        </p>
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="javaee:descriptionGroup"/>
+      <xsd:element minOccurs="1"
+                   maxOccurs="1"
+                   name="converter-id"
+                   type="javaee:string"/>
+      <xsd:element minOccurs="0"
+                   maxOccurs="1"
+                   name="handler-class"
+                   type="javaee:fully-qualified-classType"/>
+      <xsd:element name="converter-extension"
+                   type="javaee:facelet-taglib-tag-converter-extensionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="facelet-taglib-tag-converter-extensionType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p>
+        
+        Extension element for converter It may contain
+        implementation specific content.
+        
+        </p>
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:any namespace="##any"
+               processContents="lax"
+               minOccurs="0"
+               maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="facelet-taglib-tag-validatorType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p>
+        
+        Within a tag element, the validator element encapsulates
+        information specific to a JSF Validator.
+        
+        </p>
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="javaee:descriptionGroup"/>
+      <xsd:element minOccurs="1"
+                   maxOccurs="1"
+                   name="validator-id"
+                   type="javaee:string"/>
+      <xsd:element minOccurs="0"
+                   maxOccurs="1"
+                   name="handler-class"
+                   type="javaee:fully-qualified-classType"/>
+      <xsd:element name="validator-extension"
+                   type="javaee:facelet-taglib-tag-validator-extensionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="facelet-taglib-tag-validator-extensionType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p>
+        
+        Extension element for validator It may contain
+        implementation specific content.
+        
+        </p>
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:any namespace="##any"
+               processContents="lax"
+               minOccurs="0"
+               maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+  <xsd:simpleType name="facelet-taglib-versionType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p>
+        
+        This type contains the recognized versions of
+        facelet-taglib supported.
+        
+        </p>
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="2.3"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="facelet-taglib-canonical-nameType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p>
+        
+        <p>Defines the canonical name of a tag or attribute being
+        defined.</p>
+        
+        <p>The name must conform to the lexical rules for an NCName</p>
+        
+        </p>
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:extension base="xsd:NCName">
+        <xsd:attribute name="id"
+                       type="xsd:ID"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+</xsd:schema>

--- a/impl/src/main/resources/org/apache/myfaces/resource/web-facelettaglibrary_3_0.xsd
+++ b/impl/src/main/resources/org/apache/myfaces/resource/web-facelettaglibrary_3_0.xsd
@@ -1,0 +1,751 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema targetNamespace="https://jakarta.ee/xml/ns/jakartaee"
+            xmlns:jakartaee="https://jakarta.ee/xml/ns/jakartaee"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns:xml="http://www.w3.org/XML/1998/namespace"
+            elementFormDefault="qualified"
+            attributeFormDefault="unqualified"
+            version="3.0">
+  <xsd:include schemaLocation="jakartaee_9.xsd"/>
+
+  <xsd:annotation>
+    <xsd:documentation>
+
+      Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
+      
+      This program and the accompanying materials are made available under the
+      terms of the Eclipse Public License v. 2.0, which is available at
+      http://www.eclipse.org/legal/epl-2.0.
+      
+      This Source Code may also be made available under the following Secondary
+      Licenses when the conditions for such availability set forth in the
+      Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+      version 2 with the GNU Classpath Exception, which is available at
+      https://www.gnu.org/software/classpath/license.html.
+      
+      SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+      
+    </xsd:documentation>
+  </xsd:annotation>
+
+  <xsd:annotation>
+    <xsd:documentation>
+      <![CDATA[
+      [
+      <p>The XML Schema for the Tag Libraries in the Jakarta Server Faces
+      Standard Facelets View Declaration Language (Facelets VDL)
+      (Version 3.0).</p>
+      
+      <p>Jakarta Server Faces 3.0 Facelet Tag Libraries that wish to conform to 
+      this schema must declare it in the following manner.</p>
+      
+      &lt;facelet-taglib xmlns="https://jakarta.ee/xml/ns/jakartaee"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-facelettaglibary_3_0.xsd"
+      version="3.0"&gt;
+      
+      ...
+      
+      &lt;/facelet-taglib&gt;</pre>
+      
+      <p>The instance documents may indicate the published
+      version of the schema using xsi:schemaLocation attribute
+      for jakartaee namespace with the following location:</p>
+      
+      <p>https://jakarta.ee/xml/ns/jakartaee/web-facelettaglibary_3_0.xsd</p>
+      
+      ]]>
+    </xsd:documentation>
+  </xsd:annotation>
+
+
+<!-- **************************************************** -->
+
+  <xsd:element name="facelet-taglib"
+               type="jakartaee:facelet-taglibType">
+    <xsd:unique name="facelet-taglib-tagname-uniqueness">
+      <xsd:annotation>
+        <xsd:documentation>
+          <![CDATA[
+          <p>
+          
+          tag-names must be unique within a document.
+          
+          </p>
+          ]]>
+        </xsd:documentation>
+      </xsd:annotation>
+      <xsd:selector xpath="jakartaee:tag"/>
+      <xsd:field xpath="jakartaee:tag-name"/>
+    </xsd:unique>
+    <xsd:unique name="faces-config-behavior-ID-uniqueness">
+      <xsd:annotation>
+        <xsd:documentation>
+          <![CDATA[
+          <p>
+          
+          Behavior IDs must be unique within a document.
+          
+          </p>
+          ]]>
+        </xsd:documentation>
+      </xsd:annotation>
+      <xsd:selector xpath="jakartaee:behavior"/>
+      <xsd:field xpath="jakartaee:behavior-id"/>
+    </xsd:unique>
+    <xsd:unique name="faces-config-converter-ID-uniqueness">
+      <xsd:annotation>
+        <xsd:documentation>
+          <![CDATA[
+          <p>
+          
+          Converter IDs must be unique within a document.
+          
+          </p>
+          ]]>
+        </xsd:documentation>
+      </xsd:annotation>
+      <xsd:selector xpath="jakartaee:converter"/>
+      <xsd:field xpath="jakartaee:converter-id"/>
+    </xsd:unique>
+    <xsd:unique name="faces-config-validator-ID-uniqueness">
+      <xsd:annotation>
+        <xsd:documentation>
+          <![CDATA[
+          <p>
+          
+          Validator IDs must be unique within a document.
+          
+          </p>
+          ]]>
+        </xsd:documentation>
+      </xsd:annotation>
+      <xsd:selector xpath="jakartaee:validator"/>
+      <xsd:field xpath="jakartaee:validator-id"/>
+    </xsd:unique>
+  </xsd:element>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="facelet-taglibType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p>
+        
+        The top level XML element in a facelet tag library XML file.
+        
+        </p>
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="jakartaee:descriptionGroup"/>
+      <xsd:choice>
+        <xsd:element name="library-class"
+                     type="jakartaee:fully-qualified-classType"/>
+        <xsd:sequence>
+          <xsd:element name="namespace"
+                       type="jakartaee:string"/>
+          <xsd:element minOccurs="0"
+                       maxOccurs="1"
+                       name="short-name"
+                       type="jakartaee:string">
+            <xsd:annotation>
+              <xsd:documentation>
+                <![CDATA[
+                <p>
+                
+                An advisory short name for usages of tags from this tag library.
+                
+                </p>
+                ]]>
+              </xsd:documentation>
+            </xsd:annotation>
+          </xsd:element>
+          <xsd:element minOccurs="0"
+                       maxOccurs="1"
+                       name="composite-library-name"
+                       type="jakartaee:string"/>
+          <xsd:choice minOccurs="0"
+                      maxOccurs="unbounded">
+            <xsd:element name="tag"
+                         type="jakartaee:facelet-taglib-tagType"/>
+            <xsd:element name="function"
+                         type="jakartaee:facelet-taglib-functionType"/>
+          </xsd:choice>
+        </xsd:sequence>
+      </xsd:choice>
+      <xsd:element name="taglib-extension"
+                   type="jakartaee:facelet-taglib-extensionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+    <xsd:attribute name="version"
+                   type="jakartaee:facelet-taglib-versionType"
+                   use="required"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="facelet-taglib-extensionType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p>
+        
+        Extension element for facelet-taglib. It may contain
+        implementation specific content.
+        
+        </p>
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:any namespace="##any"
+               processContents="lax"
+               minOccurs="0"
+               maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="facelet-taglib-tagType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p>If the tag library XML
+        file contains individual tag declarations rather than pointing
+        to a library-class or a declaring a composite-library name, the
+        individual tags are enclosed in tag elements.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="jakartaee:descriptionGroup"/>
+      <xsd:element name="tag-name"
+                   type="jakartaee:facelet-taglib-canonical-nameType"/>
+      <xsd:choice>
+        <xsd:element name="handler-class"
+                     type="jakartaee:fully-qualified-classType"/>
+        <xsd:element name="behavior"
+                     type="jakartaee:facelet-taglib-tag-behaviorType"/>
+        <xsd:element name="component"
+                     type="jakartaee:facelet-taglib-tag-componentType"/>
+        <xsd:element name="converter"
+                     type="jakartaee:facelet-taglib-tag-converterType"/>
+        <xsd:element name="validator"
+                     type="jakartaee:facelet-taglib-tag-validatorType"/>
+        <xsd:element name="source"
+                     type="jakartaee:string"/>
+      </xsd:choice>
+      <xsd:element name="attribute"
+                   type="jakartaee:facelet-taglib-tag-attributeType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="tag-extension"
+                   type="jakartaee:facelet-taglib-tag-extensionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="facelet-taglib-tag-attributeType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p>
+        
+        <p>The attribute element defines an attribute for the nesting
+        tag. The attribute element may have several subelements
+        defining:</p>
+        
+        <dl>
+        
+        <dt>description</dt><dd><p> a description of the attribute
+        </p></dd>
+        
+        <dt>name</dt><dd><p> the name of the attribute
+        </p></dd>
+        
+        <dt>required</dt><dd><p> whether the attribute is required or
+        optional
+        </p></dd>
+        
+        <dt>type</dt><dd><p> the type of the attribute
+        </p></dd>
+        
+        </dl>
+        
+        </p>
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="jakartaee:descriptionGroup"/>
+      <xsd:element name="name"
+                   type="jakartaee:xsdNMTOKENType"/>
+      <xsd:element name="required"
+                   type="jakartaee:generic-booleanType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p>Defines if the nesting attribute is required or
+            optional.</p>
+            
+            <p>If not present then the default is "false", i.e
+            the attribute is optional.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:choice>
+        <xsd:element name="type"
+                     type="jakartaee:fully-qualified-classType"
+                     minOccurs="0">
+          <xsd:annotation>
+            <xsd:documentation>
+              <![CDATA[
+              <p>
+              
+              Defines the Java type of the attributes
+              value. If this element is omitted, the
+              expected type is assumed to be
+              "java.lang.Object".</p>
+              
+              ]]>
+            </xsd:documentation>
+          </xsd:annotation>
+        </xsd:element>
+        <xsd:element name="method-signature"
+                     type="jakartaee:string"
+                     minOccurs="0">
+          <xsd:annotation>
+            <xsd:documentation>
+              <![CDATA[
+              <p>
+              
+              Defines the method signature for a MethodExpression-
+              enabled attribute.  The syntax of the method-signature
+              element is as follows (taken from the function-signature
+              EBNF in web-jsptaglibrary_2_1.xsd):</p>
+              
+              <code>
+              
+              <p>MethodSignature ::= ReturnType S MethodName S? '(' S? Parameters? S? ')'</p>
+              
+              <p>ReturnType        ::= Type</p>
+              
+              <p>MethodName        ::= Identifier</p>
+              
+              <p>Parameters        ::= Parameter | ( Parameter S? ',' S? Parameters )</p>
+              
+              <p>Parameter         ::= Type</p>
+              
+              </code>
+              
+              <p>Where:</p>
+              
+              <ul>
+              
+              <li><p><code>Type</code> is a basic type or a fully qualified
+              Java class name (including package name), as per the 'Type'
+              production in the Java Language Specification, Second Edition,
+              Chapter 18.</p></li>
+              
+              <li><p><code>Identifier</code> is a Java identifier, as per the
+              'Identifier' production in the Java Language Specification,
+              Second Edition, Chapter 18.</p></li>
+              
+              </ul>
+              
+              <p>Example:</p>
+              
+              <p><code>java.lang.String nickName( java.lang.String, int )</code></p>
+              
+              ]]>
+            </xsd:documentation>
+          </xsd:annotation>
+        </xsd:element>
+      </xsd:choice>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="facelet-taglib-tag-extensionType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p>
+        
+        Extension element for tag It may contain
+        implementation specific content.
+        
+        </p>
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:any namespace="##any"
+               processContents="lax"
+               minOccurs="0"
+               maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="facelet-taglib-functionType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p>
+        
+        If the tag library XML file contains individual function
+        declarations rather than pointing to a library-class or a
+        declaring a composite-library name, the individual functions are
+        enclosed in function elements.
+        
+        </p>
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="jakartaee:descriptionGroup"/>
+      <xsd:element name="function-name"
+                   type="jakartaee:string"/>
+      <xsd:element name="function-class"
+                   type="jakartaee:fully-qualified-classType"/>
+      <xsd:element name="function-signature"
+                   type="jakartaee:string"/>
+    </xsd:sequence>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="facelet-taglib-tag-behaviorType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p>
+        
+        Within a tag element, the behavior element encapsulates
+        information specific to a Faces Behavior.
+        
+        </p>
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="jakartaee:descriptionGroup"/>
+      <xsd:element minOccurs="1"
+                   maxOccurs="1"
+                   name="behavior-id"
+                   type="jakartaee:string"/>
+      <xsd:element minOccurs="0"
+                   maxOccurs="1"
+                   name="handler-class"
+                   type="jakartaee:fully-qualified-classType"/>
+      <xsd:element name="behavior-extension"
+                   type="jakartaee:facelet-taglib-tag-behavior-extensionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="facelet-taglib-tag-behavior-extensionType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p>
+        
+        Extension element for behavior. It may contain
+        implementation specific content.
+        
+        </p>
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:any namespace="##any"
+               processContents="lax"
+               minOccurs="0"
+               maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="facelet-taglib-tag-componentType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p><span class="changed_modified_2_2
+        changed_modified_2_3">Within</span> a tag element, the component
+        element encapsulates information specific to a Faces UIComponent.</p>
+        
+        <div class="changed_added_2_2 changed_deleted_2_3">
+        
+        <p>As of 3.0 of the specification, this requirement is no longer
+        present: This element must have exactly one of
+        <code>&lt;component-type&gt;</code>, <code>&lt;resource-id&gt;</code>,
+        or <code>&lt;handler-class&gt;</code> among its child elements.</p>
+        
+        </div>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="jakartaee:descriptionGroup"/>
+      <xsd:element name="component-type"
+                   type="jakartaee:string"/>
+      <xsd:element minOccurs="0"
+                   maxOccurs="1"
+                   name="renderer-type"
+                   type="jakartaee:string"/>
+      <xsd:element minOccurs="0"
+                   maxOccurs="1"
+                   name="handler-class"
+                   type="jakartaee:fully-qualified-classType"/>
+      <xsd:element minOccurs="0"
+                   maxOccurs="1"
+                   name="resource-id"
+                   type="jakartaee:string">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p class="changed_added_2_2">A valid resource identifier
+            as specified in the spec prose document section
+            2.6.1.3.  For example:</p>
+            
+            <p><code>&lt;resource-id&gt;myCC/ccName.xhtml&lt;/resource-id&gt;</code></p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="component-extension"
+                   type="jakartaee:facelet-taglib-tag-component-extensionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="facelet-taglib-tag-component-extensionType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p>
+        
+        Extension element for component It may contain
+        implementation specific content.
+        
+        </p>
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:any namespace="##any"
+               processContents="lax"
+               minOccurs="0"
+               maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="facelet-taglib-tag-converterType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p>
+        
+        Within a tag element, the converter element encapsulates
+        information specific to a Faces Converter.
+        
+        </p>
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="jakartaee:descriptionGroup"/>
+      <xsd:element minOccurs="1"
+                   maxOccurs="1"
+                   name="converter-id"
+                   type="jakartaee:string"/>
+      <xsd:element minOccurs="0"
+                   maxOccurs="1"
+                   name="handler-class"
+                   type="jakartaee:fully-qualified-classType"/>
+      <xsd:element name="converter-extension"
+                   type="jakartaee:facelet-taglib-tag-converter-extensionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="facelet-taglib-tag-converter-extensionType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p>
+        
+        Extension element for converter It may contain
+        implementation specific content.
+        
+        </p>
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:any namespace="##any"
+               processContents="lax"
+               minOccurs="0"
+               maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="facelet-taglib-tag-validatorType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p>
+        
+        Within a tag element, the validator element encapsulates
+        information specific to a Faces Validator.
+        
+        </p>
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="jakartaee:descriptionGroup"/>
+      <xsd:element minOccurs="1"
+                   maxOccurs="1"
+                   name="validator-id"
+                   type="jakartaee:string"/>
+      <xsd:element minOccurs="0"
+                   maxOccurs="1"
+                   name="handler-class"
+                   type="jakartaee:fully-qualified-classType"/>
+      <xsd:element name="validator-extension"
+                   type="jakartaee:facelet-taglib-tag-validator-extensionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="facelet-taglib-tag-validator-extensionType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p>
+        
+        Extension element for validator It may contain
+        implementation specific content.
+        
+        </p>
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:any namespace="##any"
+               processContents="lax"
+               minOccurs="0"
+               maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+  <xsd:simpleType name="facelet-taglib-versionType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p>
+        
+        This type contains the recognized versions of
+        facelet-taglib supported.
+        
+        </p>
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="3.0"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="facelet-taglib-canonical-nameType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p>
+        
+        <p>Defines the canonical name of a tag or attribute being
+        defined.</p>
+        
+        <p>The name must conform to the lexical rules for an NCName</p>
+        
+        </p>
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:extension base="xsd:NCName">
+        <xsd:attribute name="id"
+                       type="xsd:ID"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+</xsd:schema>

--- a/impl/src/main/resources/org/apache/myfaces/resource/web-facelettaglibrary_4_0.xsd
+++ b/impl/src/main/resources/org/apache/myfaces/resource/web-facelettaglibrary_4_0.xsd
@@ -1,0 +1,751 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema targetNamespace="https://jakarta.ee/xml/ns/jakartaee"
+            xmlns:jakartaee="https://jakarta.ee/xml/ns/jakartaee"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns:xml="http://www.w3.org/XML/1998/namespace"
+            elementFormDefault="qualified"
+            attributeFormDefault="unqualified"
+            version="4.0">
+  <xsd:include schemaLocation="jakartaee_10.xsd"/>
+
+  <xsd:annotation>
+    <xsd:documentation>
+
+      Copyright (c) 2009, 2021 Oracle and/or its affiliates. All rights reserved.
+
+      This program and the accompanying materials are made available under the
+      terms of the Eclipse Public License v. 2.0, which is available at
+      http://www.eclipse.org/legal/epl-2.0.
+
+      This Source Code may also be made available under the following Secondary
+      Licenses when the conditions for such availability set forth in the
+      Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+      version 2 with the GNU Classpath Exception, which is available at
+      https://www.gnu.org/software/classpath/license.html.
+
+      SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+    </xsd:documentation>
+  </xsd:annotation>
+
+  <xsd:annotation>
+    <xsd:documentation>
+      <![CDATA[
+      [
+      <p>The XML Schema for the Tag Libraries in the Jakarta Faces
+      Standard Facelets View Declaration Language (Facelets VDL)
+      (Version 4.0).</p>
+
+      <p>Jakarta Faces 4.0 Facelet Tag Libraries that wish to conform to
+      this schema must declare it in the following manner.</p>
+
+      &lt;facelet-taglib xmlns="https://jakarta.ee/xml/ns/jakartaee"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-facelettaglibrary_4_0.xsd"
+      version="4.0"&gt;
+
+      ...
+
+      &lt;/facelet-taglib&gt;</pre>
+
+      <p>The instance documents may indicate the published
+      version of the schema using xsi:schemaLocation attribute
+      for jakartaee namespace with the following location:</p>
+
+      <p>https://jakarta.ee/xml/ns/jakartaee/web-facelettaglibrary_4_0.xsd</p>
+
+      ]]>
+    </xsd:documentation>
+  </xsd:annotation>
+
+
+  <!-- **************************************************** -->
+
+  <xsd:element name="facelet-taglib"
+               type="jakartaee:facelet-taglibType">
+    <xsd:unique name="facelet-taglib-tagname-uniqueness">
+      <xsd:annotation>
+        <xsd:documentation>
+          <![CDATA[
+          <p>
+
+          tag-names must be unique within a document.
+
+          </p>
+          ]]>
+        </xsd:documentation>
+      </xsd:annotation>
+      <xsd:selector xpath="jakartaee:tag"/>
+      <xsd:field xpath="jakartaee:tag-name"/>
+    </xsd:unique>
+    <xsd:unique name="faces-config-behavior-ID-uniqueness">
+      <xsd:annotation>
+        <xsd:documentation>
+          <![CDATA[
+          <p>
+
+          Behavior IDs must be unique within a document.
+
+          </p>
+          ]]>
+        </xsd:documentation>
+      </xsd:annotation>
+      <xsd:selector xpath="jakartaee:behavior"/>
+      <xsd:field xpath="jakartaee:behavior-id"/>
+    </xsd:unique>
+    <xsd:unique name="faces-config-converter-ID-uniqueness">
+      <xsd:annotation>
+        <xsd:documentation>
+          <![CDATA[
+          <p>
+
+          Converter IDs must be unique within a document.
+
+          </p>
+          ]]>
+        </xsd:documentation>
+      </xsd:annotation>
+      <xsd:selector xpath="jakartaee:converter"/>
+      <xsd:field xpath="jakartaee:converter-id"/>
+    </xsd:unique>
+    <xsd:unique name="faces-config-validator-ID-uniqueness">
+      <xsd:annotation>
+        <xsd:documentation>
+          <![CDATA[
+          <p>
+
+          Validator IDs must be unique within a document.
+
+          </p>
+          ]]>
+        </xsd:documentation>
+      </xsd:annotation>
+      <xsd:selector xpath="jakartaee:validator"/>
+      <xsd:field xpath="jakartaee:validator-id"/>
+    </xsd:unique>
+  </xsd:element>
+
+
+  <!-- **************************************************** -->
+
+  <xsd:complexType name="facelet-taglibType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p>
+
+        The top level XML element in a facelet tag library XML file.
+
+        </p>
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="jakartaee:descriptionGroup"/>
+      <xsd:choice>
+        <xsd:element name="library-class"
+                     type="jakartaee:fully-qualified-classType"/>
+        <xsd:sequence>
+          <xsd:element name="namespace"
+                       type="jakartaee:string"/>
+          <xsd:element minOccurs="0"
+                       maxOccurs="1"
+                       name="short-name"
+                       type="jakartaee:string">
+            <xsd:annotation>
+              <xsd:documentation>
+                <![CDATA[
+                <p>
+
+                An advisory short name for usages of tags from this tag library.
+
+                </p>
+                ]]>
+              </xsd:documentation>
+            </xsd:annotation>
+          </xsd:element>
+          <xsd:element minOccurs="0"
+                       maxOccurs="1"
+                       name="composite-library-name"
+                       type="jakartaee:string"/>
+          <xsd:choice minOccurs="0"
+                      maxOccurs="unbounded">
+            <xsd:element name="tag"
+                         type="jakartaee:facelet-taglib-tagType"/>
+            <xsd:element name="function"
+                         type="jakartaee:facelet-taglib-functionType"/>
+          </xsd:choice>
+        </xsd:sequence>
+      </xsd:choice>
+      <xsd:element name="taglib-extension"
+                   type="jakartaee:facelet-taglib-extensionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+    <xsd:attribute name="version"
+                   type="jakartaee:facelet-taglib-versionType"
+                   use="required"/>
+  </xsd:complexType>
+
+
+  <!-- **************************************************** -->
+
+  <xsd:complexType name="facelet-taglib-extensionType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p>
+
+        Extension element for facelet-taglib. It may contain
+        implementation specific content.
+
+        </p>
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:any namespace="##any"
+               processContents="lax"
+               minOccurs="0"
+               maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+  <!-- **************************************************** -->
+
+  <xsd:complexType name="facelet-taglib-tagType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p>If the tag library XML
+        file contains individual tag declarations rather than pointing
+        to a library-class or a declaring a composite-library name, the
+        individual tags are enclosed in tag elements.</p>
+
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="jakartaee:descriptionGroup"/>
+      <xsd:element name="tag-name"
+                   type="jakartaee:facelet-taglib-canonical-nameType"/>
+      <xsd:choice>
+        <xsd:element name="handler-class"
+                     type="jakartaee:fully-qualified-classType"/>
+        <xsd:element name="behavior"
+                     type="jakartaee:facelet-taglib-tag-behaviorType"/>
+        <xsd:element name="component"
+                     type="jakartaee:facelet-taglib-tag-componentType"/>
+        <xsd:element name="converter"
+                     type="jakartaee:facelet-taglib-tag-converterType"/>
+        <xsd:element name="validator"
+                     type="jakartaee:facelet-taglib-tag-validatorType"/>
+        <xsd:element name="source"
+                     type="jakartaee:string"/>
+      </xsd:choice>
+      <xsd:element name="attribute"
+                   type="jakartaee:facelet-taglib-tag-attributeType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="tag-extension"
+                   type="jakartaee:facelet-taglib-tag-extensionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+
+
+  <!-- **************************************************** -->
+
+  <xsd:complexType name="facelet-taglib-tag-attributeType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p>
+
+        <p>The attribute element defines an attribute for the nesting
+        tag. The attribute element may have several subelements
+        defining:</p>
+
+        <dl>
+
+        <dt>description</dt><dd><p> a description of the attribute
+        </p></dd>
+
+        <dt>name</dt><dd><p> the name of the attribute
+        </p></dd>
+
+        <dt>required</dt><dd><p> whether the attribute is required or
+        optional
+        </p></dd>
+
+        <dt>type</dt><dd><p> the type of the attribute
+        </p></dd>
+
+        </dl>
+
+        </p>
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="jakartaee:descriptionGroup"/>
+      <xsd:element name="name"
+                   type="jakartaee:xsdNMTOKENType"/>
+      <xsd:element name="required"
+                   type="jakartaee:generic-booleanType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p>Defines if the nesting attribute is required or
+            optional.</p>
+
+            <p>If not present then the default is "false", i.e
+            the attribute is optional.</p>
+
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:choice>
+        <xsd:element name="type"
+                     type="jakartaee:fully-qualified-classType"
+                     minOccurs="0">
+          <xsd:annotation>
+            <xsd:documentation>
+              <![CDATA[
+              <p>
+
+              Defines the Java type of the attributes
+              value. If this element is omitted, the
+              expected type is assumed to be
+              "java.lang.Object".</p>
+
+              ]]>
+            </xsd:documentation>
+          </xsd:annotation>
+        </xsd:element>
+        <xsd:element name="method-signature"
+                     type="jakartaee:string"
+                     minOccurs="0">
+          <xsd:annotation>
+            <xsd:documentation>
+              <![CDATA[
+              <p>
+
+              Defines the method signature for a MethodExpression-
+              enabled attribute.  The syntax of the method-signature
+              element is as follows (taken from the function-signature
+              EBNF in web-jsptaglibrary_2_1.xsd):</p>
+
+              <code>
+
+              <p>MethodSignature ::= ReturnType S MethodName S? '(' S? Parameters? S? ')'</p>
+
+              <p>ReturnType        ::= Type</p>
+
+              <p>MethodName        ::= Identifier</p>
+
+              <p>Parameters        ::= Parameter | ( Parameter S? ',' S? Parameters )</p>
+
+              <p>Parameter         ::= Type</p>
+
+              </code>
+
+              <p>Where:</p>
+
+              <ul>
+
+              <li><p><code>Type</code> is a basic type or a fully qualified
+              Java class name (including package name), as per the 'Type'
+              production in the Java Language Specification, Second Edition,
+              Chapter 18.</p></li>
+
+              <li><p><code>Identifier</code> is a Java identifier, as per the
+              'Identifier' production in the Java Language Specification,
+              Second Edition, Chapter 18.</p></li>
+
+              </ul>
+
+              <p>Example:</p>
+
+              <p><code>java.lang.String nickName( java.lang.String, int )</code></p>
+
+              ]]>
+            </xsd:documentation>
+          </xsd:annotation>
+        </xsd:element>
+      </xsd:choice>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+  <!-- **************************************************** -->
+
+  <xsd:complexType name="facelet-taglib-tag-extensionType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p>
+
+        Extension element for tag It may contain
+        implementation specific content.
+
+        </p>
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:any namespace="##any"
+               processContents="lax"
+               minOccurs="0"
+               maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+  <!-- **************************************************** -->
+
+  <xsd:complexType name="facelet-taglib-functionType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p>
+
+        If the tag library XML file contains individual function
+        declarations rather than pointing to a library-class or a
+        declaring a composite-library name, the individual functions are
+        enclosed in function elements.
+
+        </p>
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="jakartaee:descriptionGroup"/>
+      <xsd:element name="function-name"
+                   type="jakartaee:string"/>
+      <xsd:element name="function-class"
+                   type="jakartaee:fully-qualified-classType"/>
+      <xsd:element name="function-signature"
+                   type="jakartaee:string"/>
+    </xsd:sequence>
+  </xsd:complexType>
+
+
+  <!-- **************************************************** -->
+
+  <xsd:complexType name="facelet-taglib-tag-behaviorType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p>
+
+        Within a tag element, the behavior element encapsulates
+        information specific to a Faces Behavior.
+
+        </p>
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="jakartaee:descriptionGroup"/>
+      <xsd:element minOccurs="1"
+                   maxOccurs="1"
+                   name="behavior-id"
+                   type="jakartaee:string"/>
+      <xsd:element minOccurs="0"
+                   maxOccurs="1"
+                   name="handler-class"
+                   type="jakartaee:fully-qualified-classType"/>
+      <xsd:element name="behavior-extension"
+                   type="jakartaee:facelet-taglib-tag-behavior-extensionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+
+
+  <!-- **************************************************** -->
+
+  <xsd:complexType name="facelet-taglib-tag-behavior-extensionType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p>
+
+        Extension element for behavior. It may contain
+        implementation specific content.
+
+        </p>
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:any namespace="##any"
+               processContents="lax"
+               minOccurs="0"
+               maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+  <!-- **************************************************** -->
+
+  <xsd:complexType name="facelet-taglib-tag-componentType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p><span class="changed_modified_2_2
+        changed_modified_2_3">Within</span> a tag element, the component
+        element encapsulates information specific to a Faces UIComponent.</p>
+
+        <div class="changed_added_2_2 changed_deleted_2_3">
+
+        <p>As of 3.0 of the specification, this requirement is no longer
+        present: This element must have exactly one of
+        <code>&lt;component-type&gt;</code>, <code>&lt;resource-id&gt;</code>,
+        or <code>&lt;handler-class&gt;</code> among its child elements.</p>
+
+        </div>
+
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="jakartaee:descriptionGroup"/>
+      <xsd:element name="component-type"
+                   type="jakartaee:string"/>
+      <xsd:element minOccurs="0"
+                   maxOccurs="1"
+                   name="renderer-type"
+                   type="jakartaee:string"/>
+      <xsd:element minOccurs="0"
+                   maxOccurs="1"
+                   name="handler-class"
+                   type="jakartaee:fully-qualified-classType"/>
+      <xsd:element minOccurs="0"
+                   maxOccurs="1"
+                   name="resource-id"
+                   type="jakartaee:string">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p class="changed_added_2_2">A valid resource identifier
+            as specified in the Jakarta Faces Specification Document section 2.6.1.3 "Resource Identifiers".
+            For example:</p>
+
+            <p><code>&lt;resource-id&gt;myCC/ccName.xhtml&lt;/resource-id&gt;</code></p>
+
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="component-extension"
+                   type="jakartaee:facelet-taglib-tag-component-extensionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+
+
+  <!-- **************************************************** -->
+
+  <xsd:complexType name="facelet-taglib-tag-component-extensionType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p>
+
+        Extension element for component It may contain
+        implementation specific content.
+
+        </p>
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:any namespace="##any"
+               processContents="lax"
+               minOccurs="0"
+               maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+  <!-- **************************************************** -->
+
+  <xsd:complexType name="facelet-taglib-tag-converterType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p>
+
+        Within a tag element, the converter element encapsulates
+        information specific to a Faces Converter.
+
+        </p>
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="jakartaee:descriptionGroup"/>
+      <xsd:element minOccurs="1"
+                   maxOccurs="1"
+                   name="converter-id"
+                   type="jakartaee:string"/>
+      <xsd:element minOccurs="0"
+                   maxOccurs="1"
+                   name="handler-class"
+                   type="jakartaee:fully-qualified-classType"/>
+      <xsd:element name="converter-extension"
+                   type="jakartaee:facelet-taglib-tag-converter-extensionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+
+
+  <!-- **************************************************** -->
+
+  <xsd:complexType name="facelet-taglib-tag-converter-extensionType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p>
+
+        Extension element for converter It may contain
+        implementation specific content.
+
+        </p>
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:any namespace="##any"
+               processContents="lax"
+               minOccurs="0"
+               maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+  <!-- **************************************************** -->
+
+  <xsd:complexType name="facelet-taglib-tag-validatorType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p>
+
+        Within a tag element, the validator element encapsulates
+        information specific to a Faces Validator.
+
+        </p>
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="jakartaee:descriptionGroup"/>
+      <xsd:element minOccurs="1"
+                   maxOccurs="1"
+                   name="validator-id"
+                   type="jakartaee:string"/>
+      <xsd:element minOccurs="0"
+                   maxOccurs="1"
+                   name="handler-class"
+                   type="jakartaee:fully-qualified-classType"/>
+      <xsd:element name="validator-extension"
+                   type="jakartaee:facelet-taglib-tag-validator-extensionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+
+
+  <!-- **************************************************** -->
+
+  <xsd:complexType name="facelet-taglib-tag-validator-extensionType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p>
+
+        Extension element for validator It may contain
+        implementation specific content.
+
+        </p>
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:any namespace="##any"
+               processContents="lax"
+               minOccurs="0"
+               maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+  <xsd:simpleType name="facelet-taglib-versionType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p>
+
+        This type contains the recognized versions of
+        facelet-taglib supported.
+
+        </p>
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="4.0"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+
+  <!-- **************************************************** -->
+
+  <xsd:complexType name="facelet-taglib-canonical-nameType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p>
+
+        <p>Defines the canonical name of a tag or attribute being
+        defined.</p>
+
+        <p>The name must conform to the lexical rules for an NCName</p>
+
+        </p>
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:extension base="xsd:NCName">
+        <xsd:attribute name="id"
+                       type="xsd:ID"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+</xsd:schema>

--- a/impl/src/main/resources/org/apache/myfaces/resource/web-facelettaglibrary_4_1.xsd
+++ b/impl/src/main/resources/org/apache/myfaces/resource/web-facelettaglibrary_4_1.xsd
@@ -1,0 +1,751 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema targetNamespace="https://jakarta.ee/xml/ns/jakartaee"
+            xmlns:jakartaee="https://jakarta.ee/xml/ns/jakartaee"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns:xml="http://www.w3.org/XML/1998/namespace"
+            elementFormDefault="qualified"
+            attributeFormDefault="unqualified"
+            version="4.1">
+  <xsd:include schemaLocation="jakartaee_11.xsd"/>
+
+  <xsd:annotation>
+    <xsd:documentation>
+
+      Copyright (c) 2024 Contributors to Eclipse Foundation.
+
+      This program and the accompanying materials are made available under the
+      terms of the Eclipse Public License v. 2.0, which is available at
+      http://www.eclipse.org/legal/epl-2.0.
+
+      This Source Code may also be made available under the following Secondary
+      Licenses when the conditions for such availability set forth in the
+      Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+      version 2 with the GNU Classpath Exception, which is available at
+      https://www.gnu.org/software/classpath/license.html.
+
+      SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+      
+    </xsd:documentation>
+  </xsd:annotation>
+
+  <xsd:annotation>
+    <xsd:documentation>
+      <![CDATA[
+      [
+      <p>The XML Schema for the Tag Libraries in the Jakarta Faces
+      Standard Facelets View Declaration Language (Facelets VDL)
+      (Version 4.1).</p>
+      
+      <p>Jakarta Faces 4.1 Facelet Tag Libraries that wish to conform to 
+      this schema must declare it in the following manner.</p>
+      
+      &lt;facelet-taglib xmlns="https://jakarta.ee/xml/ns/jakartaee"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-facelettaglibrary_4_1.xsd"
+      version="4.1"&gt;
+      
+      ...
+      
+      &lt;/facelet-taglib&gt;</pre>
+      
+      <p>The instance documents may indicate the published
+      version of the schema using xsi:schemaLocation attribute
+      for jakartaee namespace with the following location:</p>
+      
+      <p>https://jakarta.ee/xml/ns/jakartaee/web-facelettaglibrary_4_1.xsd</p>
+      
+      ]]>
+    </xsd:documentation>
+  </xsd:annotation>
+
+
+<!-- **************************************************** -->
+
+  <xsd:element name="facelet-taglib"
+               type="jakartaee:facelet-taglibType">
+    <xsd:unique name="facelet-taglib-tagname-uniqueness">
+      <xsd:annotation>
+        <xsd:documentation>
+          <![CDATA[
+          <p>
+          
+          tag-names must be unique within a document.
+          
+          </p>
+          ]]>
+        </xsd:documentation>
+      </xsd:annotation>
+      <xsd:selector xpath="jakartaee:tag"/>
+      <xsd:field xpath="jakartaee:tag-name"/>
+    </xsd:unique>
+    <xsd:unique name="faces-config-behavior-ID-uniqueness">
+      <xsd:annotation>
+        <xsd:documentation>
+          <![CDATA[
+          <p>
+          
+          Behavior IDs must be unique within a document.
+          
+          </p>
+          ]]>
+        </xsd:documentation>
+      </xsd:annotation>
+      <xsd:selector xpath="jakartaee:behavior"/>
+      <xsd:field xpath="jakartaee:behavior-id"/>
+    </xsd:unique>
+    <xsd:unique name="faces-config-converter-ID-uniqueness">
+      <xsd:annotation>
+        <xsd:documentation>
+          <![CDATA[
+          <p>
+          
+          Converter IDs must be unique within a document.
+          
+          </p>
+          ]]>
+        </xsd:documentation>
+      </xsd:annotation>
+      <xsd:selector xpath="jakartaee:converter"/>
+      <xsd:field xpath="jakartaee:converter-id"/>
+    </xsd:unique>
+    <xsd:unique name="faces-config-validator-ID-uniqueness">
+      <xsd:annotation>
+        <xsd:documentation>
+          <![CDATA[
+          <p>
+          
+          Validator IDs must be unique within a document.
+          
+          </p>
+          ]]>
+        </xsd:documentation>
+      </xsd:annotation>
+      <xsd:selector xpath="jakartaee:validator"/>
+      <xsd:field xpath="jakartaee:validator-id"/>
+    </xsd:unique>
+  </xsd:element>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="facelet-taglibType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p>
+        
+        The top level XML element in a facelet tag library XML file.
+        
+        </p>
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="jakartaee:descriptionGroup"/>
+      <xsd:choice>
+        <xsd:element name="library-class"
+                     type="jakartaee:fully-qualified-classType"/>
+        <xsd:sequence>
+          <xsd:element name="namespace"
+                       type="jakartaee:string"/>
+          <xsd:element minOccurs="0"
+                       maxOccurs="1"
+                       name="short-name"
+                       type="jakartaee:string">
+            <xsd:annotation>
+              <xsd:documentation>
+                <![CDATA[
+                <p>
+                
+                An advisory short name for usages of tags from this tag library.
+                
+                </p>
+                ]]>
+              </xsd:documentation>
+            </xsd:annotation>
+          </xsd:element>
+          <xsd:element minOccurs="0"
+                       maxOccurs="1"
+                       name="composite-library-name"
+                       type="jakartaee:string"/>
+          <xsd:choice minOccurs="0"
+                      maxOccurs="unbounded">
+            <xsd:element name="tag"
+                         type="jakartaee:facelet-taglib-tagType"/>
+            <xsd:element name="function"
+                         type="jakartaee:facelet-taglib-functionType"/>
+          </xsd:choice>
+        </xsd:sequence>
+      </xsd:choice>
+      <xsd:element name="taglib-extension"
+                   type="jakartaee:facelet-taglib-extensionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+    <xsd:attribute name="version"
+                   type="jakartaee:facelet-taglib-versionType"
+                   use="required"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="facelet-taglib-extensionType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p>
+        
+        Extension element for facelet-taglib. It may contain
+        implementation specific content.
+        
+        </p>
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:any namespace="##any"
+               processContents="lax"
+               minOccurs="0"
+               maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="facelet-taglib-tagType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p>If the tag library XML
+        file contains individual tag declarations rather than pointing
+        to a library-class or a declaring a composite-library name, the
+        individual tags are enclosed in tag elements.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="jakartaee:descriptionGroup"/>
+      <xsd:element name="tag-name"
+                   type="jakartaee:facelet-taglib-canonical-nameType"/>
+      <xsd:choice>
+        <xsd:element name="handler-class"
+                     type="jakartaee:fully-qualified-classType"/>
+        <xsd:element name="behavior"
+                     type="jakartaee:facelet-taglib-tag-behaviorType"/>
+        <xsd:element name="component"
+                     type="jakartaee:facelet-taglib-tag-componentType"/>
+        <xsd:element name="converter"
+                     type="jakartaee:facelet-taglib-tag-converterType"/>
+        <xsd:element name="validator"
+                     type="jakartaee:facelet-taglib-tag-validatorType"/>
+        <xsd:element name="source"
+                     type="jakartaee:string"/>
+      </xsd:choice>
+      <xsd:element name="attribute"
+                   type="jakartaee:facelet-taglib-tag-attributeType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="tag-extension"
+                   type="jakartaee:facelet-taglib-tag-extensionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="facelet-taglib-tag-attributeType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p>
+        
+        <p>The attribute element defines an attribute for the nesting
+        tag. The attribute element may have several subelements
+        defining:</p>
+        
+        <dl>
+        
+        <dt>description</dt><dd><p> a description of the attribute
+        </p></dd>
+        
+        <dt>name</dt><dd><p> the name of the attribute
+        </p></dd>
+        
+        <dt>required</dt><dd><p> whether the attribute is required or
+        optional
+        </p></dd>
+        
+        <dt>type</dt><dd><p> the type of the attribute
+        </p></dd>
+        
+        </dl>
+        
+        </p>
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="jakartaee:descriptionGroup"/>
+      <xsd:element name="name"
+                   type="jakartaee:xsdNMTOKENType"/>
+      <xsd:element name="required"
+                   type="jakartaee:generic-booleanType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p>Defines if the nesting attribute is required or
+            optional.</p>
+            
+            <p>If not present then the default is "false", i.e
+            the attribute is optional.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:choice>
+        <xsd:element name="type"
+                     type="jakartaee:fully-qualified-classType"
+                     minOccurs="0">
+          <xsd:annotation>
+            <xsd:documentation>
+              <![CDATA[
+              <p>
+              
+              Defines the Java type of the attributes
+              value. If this element is omitted, the
+              expected type is assumed to be
+              "java.lang.Object".</p>
+              
+              ]]>
+            </xsd:documentation>
+          </xsd:annotation>
+        </xsd:element>
+        <xsd:element name="method-signature"
+                     type="jakartaee:string"
+                     minOccurs="0">
+          <xsd:annotation>
+            <xsd:documentation>
+              <![CDATA[
+              <p>
+              
+              Defines the method signature for a MethodExpression-
+              enabled attribute.  The syntax of the method-signature
+              element is as follows (taken from the function-signature
+              EBNF in web-jsptaglibrary_2_1.xsd):</p>
+              
+              <code>
+              
+              <p>MethodSignature ::= ReturnType S MethodName S? '(' S? Parameters? S? ')'</p>
+              
+              <p>ReturnType        ::= Type</p>
+              
+              <p>MethodName        ::= Identifier</p>
+              
+              <p>Parameters        ::= Parameter | ( Parameter S? ',' S? Parameters )</p>
+              
+              <p>Parameter         ::= Type</p>
+              
+              </code>
+              
+              <p>Where:</p>
+              
+              <ul>
+              
+              <li><p><code>Type</code> is a basic type or a fully qualified
+              Java class name (including package name), as per the 'Type'
+              production in the Java Language Specification, Second Edition,
+              Chapter 18.</p></li>
+              
+              <li><p><code>Identifier</code> is a Java identifier, as per the
+              'Identifier' production in the Java Language Specification,
+              Second Edition, Chapter 18.</p></li>
+              
+              </ul>
+              
+              <p>Example:</p>
+              
+              <p><code>java.lang.String nickName( java.lang.String, int )</code></p>
+              
+              ]]>
+            </xsd:documentation>
+          </xsd:annotation>
+        </xsd:element>
+      </xsd:choice>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="facelet-taglib-tag-extensionType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p>
+        
+        Extension element for tag It may contain
+        implementation specific content.
+        
+        </p>
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:any namespace="##any"
+               processContents="lax"
+               minOccurs="0"
+               maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="facelet-taglib-functionType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p>
+        
+        If the tag library XML file contains individual function
+        declarations rather than pointing to a library-class or a
+        declaring a composite-library name, the individual functions are
+        enclosed in function elements.
+        
+        </p>
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="jakartaee:descriptionGroup"/>
+      <xsd:element name="function-name"
+                   type="jakartaee:string"/>
+      <xsd:element name="function-class"
+                   type="jakartaee:fully-qualified-classType"/>
+      <xsd:element name="function-signature"
+                   type="jakartaee:string"/>
+    </xsd:sequence>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="facelet-taglib-tag-behaviorType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p>
+        
+        Within a tag element, the behavior element encapsulates
+        information specific to a Faces Behavior.
+        
+        </p>
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="jakartaee:descriptionGroup"/>
+      <xsd:element minOccurs="1"
+                   maxOccurs="1"
+                   name="behavior-id"
+                   type="jakartaee:string"/>
+      <xsd:element minOccurs="0"
+                   maxOccurs="1"
+                   name="handler-class"
+                   type="jakartaee:fully-qualified-classType"/>
+      <xsd:element name="behavior-extension"
+                   type="jakartaee:facelet-taglib-tag-behavior-extensionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="facelet-taglib-tag-behavior-extensionType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p>
+        
+        Extension element for behavior. It may contain
+        implementation specific content.
+        
+        </p>
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:any namespace="##any"
+               processContents="lax"
+               minOccurs="0"
+               maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="facelet-taglib-tag-componentType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p><span class="changed_modified_2_2
+        changed_modified_2_3">Within</span> a tag element, the component
+        element encapsulates information specific to a Faces UIComponent.</p>
+        
+        <div class="changed_added_2_2 changed_deleted_2_3">
+        
+        <p>As of 3.0 of the specification, this requirement is no longer
+        present: This element must have exactly one of
+        <code>&lt;component-type&gt;</code>, <code>&lt;resource-id&gt;</code>,
+        or <code>&lt;handler-class&gt;</code> among its child elements.</p>
+        
+        </div>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="jakartaee:descriptionGroup"/>
+      <xsd:element name="component-type"
+                   type="jakartaee:string"/>
+      <xsd:element minOccurs="0"
+                   maxOccurs="1"
+                   name="renderer-type"
+                   type="jakartaee:string"/>
+      <xsd:element minOccurs="0"
+                   maxOccurs="1"
+                   name="handler-class"
+                   type="jakartaee:fully-qualified-classType"/>
+      <xsd:element minOccurs="0"
+                   maxOccurs="1"
+                   name="resource-id"
+                   type="jakartaee:string">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p class="changed_added_2_2">A valid resource identifier
+            as specified in the Jakarta Faces Specification Document section 2.6.1.3 "Resource Identifiers".
+            For example:</p>
+            
+            <p><code>&lt;resource-id&gt;myCC/ccName.xhtml&lt;/resource-id&gt;</code></p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="component-extension"
+                   type="jakartaee:facelet-taglib-tag-component-extensionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="facelet-taglib-tag-component-extensionType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p>
+        
+        Extension element for component It may contain
+        implementation specific content.
+        
+        </p>
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:any namespace="##any"
+               processContents="lax"
+               minOccurs="0"
+               maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="facelet-taglib-tag-converterType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p>
+        
+        Within a tag element, the converter element encapsulates
+        information specific to a Faces Converter.
+        
+        </p>
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="jakartaee:descriptionGroup"/>
+      <xsd:element minOccurs="1"
+                   maxOccurs="1"
+                   name="converter-id"
+                   type="jakartaee:string"/>
+      <xsd:element minOccurs="0"
+                   maxOccurs="1"
+                   name="handler-class"
+                   type="jakartaee:fully-qualified-classType"/>
+      <xsd:element name="converter-extension"
+                   type="jakartaee:facelet-taglib-tag-converter-extensionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="facelet-taglib-tag-converter-extensionType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p>
+        
+        Extension element for converter It may contain
+        implementation specific content.
+        
+        </p>
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:any namespace="##any"
+               processContents="lax"
+               minOccurs="0"
+               maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="facelet-taglib-tag-validatorType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p>
+        
+        Within a tag element, the validator element encapsulates
+        information specific to a Faces Validator.
+        
+        </p>
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="jakartaee:descriptionGroup"/>
+      <xsd:element minOccurs="1"
+                   maxOccurs="1"
+                   name="validator-id"
+                   type="jakartaee:string"/>
+      <xsd:element minOccurs="0"
+                   maxOccurs="1"
+                   name="handler-class"
+                   type="jakartaee:fully-qualified-classType"/>
+      <xsd:element name="validator-extension"
+                   type="jakartaee:facelet-taglib-tag-validator-extensionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="facelet-taglib-tag-validator-extensionType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p>
+        
+        Extension element for validator It may contain
+        implementation specific content.
+        
+        </p>
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:any namespace="##any"
+               processContents="lax"
+               minOccurs="0"
+               maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+  <xsd:simpleType name="facelet-taglib-versionType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p>
+        
+        This type contains the recognized versions of
+        facelet-taglib supported.
+        
+        </p>
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="4.1"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="facelet-taglib-canonical-nameType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p>
+        
+        <p>Defines the canonical name of a tag or attribute being
+        defined.</p>
+        
+        <p>The name must conform to the lexical rules for an NCName</p>
+        
+        </p>
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:extension base="xsd:NCName">
+        <xsd:attribute name="id"
+                       type="xsd:ID"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+</xsd:schema>

--- a/impl/src/main/resources/org/apache/myfaces/resource/web-facesconfig_4_1.xsd
+++ b/impl/src/main/resources/org/apache/myfaces/resource/web-facesconfig_4_1.xsd
@@ -1,0 +1,3447 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns:jakartaee="https://jakarta.ee/xml/ns/jakartaee"
+            attributeFormDefault="unqualified"
+            elementFormDefault="qualified"
+            targetNamespace="https://jakarta.ee/xml/ns/jakartaee"
+            version="4.1"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <xsd:include schemaLocation="jakartaee_11.xsd"/>
+
+  <xsd:annotation>
+    <xsd:documentation>
+
+      Copyright (c) 2024 Contributors to Eclipse Foundation.
+
+      This program and the accompanying materials are made available under the
+      terms of the Eclipse Public License v. 2.0, which is available at
+      http://www.eclipse.org/legal/epl-2.0.
+
+      This Source Code may also be made available under the following Secondary
+      Licenses when the conditions for such availability set forth in the
+      Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+      version 2 with the GNU Classpath Exception, which is available at
+      https://www.gnu.org/software/classpath/license.html.
+
+      SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+      
+    </xsd:documentation>
+  </xsd:annotation>
+
+  <xsd:annotation>
+    <xsd:documentation>
+      <![CDATA[
+      <p>The XML Schema for the Jakarta Faces Application
+      Configuration File (Version 4.1).</p>
+      
+      <p>All Jakarta Faces configuration files must indicate
+      the Jakarta Faces schema by indicating the
+      Jakarta Faces namespace:</p>
+      
+      <p>https://jakarta.ee/xml/ns/jakartaee</p>
+      
+      <p>and by indicating the version of the schema by
+      using the version element as shown below:</p>
+      
+      <pre>&lt;faces-config xmlns="https://jakarta.ee/xml/ns/jakartaee"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="..."
+      version="4.1"&gt;
+      ...
+      &lt;/faces-config&gt;</pre>
+      
+      <p>The instance documents may indicate the published
+      version of the schema using xsi:schemaLocation attribute
+      for jakartaee namespace with the following location:</p>
+      
+      <p>https://jakarta.ee/xml/ns/jakartaee/web-facesconfig_4_1.xsd</p>
+      
+      ]]>
+    </xsd:documentation>
+  </xsd:annotation>
+
+
+<!-- **************************************************** -->
+
+  <xsd:element name="faces-config"
+               type="jakartaee:faces-configType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p>The "faces-config" element is the root of the configuration
+        information hierarchy, and contains nested elements for all
+        of the other configuration settings.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:unique name="faces-config-behavior-ID-uniqueness">
+      <xsd:annotation>
+        <xsd:documentation>
+          <![CDATA[
+          <p>Behavior IDs must be unique within a document.</p>
+          
+          ]]>
+        </xsd:documentation>
+      </xsd:annotation>
+      <xsd:selector xpath="jakartaee:behavior"/>
+      <xsd:field xpath="jakartaee:behavior-id"/>
+    </xsd:unique>
+    <xsd:unique name="faces-config-converter-ID-uniqueness">
+      <xsd:annotation>
+        <xsd:documentation>
+          <![CDATA[
+          <p>Converter IDs must be unique within a document.</p>
+          
+          ]]>
+        </xsd:documentation>
+      </xsd:annotation>
+      <xsd:selector xpath="jakartaee:converter"/>
+      <xsd:field xpath="jakartaee:converter-id"/>
+    </xsd:unique>
+    <xsd:unique name="faces-config-converter-for-class-uniqueness">
+      <xsd:annotation>
+        <xsd:documentation>
+          <![CDATA[
+          <p>'converter-for-class' element values must be unique
+          within a document.</p>
+          
+          ]]>
+        </xsd:documentation>
+      </xsd:annotation>
+      <xsd:selector xpath="jakartaee:converter"/>
+      <xsd:field xpath="jakartaee:converter-for-class"/>
+    </xsd:unique>
+    <xsd:unique name="faces-config-validator-ID-uniqueness">
+      <xsd:annotation>
+        <xsd:documentation>
+          <![CDATA[
+          <p> Validator IDs must be unique within a document.</p>
+          
+          ]]>
+        </xsd:documentation>
+      </xsd:annotation>
+      <xsd:selector xpath="jakartaee:validator"/>
+      <xsd:field xpath="jakartaee:validator-id"/>
+    </xsd:unique>
+  </xsd:element>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-configType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> The "faces-config" element is the root of the configuration
+        information hierarchy, and contains nested elements for all
+        of the other configuration settings.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:choice minOccurs="0"
+                maxOccurs="unbounded">
+      <xsd:element name="application"
+                   type="jakartaee:faces-config-applicationType"/>
+      <xsd:element name="ordering"
+                   type="jakartaee:faces-config-orderingType"/>
+      <xsd:element name="absolute-ordering"
+                   type="jakartaee:faces-config-absoluteOrderingType"
+                   minOccurs="0"/>
+      <xsd:element name="factory"
+                   type="jakartaee:faces-config-factoryType"/>
+      <xsd:element name="component"
+                   type="jakartaee:faces-config-componentType"/>
+      <xsd:element name="converter"
+                   type="jakartaee:faces-config-converterType"/>
+      <xsd:element name="flow-definition"
+                   type="jakartaee:faces-config-flow-definitionType"/>
+      <xsd:element name="name"
+                   type="jakartaee:java-identifierType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> <span class="changed_modified_2_2">The</span> "name" element 
+            within the top level "faces-config"
+            element declares the name of this application
+            configuration resource.  Such names are used
+            in the document ordering scheme specified in section
+            11.3.8 "Ordering of Artifacts" of the Jakarta Faces Specification Document.</p>
+            
+            <p class="changed_added_2_2">This value is taken to be the 
+            defining document id of any &lt;flow-definition&gt; elements 
+            defined in this Application Configuration Resource file.  If this
+            element is not specified, the runtime must take the empty string 
+            as its value.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="navigation-rule"
+                   type="jakartaee:faces-config-navigation-ruleType"/>
+      <xsd:element name="protected-views"
+                   type="jakartaee:faces-config-protected-viewsType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="referenced-bean"
+                   type="jakartaee:faces-config-referenced-beanType"/>
+      <xsd:element name="render-kit"
+                   type="jakartaee:faces-config-render-kitType"/>
+      <xsd:element name="lifecycle"
+                   type="jakartaee:faces-config-lifecycleType"/>
+      <xsd:element name="validator"
+                   type="jakartaee:faces-config-validatorType"/>
+      <xsd:element name="behavior"
+                   type="jakartaee:faces-config-behaviorType"/>
+      <xsd:element name="faces-config-extension"
+                   type="jakartaee:faces-config-extensionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+    </xsd:choice>
+    <xsd:attribute name="metadata-complete"
+                   type="xsd:boolean"
+                   use="optional">
+      <xsd:annotation>
+        <xsd:documentation>
+
+          The metadata-complete attribute defines whether this
+          Faces application is complete, or whether
+          the class files available to this module and packaged with
+          this application should be examined for annotations
+          that specify configuration information.
+          
+          This attribute is only inspected on the application 
+          configuration resource file located at "WEB-INF/faces-config.xml".
+          The presence of this attribute on any application configuration
+          resource other than the one located at "WEB-INF/faces-config.xml",
+          including any files named using the jakarta.faces.CONFIG_FILES
+          attribute, must be ignored.
+          
+          If metadata-complete is set to "true", the Faces
+          runtime must ignore any annotations that specify configuration
+          information, which might be present in the class files
+          of the application.
+          
+          If metadata-complete is not specified or is set to
+          "false", the Faces runtime must examine the class
+          files of the application for annotations, as specified by
+          the specification.
+          
+          If "WEB-INF/faces-config.xml" is not present, the 
+          Faces runtime will assume metadata-complete to be "false".
+          
+          The value of this attribute will have no impact on
+          runtime annotations such as @ResourceDependency or
+          @ListenerFor.
+          
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+    <xsd:attribute name="version"
+                   type="jakartaee:faces-config-versionType"
+                   use="required"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-extensionType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> Extension element for faces-config.  It may contain
+        implementation specific content.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:any minOccurs="0"
+               maxOccurs="unbounded"
+               namespace="##any"
+               processContents="lax"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-orderingType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> Please see section 
+        11.3.8 "Ordering of Artifacts" of the Jakarta Faces Specification Document
+        for the specification of this element.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="after"
+                   type="jakartaee:faces-config-ordering-orderingType"
+                   minOccurs="0"/>
+      <xsd:element name="before"
+                   type="jakartaee:faces-config-ordering-orderingType"
+                   minOccurs="0"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-ordering-orderingType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> This element contains a sequence of "id" elements, each of which
+        refers to an application configuration resource by the "id"
+        declared on its faces-config element.  This element can also contain
+        a single "others" element which specifies that this document comes
+        before or after other documents within the application.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="name"
+                   type="jakartaee:java-identifierType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="others"
+                   type="jakartaee:faces-config-ordering-othersType"
+                   minOccurs="0"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-ordering-othersType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> This element indicates that the ordering sub-element in which
+        it was placed should take special action regarding the ordering
+        of this application resource relative to other
+        application configuration resources.
+        See section 11.3.8 "Ordering of Artifacts" of the Jakarta Faces Specification Document
+        for the complete specification.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-absoluteOrderingType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> Only relevant if this is placed within the /WEB-INF/faces-config.xml.
+        Please see 
+        section 11.3.8 "Ordering of Artifacts" of the Jakarta Faces Specification Document
+        for the specification for details.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:choice minOccurs="0"
+                maxOccurs="unbounded">
+      <xsd:element name="name"
+                   type="jakartaee:java-identifierType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="others"
+                   type="jakartaee:faces-config-ordering-othersType"
+                   minOccurs="0"/>
+    </xsd:choice>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-applicationType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> The "application" element provides a mechanism to define the
+        various per-application-singleton implementation artifacts for
+        a particular web application that is utilizing
+        Jakarta Faces.  For nested elements that are not specified,
+        the Jakarta Faces implementation must provide a suitable 
+        default.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:choice minOccurs="0"
+                maxOccurs="unbounded">
+      <xsd:element name="action-listener"
+                   type="jakartaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The "action-listener" element contains the fully
+            qualified class name of the concrete
+            ActionListener implementation class that will be
+            called during the Invoke Application phase of the
+            request processing lifecycle.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="default-render-kit-id"
+                   type="jakartaee:string">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The "default-render-kit-id" element allows the
+            application to define a renderkit to be used other
+            than the standard one.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="message-bundle"
+                   type="jakartaee:string">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The base name of a resource bundle representing
+            the message resources for this application.  See
+            the JavaDocs for the "java.util.ResourceBundle"
+            class for more information on the syntax of
+            resource bundle names.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="navigation-handler"
+                   type="jakartaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The "navigation-handler" element contains the
+            fully qualified class name of the concrete
+            NavigationHandler implementation class that will
+            be called during the Invoke Application phase
+            of the request processing lifecycle, if the
+            default ActionListener (provided by the Jakarta Faces 
+            implementation) is used.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="view-handler"
+                   type="jakartaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The "view-handler" element contains the fully
+            qualified class name of the concrete ViewHandler
+            implementation class that will be called during
+            the Restore View and Render Response phases of the
+            request processing lifecycle.  The faces
+            implementation must provide a default
+            implementation of this class.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="state-manager"
+                   type="jakartaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The "state-manager" element contains the fully
+            qualified class name of the concrete StateManager
+            implementation class that will be called during
+            the Restore View and Render Response phases of the
+            request processing lifecycle.  The faces
+            implementation must provide a default
+            implementation of this class.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="el-resolver"
+                   type="jakartaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The "el-resolver" element contains the fully
+            qualified class name of the concrete
+            jakarta.el.ELResolver implementation class
+            that will be used during the processing of
+            EL expressions.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="resource-handler"
+                   type="jakartaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The "resource-handler" element contains the
+            fully qualified class name of the concrete
+            ResourceHandler implementation class that
+            will be used during rendering and decoding
+            of resource requests The standard
+            constructor based decorator pattern used for
+            other application singletons will be
+            honored.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="resource-library-contracts"
+                   type="jakartaee:faces-config-application-resource-library-contractsType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p class="changed_added_2_2">The "resource-library-contracts" element
+            specifies the mappings between views in the application and resource
+            library contracts that, if present in the application, must be made
+            available for use as templates of the specified views.
+            </p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="search-expression-handler"
+                   type="jakartaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p class="changed_added_2_3">The "search-expression-handler"
+            element contains the fully qualified class name of the
+            concrete jakarta.faces.component.search.SearchExpressionHandler
+            implementation class that will be used for processing of a
+            search expression.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="search-keyword-resolver"
+                   type="jakartaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p class="changed_added_2_3"> The "search-keyword-resolver"
+            element contains the fully qualified class name of the
+            concrete jakarta.faces.component.search.SearchKeywordResolver
+            implementation class that will be used during the processing
+            of a search expression keyword.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="system-event-listener"
+                   type="jakartaee:faces-config-system-event-listenerType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="locale-config"
+                   type="jakartaee:faces-config-locale-configType"/>
+      <xsd:element name="resource-bundle"
+                   type="jakartaee:faces-config-application-resource-bundleType"/>
+      <xsd:element name="application-extension"
+                   type="jakartaee:faces-config-application-extensionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="default-validators"
+                   type="jakartaee:faces-config-default-validatorsType"/>
+    </xsd:choice>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-application-resource-bundleType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> The resource-bundle element inside the application element
+        references a java.util.ResourceBundle instance by name
+        using the var element.  ResourceBundles referenced in this
+        manner may be returned by a call to
+        Application.getResourceBundle() passing the current
+        FacesContext for this request and the value of the var
+        element below.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="jakartaee:descriptionGroup"/>
+      <xsd:element name="base-name"
+                   type="jakartaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The fully qualified class name of the
+            java.util.ResourceBundle instance.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="var"
+                   type="jakartaee:string">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The name by which this ResourceBundle instance
+            is retrieved by a call to
+            Application.getResourceBundle().</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-application-resource-library-contractsType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p class="changed_added_2_2">The "resource-library-contracts" element
+        specifies the mappings between views in the application and resource
+        library contracts that, if present in the application, must be made
+        available for use as templates of the specified views.
+        </p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="jakartaee:descriptionGroup"/>
+      <xsd:element name="contract-mapping"
+                   type="jakartaee:faces-config-application-resource-library-contracts-contract-mappingType"
+                   maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p classes="changed_added_2_2">Declare a mapping between a collection
+            of views in the application and the list of contracts (if present in the application)
+            that may be used as a source for templates and resources for those views.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-application-resource-library-contracts-contract-mappingType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p class="changed_added_2_2">The "contract-mapping" element
+        specifies the mappings between a collection of views in the application and resource
+        library contracts that, if present in the application, must be made
+        available for use as templates of the specified views.
+        </p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="jakartaee:descriptionGroup"/>
+      <xsd:element name="url-pattern"
+                   type="jakartaee:url-patternType"
+                   maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p class="changed_added_2_2">The "url-pattern" element
+            specifies the collection of views in this application that 
+            are allowed to use the corresponding contracts.
+            </p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="contracts"
+                   type="jakartaee:string"
+                   maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p class="changed_added_2_2">The "contracts" element
+            is a comma separated list of resource library contracts that,
+            if available to the application, may be used by the views
+            matched by the corresponding "url-pattern"
+            </p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-application-extensionType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> Extension element for application.  It may contain
+        implementation specific content.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:any minOccurs="0"
+               maxOccurs="unbounded"
+               namespace="##any"
+               processContents="lax"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-factoryType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> The "factory" element provides a mechanism to define the
+        various Factories that comprise parts of the implementation
+        of Jakarta Faces.  For nested elements that are not
+        specified, the Jakarta Faces implementation must provide a 
+        suitable default.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:choice minOccurs="0"
+                maxOccurs="unbounded">
+      <xsd:element name="application-factory"
+                   type="jakartaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The "application-factory" element contains the
+            fully qualified class name of the concrete
+            ApplicationFactory implementation class that will
+            be called when
+            FactoryFinder.getFactory(APPLICATION_FACTORY) is
+            called.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="exception-handler-factory"
+                   type="jakartaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The "exception-handler-factory" element contains the
+            fully qualified class name of the concrete
+            ExceptionHandlerFactory implementation class that will
+            be called when
+            FactoryFinder.getFactory(EXCEPTION_HANDLER_FACTORY)
+            is called.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="external-context-factory"
+                   type="jakartaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The "external-context-factory" element contains the
+            fully qualified class name of the concrete
+            ExternalContextFactory implementation class that will
+            be called when
+            FactoryFinder.getFactory(EXTERNAL_CONTEXT_FACTORY)
+            is called.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="faces-context-factory"
+                   type="jakartaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The "faces-context-factory" element contains the
+            fully qualified class name of the concrete
+            FacesContextFactory implementation class that will
+            be called when
+            FactoryFinder.getFactory(FACES_CONTEXT_FACTORY)
+            is called.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="facelet-cache-factory"
+                   type="jakartaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The "facelet-cache-factory" element contains the
+            fully qualified class name of the concrete
+            FaceletCacheFactory implementation class that will
+            be called when
+            FactoryFinder.getFactory(FACELET_CACHE_FACTORY)
+            is called.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="partial-view-context-factory"
+                   type="jakartaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The "partial-view-context-factory" element contains the
+            fully qualified class name of the concrete
+            PartialViewContextFactory implementation class that will
+            be called when FactoryFinder.getFactory
+            (FactoryFinder.PARTIAL_VIEW_CONTEXT_FACTORY) is called.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="lifecycle-factory"
+                   type="jakartaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The "lifecycle-factory" element contains the fully
+            qualified class name of the concrete LifecycleFactory
+            implementation class that will be called when
+            FactoryFinder.getFactory(LIFECYCLE_FACTORY) is called.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="view-declaration-language-factory"
+                   type="jakartaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The "view-declaration-language-factory" element contains
+            the fully qualified class name of the concrete
+            ViewDeclarationLanguageFactory
+            implementation class that will be called when
+            FactoryFinder.getFactory(VIEW_DECLARATION_FACTORY) is called.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="tag-handler-delegate-factory"
+                   type="jakartaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The "tag-handler-delegate-factory" element contains
+            the fully qualified class name of the concrete
+            ViewDeclarationLanguageFactory
+            implementation class that will be called when
+            FactoryFinder.getFactory(TAG_HANDLER_DELEGATE_FACTORY) is called.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="render-kit-factory"
+                   type="jakartaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The "render-kit-factory" element contains the fully
+            qualified class name of the concrete RenderKitFactory
+            implementation class that will be called when
+            FactoryFinder.getFactory(RENDER_KIT_FACTORY) is
+            called.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="visit-context-factory"
+                   type="jakartaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The "visit-context-factory" element contains the fully
+            qualified class name of the concrete VisitContextFactory
+            implementation class that will be called when
+            FactoryFinder.getFactory(VISIT_CONTEXT_FACTORY) is
+            called.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="flash-factory"
+                   type="jakartaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p class="changed_added_2_2"> The "flash-factory" element contains the
+            fully qualified class name of the concrete
+            FaceletFactory implementation class that will
+            be called when
+            FactoryFinder.getFactory(FLASH_FACTORY) is
+            called.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="flow-handler-factory"
+                   type="jakartaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The "flow-handler-factory" element contains the
+            fully qualified class name of the concrete
+            FlowHandlerFactory implementation class that will
+            be called when
+            FactoryFinder.getFactory(FLOW_HANDLER_FACTORY) is
+            called.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="client-window-factory"
+                   type="jakartaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p class="changed_added_2_3"> The "client-window-factory" element contains the fully 
+            qualified class name of the concrete ClientWindowFactory implementation class that 
+            will be called when FactoryFinder.getFactory(CLIENT_WINDOW_FACTORY) is called.</p>  
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="search-expression-context-factory"
+                   type="jakartaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p class="changed_added_2_3"> The
+            "search-expression-context-factory" element contains the
+            fully qualified class name of the concrete
+            SearchExpressionContextFactory implementation class that will
+            be called when
+            FactoryFinder.getFactory(SEARCH_EXPRESSION_CONTEXT_FACTORY)
+            is called.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="factory-extension"
+                   type="jakartaee:faces-config-factory-extensionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+    </xsd:choice>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-factory-extensionType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> Extension element for factory.  It may contain
+        implementation specific content.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:any minOccurs="0"
+               maxOccurs="unbounded"
+               namespace="##any"
+               processContents="lax"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-attributeType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> The "attribute" element represents a named, typed, value
+        associated with the parent UIComponent via the generic
+        attributes mechanism.</p>
+        
+        <p>Attribute names must be unique within the scope of the parent
+        (or related) component.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="jakartaee:descriptionGroup"/>
+      <xsd:element name="attribute-name"
+                   type="jakartaee:string">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The "attribute-name" element represents the name under
+            which the corresponding value will be stored, in the
+            generic attributes of the UIComponent we are related
+            to.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="attribute-class"
+                   type="jakartaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The "attribute-class" element represents the Java type
+            of the value associated with this attribute name.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="default-value"
+                   type="jakartaee:faces-config-default-valueType"
+                   minOccurs="0"/>
+      <xsd:element name="suggested-value"
+                   type="jakartaee:faces-config-suggested-valueType"
+                   minOccurs="0"/>
+      <xsd:element name="attribute-extension"
+                   type="jakartaee:faces-config-attribute-extensionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-attribute-extensionType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> Extension element for attribute.  It may contain
+        implementation specific content.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:any minOccurs="0"
+               maxOccurs="unbounded"
+               namespace="##any"
+               processContents="lax"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-componentType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> The "component" element represents a concrete UIComponent
+        implementation class that should be registered under the
+        specified type identifier, along with its associated
+        properties and attributes.  Component types must be unique
+        within the entire web application.</p>
+        
+        <p>Nested "attribute" elements identify generic attributes that
+        are recognized by the implementation logic of this component.
+        Nested "property" elements identify JavaBeans properties of
+        the component class that may be exposed for manipulation
+        via tools.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="jakartaee:descriptionGroup"/>
+      <xsd:element name="component-type"
+                   type="jakartaee:string">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The "component-type" element represents the name under
+            which the corresponding UIComponent class should be
+            registered.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="component-class"
+                   type="jakartaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The "component-class" element represents the fully
+            qualified class name of a concrete UIComponent
+            implementation class.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="facet"
+                   type="jakartaee:faces-config-facetType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="attribute"
+                   type="jakartaee:faces-config-attributeType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="property"
+                   type="jakartaee:faces-config-propertyType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="component-extension"
+                   type="jakartaee:faces-config-component-extensionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-component-extensionType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> Extension element for component.  It may contain
+        implementation specific content.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:any minOccurs="0"
+               maxOccurs="unbounded"
+               namespace="##any"
+               processContents="lax"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-default-localeType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> The "default-locale" element declares the default locale
+        for this application instance.</p>
+        
+        <p class="modified_added_2_3">
+        To facilitate BCP 47 this element first needs to be parsed by the
+        Locale.forLanguageTag method. If it does not return a Locale with
+        a language the old specification below needs to take effect.
+        </p>
+        
+        <p>It must be specified as :language:[_:country:[_:variant:]]
+        without the colons, for example "ja_JP_SJIS".  The
+        separators between the segments may be '-' or '_'.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:extension base="jakartaee:faces-config-localeType">
+        <xsd:attribute name="id"
+                       type="xsd:ID"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-default-valueType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> The "default-value" contains the value for the property or
+        attribute in which this element resides.  This value differs
+        from the "suggested-value" in that the property or attribute
+        must take the value, whereas in "suggested-value" taking the
+        value is optional.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="jakartaee:string">
+        <xsd:attribute name="id"
+                       type="xsd:ID"/>
+      </xsd:restriction>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+  <xsd:simpleType name="faces-config-el-expressionType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> EL expressions present within a faces config file
+        must start with the character sequence of '#{' and
+        end with '}'.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:restriction base="xsd:string">
+      <xsd:pattern value="#\{.*\}"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-facetType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> Define the name and other design-time information for a facet
+        that is associated with a renderer or a component.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="jakartaee:descriptionGroup"/>
+      <xsd:element name="facet-name"
+                   type="jakartaee:java-identifierType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The "facet-name" element represents the facet name
+            under which a UIComponent will be added to its parent.
+            It must be of type "Identifier".</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="facet-extension"
+                   type="jakartaee:faces-config-facet-extensionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-facet-extensionType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> Extension element for facet.  It may contain implementation
+        specific content.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:any minOccurs="0"
+               maxOccurs="unbounded"
+               namespace="##any"
+               processContents="lax"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-from-view-idType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p><span class="changed_modified_2_2">The</span>
+        value of from-view-id must contain one of the following
+        values:</p>
+        
+        <ul>
+        
+        <li><p>The exact match for a view identifier that is recognized
+        by the the ViewHandler implementation being used (such as
+        "/index.jsp" if you are using the default ViewHandler).</p></li>
+        
+        <li><p class="changed_added_2_2">The exact match of a flow node id
+        in the current flow, or a flow id of another flow.</p></li>
+        
+        <li><p> A proper prefix of a view identifier, plus a trailing
+        "*" character.  This pattern indicates that all view
+        identifiers that match the portion of the pattern up to the
+        asterisk will match the surrounding rule.  When more than one
+        match exists, the match with the longest pattern is selected.
+        </p></li>
+        
+        <li><p>An "*" character, which means that this pattern applies
+        to all view identifiers.  </p></li>
+        
+        </ul>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="jakartaee:string">
+        <xsd:attribute name="id"
+                       type="xsd:ID"/>
+      </xsd:restriction>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-from-actionType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> The "from-action" element contains an action reference
+        expression that must have been executed (by the default
+        ActionListener for handling application level events)
+        in order to select the navigation rule.  If not specified,
+        this rule will be relevant no matter which action reference
+        was executed (or if no action reference was executed).</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:extension base="jakartaee:faces-config-el-expressionType">
+        <xsd:attribute name="id"
+                       type="xsd:ID"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-ifType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p>The "if" element defines a condition that must resolve
+        to true in order for the navigation case on which it is
+        defined to be matched, with the existing match criteria
+        (action method and outcome) as a prerequiste, if present.
+        The condition is defined declaratively using a value
+        expression in the body of this element. The expression is
+        evaluated at the time the navigation case is being matched.
+        If the "from-outcome" is omitted and this element is
+        present, the navigation handler will match a null outcome
+        and use the condition return value to determine if the
+        case should be considered a match.</p>
+        
+        <div class="changed_added_2_2">
+        
+        <p>When used in a <code>&lt;switch&gt;</code> within a flow, if the
+        expresion returns <code>true</code>, the
+        <code>&lt;from-outcome&gt;</code> sibling element's outcome is used as
+        the id of the node in the flow graph to which control must be
+        passed.</p>
+        
+        </div>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:extension base="jakartaee:faces-config-el-expressionType">
+        <xsd:attribute name="id"
+                       type="xsd:ID"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-flow-definition-parameter-valueType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p class="changed_added_2_2"></p>
+        
+        <div class="changed_added_2_2">
+        
+        </div>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:extension base="jakartaee:faces-config-el-expressionType">
+        <xsd:attribute name="id"
+                       type="xsd:ID"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-converterType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> The "converter" element represents a concrete Converter
+        implementation class that should be registered under the
+        specified converter identifier.  Converter identifiers must
+        be unique within the entire web application.</p>
+        
+        <p>Nested "attribute" elements identify generic attributes that
+        may be configured on the corresponding UIComponent in order
+        to affect the operation of the Converter.  Nested "property"
+        elements identify JavaBeans properties of the Converter
+        implementation class that may be configured to affect the
+        operation of the Converter.  "attribute" and "property"
+        elements are intended to allow component developers to
+        more completely describe their components to tools and users.
+        These elements have no required runtime semantics.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="jakartaee:descriptionGroup"/>
+      <xsd:choice>
+        <xsd:element name="converter-id"
+                     type="jakartaee:string">
+          <xsd:annotation>
+            <xsd:documentation>
+              <![CDATA[
+              <p> The "converter-id" element represents the
+              identifier under which the corresponding
+              Converter class should be registered.</p>
+              
+              ]]>
+            </xsd:documentation>
+          </xsd:annotation>
+        </xsd:element>
+        <xsd:element name="converter-for-class"
+                     type="jakartaee:fully-qualified-classType">
+          <xsd:annotation>
+            <xsd:documentation>
+              <![CDATA[
+              <p> The "converter-for-class" element represents the
+              fully qualified class name for which a Converter
+              class will be registered.</p>
+              
+              ]]>
+            </xsd:documentation>
+          </xsd:annotation>
+        </xsd:element>
+      </xsd:choice>
+      <xsd:element name="converter-class"
+                   type="jakartaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The "converter-class" element represents the fully
+            qualified class name of a concrete Converter
+            implementation class.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="attribute"
+                   type="jakartaee:faces-config-attributeType"
+                   minOccurs="0"
+                   maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> Nested "attribute" elements identify generic
+            attributes that may be configured on the
+            corresponding UIComponent in order to affect the
+            operation of the Converter.  This attribute is
+            primarily for design-time tools and is not
+            specified to have any meaning at runtime.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="property"
+                   type="jakartaee:faces-config-propertyType"
+                   minOccurs="0"
+                   maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> Nested "property" elements identify JavaBeans
+            properties of the Converter implementation class
+            that may be configured to affect the operation of
+            the Converter.  This attribute is primarily for
+            design-time tools and is not specified to have
+            any meaning at runtime.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="converter-extension"
+                   type="jakartaee:faces-config-converter-extensionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-converter-extensionType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> Extension element for converter.  It may contain
+        implementation specific content.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:any minOccurs="0"
+               maxOccurs="unbounded"
+               namespace="##any"
+               processContents="lax"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-lifecycleType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> The "lifecycle" element provides a mechanism to specify
+        modifications to the behaviour of the default Lifecycle
+        implementation for this web application.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="phase-listener"
+                   type="jakartaee:fully-qualified-classType"
+                   minOccurs="0"
+                   maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The "phase-listener" element contains the fully
+            qualified class name of the concrete PhaseListener
+            implementation class that will be registered on
+            the Lifecycle.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="lifecycle-extension"
+                   type="jakartaee:faces-config-lifecycle-extensionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-lifecycle-extensionType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> Extension element for lifecycle.  It may contain
+        implementation specific content.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:any minOccurs="0"
+               maxOccurs="unbounded"
+               namespace="##any"
+               processContents="lax"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+  <xsd:simpleType name="faces-config-localeType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> The localeType defines valid locale defined by ISO-639-1
+        and ISO-3166.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:restriction base="xsd:string">
+      <xsd:pattern value="([a-z]{2})[_|\-]?([\p{L}]{2})?[_|\-]?(\w+)?"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-locale-configType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> The "locale-config" element allows the app developer to
+        declare the supported locales for this application.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="default-locale"
+                   type="jakartaee:faces-config-default-localeType"
+                   minOccurs="0"/>
+      <xsd:element name="supported-locale"
+                   type="jakartaee:faces-config-supported-localeType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-default-validatorsType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> The "default-validators" element allows the app developer to
+        register a set of validators, referenced by identifier, that
+        are automatically assigned to any EditableValueHolder component
+        in the application, unless overridden or disabled locally.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="validator-id"
+                   type="jakartaee:string"
+                   minOccurs="0"
+                   maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The "validator-id" element represents the identifier
+            of a registered validator.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+ 
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-flow-definitionType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p class="changed_added_2_2">Top level element for a flow
+        definition.</p>
+        
+        <div class="changed_added_2_2">
+        
+        <p>If there is no <code>&lt;start-node&gt;</code> element declared, it
+        is assumed to be <code>&lt;flowName&gt;.xhtml</code>.</p>
+        
+        </div>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="jakartaee:descriptionGroup"/>
+      <xsd:element name="start-node"
+                   type="jakartaee:java-identifierType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p class="changed_added_2_2">Declare the id of the starting node in the
+            flow graph.  The start node may be any of the node types mentioned in
+            the class javadocs for <code><a target="_"
+            href="jakarta/faces/flow/FlowHandler.html">FlowHandler</a></code>.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="view"
+                   type="jakartaee:faces-config-flow-definition-viewType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="switch"
+                   type="jakartaee:faces-config-flow-definition-switchType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="flow-return"
+                   type="jakartaee:faces-config-flow-definition-flow-returnType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="navigation-rule"
+                   type="jakartaee:faces-config-navigation-ruleType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="flow-call"
+                   type="jakartaee:faces-config-flow-definition-flow-callType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="method-call"
+                   type="jakartaee:faces-config-flow-definition-faces-method-callType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="initializer"
+                   type="jakartaee:faces-config-flow-definition-initializerType"
+                   minOccurs="0"/>
+      <xsd:element name="finalizer"
+                   type="jakartaee:faces-config-flow-definition-finalizerType"
+                   minOccurs="0"/>
+      <xsd:element name="inbound-parameter"
+                   type="jakartaee:faces-config-flow-definition-inbound-parameterType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"
+                   use="required">
+      <xsd:annotation>
+        <xsd:documentation>
+          <![CDATA[
+          <p class="changed_added_2_2">The id of this flow.  The id
+          must be unique within the Application configuration Resource
+          file in which this flow is defined.  The value of this attribute, 
+          combined with the value of the &lt;faces-config&gt;&lt;name&gt; element
+          must globally identify the flow within the application.<p> 
+          
+          ]]>
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-flow-definition-faces-method-callType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p class="changed_added_2_2">Invoke a method, passing parameters if necessary.
+        The return from the method is used as the outcome for where to go next in the
+        flow.  If the method is a void method, the default outcome is used.<p> 
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="method"
+                   type="jakartaee:faces-config-flow-definition-faces-method-call-methodType"/>
+      <xsd:element name="default-outcome"
+                   type="jakartaee:string"/>
+      <xsd:element name="parameter"
+                   type="jakartaee:faces-config-flow-definition-flow-call-parameterType"
+                   minOccurs="0"
+                   maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p class="changed_added_2_2">A parameter to pass when calling the method
+            identified in the "method" element that is a sibling of this element.<p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-flow-definition-faces-method-call-methodType">
+    <xsd:simpleContent>
+      <xsd:extension base="jakartaee:faces-config-el-expressionType">
+        <xsd:attribute name="id"
+                       type="xsd:ID"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-flow-definition-flow-call-parameterType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p class="changed_added_2_2">A parameter to pass when calling the method
+        identified in the "method" element that is a sibling of this element.<p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="class"
+                   type="jakartaee:string"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p class="changed_added_2_2"> The optional "class" element within a "parameter" element 
+            will be interpreted as the fully qualified class name for the type
+            of the "value" element.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="value"
+                   type="jakartaee:faces-config-flow-definition-parameter-valueType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p class="changed_added_2_2"> The "value" element within an "parameter"
+            must be a literal string or an EL Expression whose "get" will be called when the "method"
+            associated with this element is invoked.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-flow-definition-viewType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p class="changed_added_2_2">Define a view node in a flow graph.</p>
+        
+        <p>This element must contain exactly one
+        <code>&lt;vdl-document&gt;</code> element.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="vdl-document"
+                   type="jakartaee:pathType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p class="changed_added_2_2 changed_modified_2_3">
+            Define the path to the vdl-document for the enclosing view.
+            <p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"
+                   use="required">
+      <xsd:annotation>
+        <xsd:documentation>
+          <![CDATA[
+          <p class="changed_added_2_2">The id of this view.  It must be
+          unique within the flow.</p>
+          
+          ]]>
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-flow-definition-switchType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p class="changed_added_2_2">Define a switch node in a flow graph.</p>
+        
+        <div class="changed_added_2_2">
+        
+        <p>This element must contain one or more
+        <code>&lt;case&gt;</code> elements.  When control passes to the
+        <code>&lt;switch&gt;</code> node, each of the cases must be considered
+        in order and control must past to the <code>&lt;from-outcome&gt;</code>
+        of the first one whose <code>&lt;if&gt;</code> expression evaluates to 
+        <code>true</code>.</p>
+        
+        </div>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="case"
+                   type="jakartaee:faces-config-flow-definition-switch-caseType"
+                   minOccurs="0"
+                   maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p class="changed_added_2_2">Defines a case that must be
+            considered in the list of cases in the
+            <code>&lt;switch&gt;</code>.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="default-outcome"
+                   type="jakartaee:string"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p class="changed_added_2_2">Defines the default case that will
+            be taken if none of the other cases in the
+            <code>&lt;switch&gt;</code> are taken.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"
+                   use="required">
+      <xsd:annotation>
+        <xsd:documentation>
+          <![CDATA[
+          <p class="changed_added_2_2">The id of this switch.  It must be
+          unique within the flow.</p>
+          
+          ]]>
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-flow-definition-switch-caseType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p class="changed_added_2_2">Defines a case that will
+        be considered in the <code>&lt;switch&gt;</code>.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="jakartaee:descriptionGroup"/>
+      <xsd:element name="if"
+                   type="jakartaee:faces-config-ifType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p class="changed_added_2_2">If this EL expression evaluates to
+            <code>true</code>, the corresponding <code>from-outcome</code> will 
+            be the outcome taken by the enclosing <code>&lt;switch&gt;</code></p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="from-outcome"
+                   type="jakartaee:string"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p>The "from-outcome" element contains a logical outcome
+            string returned by the execution of an application
+            action method selected via an "actionRef" property
+            (or a literal value specified by an "action" property)
+            of a UICommand component.  If specified, this rule
+            will be relevant only if the outcome value matches
+            this element's value.  If not specified, this rule
+            will be relevant if the outcome value is non-null
+            or, if the "if" element is present, will be relevant
+            for any outcome value, with the assumption that the
+            condition specified in the "if" element ultimately
+            determines if this rule is a match.</p>
+            
+            <p class="changed_added_2_2">If used in a faces flow, this element
+            represents the node id to which control will be passed.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID">
+    </xsd:attribute>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-flow-definition-flow-returnType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p class="changed_added_2_2">Define a return node in a flow graph.</p>
+        
+        <div class="changed_added_2_2">
+        
+        <p>This element must contain exactly one <code>&lt;from-outcome&gt;</code> element.</p>
+        </div>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="from-outcome"
+                   type="jakartaee:string">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p class="changed_added_2_2">This element
+            represents the node id to which control will be passed.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"
+                   use="required">
+      <xsd:annotation>
+        <xsd:documentation>
+          <![CDATA[
+          <p class="changed_added_2_2">The id of this flow-return.</p>
+          
+          ]]>
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-flow-definition-flow-callType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p class="changed_added_2_2">Define a call node in a flow graph.</p>
+        
+        <div class="changed_added_2_2">
+        
+        <p>This element must contain exactly one <code>&lt;flow-reference&gt;</code> element, 
+        which must contain exactly one <code>&lt;flow-id&gt;</code> element.</p>
+        </div>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="flow-reference"
+                   type="jakartaee:faces-config-flow-definition-flow-call-flow-referenceType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p class="changed_added_2_2">The flow id of the called flow.<p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="outbound-parameter"
+                   type="jakartaee:faces-config-flow-definition-flow-call-outbound-parameterType"
+                   minOccurs="0"
+                   maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p class="changed_added_2_2">A parameter to pass when calling the flow
+            identified in the "flow-reference" element that is a sibling of this element.<p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"
+                   use="required">
+      <xsd:annotation>
+        <xsd:documentation>
+          <![CDATA[
+          <p class="changed_added_2_2">The id of this flow-return.</p>
+          
+          ]]>
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-flow-definition-flow-call-flow-referenceType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p class="changed_added_2_2">Identifiy the called flow.</p>
+        
+        <div class="changed_added_2_2">
+        
+        </div>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="flow-document-id"
+                   type="jakartaee:java-identifierType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p>The document id of the called flow.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="flow-id"
+                   type="jakartaee:java-identifierType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p>The id of the called flow.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-flow-definition-initializerType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p class="changed_added_2_2">A <code>MethodExpression</code> that will be invoked when the flow is entered.<p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:extension base="jakartaee:faces-config-el-expressionType">
+        <xsd:attribute name="id"
+                       type="xsd:ID"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-flow-definition-finalizerType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p class="changed_added_2_2">A <code>MethodExpression</code> that will be invoked when the flow is exited.<p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:extension base="jakartaee:faces-config-el-expressionType">
+        <xsd:attribute name="id"
+                       type="xsd:ID"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-flow-definition-inbound-parameterType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p class="changed_added_2_2">A named parameter whose value will be populated
+        with a correspondingly named parameter within an "outbound-parameter" element.<p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="name"
+                   type="jakartaee:java-identifierType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p class="changed_added_2_2"> The "name" element within an "inbound-parameter"
+            element declares the name of this parameter
+            to be passed into a flow.  There must be 
+            a sibling "value" element in the same parent as this element.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="value"
+                   type="jakartaee:faces-config-flow-definition-parameter-valueType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p class="changed_added_2_2"> The "value" element within an "inbound-parameter"
+            must be an EL Expression whose value will be set with the correspondingly
+            named "outbound-parameter" when this flow is entered, if such a 
+            parameter exists.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-flow-definition-flow-call-outbound-parameterType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p class="changed_added_2_2">A named parameter whose value will be 
+        passed to a correspondingly named parameter within an "inbound-parameter" element
+        on the target flow.<p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="name"
+                   type="jakartaee:java-identifierType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p class="changed_added_2_2"> The "name" element within an "outbound-parameter" element 
+            declares the name of this parameter to be passed out of a flow.  There must be 
+            a sibling "value" element in the same parent as this element.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="value"
+                   type="jakartaee:faces-config-flow-definition-parameter-valueType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p class="changed_added_2_2"> The "value" element within an "outbound-parameter"
+            must be a literal string or an EL Expression whose "get" will be called when the "flow-call"
+            containing this element is traversed to go to a new flow.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+  </xsd:complexType>
+
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-navigation-caseType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> <span class="changed_modified_2_2">The</span>
+        "navigation-case" element describes a particular
+        combination of conditions that must match for this case to
+        be executed, and the view id of the component tree that
+        should be selected next.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="jakartaee:descriptionGroup"/>
+      <xsd:element name="from-action"
+                   type="jakartaee:faces-config-from-actionType"
+                   minOccurs="0"/>
+      <xsd:element name="from-outcome"
+                   type="jakartaee:string"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p>The "from-outcome" element contains a logical outcome
+            string returned by the execution of an application
+            action method selected via an "actionRef" property
+            (or a literal value specified by an "action" property)
+            of a UICommand component.  If specified, this rule
+            will be relevant only if the outcome value matches
+            this element's value.  If not specified, this rule
+            will be relevant if the outcome value is non-null
+            or, if the "if" element is present, will be relevant
+            for any outcome value, with the assumption that the
+            condition specified in the "if" element ultimately
+            determines if this rule is a match.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="if"
+                   type="jakartaee:faces-config-ifType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> Please see section 7.4.2 "Default NavigationHandler Algorithm" of the Jakarta Faces Specification Document
+            for the specification of this element.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="to-view-id"
+                   type="jakartaee:faces-config-valueType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p><span class="changed_modified_2_2">The "to-view-id" element 
+            contains the view identifier (<span class="changed_added_2_2">or 
+            flow node id, or flow id</span>)
+            of the next view (<span class="changed_added_2_2">or flow node or 
+            flow</span>) that should be displayed if this
+            navigation rule is matched. If the contents is a
+            value expression, it should be resolved by the
+            navigation handler to obtain the view (
+            <span class="changed_added_2_2">or flow node or flow</span>) 
+            identifier.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="to-flow-document-id"
+                   type="jakartaee:java-identifierType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p class="changed_added_2_2">The document id of the called flow.
+            If this element appears in a &lt;navigation-case&gt; nested within 
+            a &lt;flow-definition&gt;, it must be ignored because navigation
+            cases within flows may only navigate among the view nodes of that 
+            flow.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="redirect"
+                   type="jakartaee:faces-config-redirectType"
+                   minOccurs="0"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-navigation-ruleType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> The "navigation-rule" element represents an individual
+        decision rule that will be utilized by the default
+        NavigationHandler implementation to make decisions on
+        what view should be displayed next, based on the
+        view id being processed.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="jakartaee:descriptionGroup"/>
+      <xsd:element name="from-view-id"
+                   type="jakartaee:faces-config-from-view-idType"/>
+      <xsd:element name="navigation-case"
+                   type="jakartaee:faces-config-navigation-caseType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="navigation-rule-extension"
+                   type="jakartaee:faces-config-navigation-rule-extensionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-navigation-rule-extensionType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> Extension element for navigation-rule.  It may contain
+        implementation specific content.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:any minOccurs="0"
+               maxOccurs="unbounded"
+               namespace="##any"
+               processContents="lax"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-null-valueType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> The "null-value" element indicates that the managed
+        property in which we are nested will be explicitly
+        set to null if our managed bean is automatically
+        created.  This is different from omitting the managed
+        property element entirely, which will cause no
+        property setter to be called for this property.</p>
+        
+        <p>The "null-value" element can only be used when the
+        associated "property-class" identifies a Java class,
+        not a Java primitive.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-propertyType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> The "property" element represents a JavaBean property of the
+        Java class represented by our parent element.</p>
+        
+        <p>Property names must be unique within the scope of the Java
+        class that is represented by the parent element, and must
+        correspond to property names that will be recognized when
+        performing introspection against that class via
+        java.beans.Introspector.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="jakartaee:descriptionGroup"/>
+      <xsd:element name="property-name"
+                   type="jakartaee:string">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The "property-name" element represents the JavaBeans
+            property name under which the corresponding value
+            may be stored.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="property-class"
+                   type="jakartaee:java-typeType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The "property-class" element represents the Java type
+            of the value associated with this property name.
+            If not specified, it can be inferred from existing
+            classes; however, this element should be specified if
+            the configuration file is going to be the source for
+            generating the corresponding classes.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="default-value"
+                   type="jakartaee:faces-config-default-valueType"
+                   minOccurs="0"/>
+      <xsd:element name="suggested-value"
+                   type="jakartaee:faces-config-suggested-valueType"
+                   minOccurs="0"/>
+      <xsd:element name="property-extension"
+                   type="jakartaee:faces-config-property-extensionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-protected-viewsType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p class="changed_added_2_2">Any view that matches any of the
+        url-patterns in this element may only be reached from another Jakarta Faces 
+        view in the same web application. Because the runtime is aware of
+        which views are protected, any navigation from an unprotected
+        view to a protected view is automatically subject to
+        protection.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="url-pattern"
+                   type="jakartaee:url-patternType"
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-property-extensionType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> Extension element for property.  It may contain
+        implementation specific content.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:any minOccurs="0"
+               maxOccurs="unbounded"
+               namespace="##any"
+               processContents="lax"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-redirectType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> The "redirect" element indicates that navigation to the
+        specified "to-view-id" should be accomplished by
+        performing an HTTP redirect rather than the usual
+        ViewHandler mechanisms.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="redirect-param"
+                   type="jakartaee:faces-config-redirect-redirectParamType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+    <xsd:attribute name="include-view-params"
+                   type="xsd:boolean"
+                   use="optional"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-redirect-viewParamType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> This element was introduced due to a specification
+        error, and is now deprecated.  The correct name for
+        this element is "redirect-param" and its meaning is
+        documented therein.  The "view-param" element is
+        maintained to preserve backwards compatibility.
+        Implementations must treat this element the same as
+        "redirect-param".</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="name"
+                   type="jakartaee:string"/>
+      <xsd:element name="value"
+                   type="jakartaee:string"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-redirect-redirectParamType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> The "redirect-param" element, only valid within
+        a "redirect" element, contains child "name"
+        and "value" elements that must be included in the
+        redirect url when the redirect is performed.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="name"
+                   type="jakartaee:string"/>
+      <xsd:element name="value"
+                   type="jakartaee:string"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-referenced-beanType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> The "referenced-bean" element represents at design time the
+        promise that a Java object of the specified type will exist at
+        runtime in some scope, under the specified key.  This can be
+        used by design time tools to construct user interface dialogs
+        based on the properties of the specified class.  The presence
+        or absence of a referenced bean element has no impact on the
+        Jakarta Faces runtime environment inside a web application.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="jakartaee:descriptionGroup"/>
+      <xsd:element name="referenced-bean-name"
+                   type="jakartaee:java-identifierType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The "referenced-bean-name" element represents the
+            attribute name under which the corresponding
+            referenced bean may be assumed to be stored, in one
+            of 'request', 'session', 'view', 'application'
+            or a custom scope.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="referenced-bean-class"
+                   type="jakartaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The "referenced-bean-class" element represents the
+            fully qualified class name of the Java class
+            (either abstract or concrete) or Java interface
+            implemented by the corresponding referenced bean.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-render-kitType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> The "render-kit" element represents a concrete RenderKit
+        implementation that should be registered under the specified
+        render-kit-id.  If no render-kit-id is specified, the
+        identifier of the default RenderKit
+        (RenderKitFactory.DEFAULT_RENDER_KIT) is assumed.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="jakartaee:descriptionGroup"/>
+      <xsd:element name="render-kit-id"
+                   type="jakartaee:string"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The "render-kit-id" element represents an identifier
+            for the RenderKit represented by the parent
+            "render-kit" element.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="render-kit-class"
+                   type="jakartaee:fully-qualified-classType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The "render-kit-class" element represents the fully
+            qualified class name of a concrete RenderKit
+            implementation class.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="renderer"
+                   type="jakartaee:faces-config-rendererType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="client-behavior-renderer"
+                   type="jakartaee:faces-config-client-behavior-rendererType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="render-kit-extension"
+                   type="jakartaee:faces-config-render-kit-extensionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-client-behavior-rendererType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> The "client-behavior-renderer" element represents a concrete
+        ClientBehaviorRenderer implementation class that should be
+        registered under the specified behavior renderer type identifier,
+        in the RenderKit associated with the parent "render-kit"
+        element.  Client Behavior renderer type must be unique within the RenderKit
+        associated with the parent "render-kit" element.</p>
+        
+        <p>Nested "attribute" elements identify generic component
+        attributes that are recognized by this renderer.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="client-behavior-renderer-type"
+                   type="jakartaee:string">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The "client-behavior-renderer-type" element represents a renderer type
+            identifier for the Client Behavior Renderer represented by the parent
+            "client-behavior-renderer" element.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="client-behavior-renderer-class"
+                   type="jakartaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The "client-behavior-renderer-class" element represents the fully
+            qualified class name of a concrete Client Behavior Renderer
+            implementation class.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-rendererType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> The "renderer" element represents a concrete Renderer
+        implementation class that should be registered under the
+        specified component family and renderer type identifiers,
+        in the RenderKit associated with the parent "render-kit"
+        element.  Combinations of component family and
+        renderer type must be unique within the RenderKit
+        associated with the parent "render-kit" element.</p>
+        
+        <p>Nested "attribute" elements identify generic component
+        attributes that are recognized by this renderer.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="jakartaee:descriptionGroup"/>
+      <xsd:element name="component-family"
+                   type="jakartaee:string">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The "component-family" element represents the
+            component family for which the Renderer represented
+            by the parent "renderer" element will be used.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="renderer-type"
+                   type="jakartaee:string">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The "renderer-type" element represents a renderer type
+            identifier for the Renderer represented by the parent
+            "renderer" element.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="renderer-class"
+                   type="jakartaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The "renderer-class" element represents the fully
+            qualified class name of a concrete Renderer
+            implementation class.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="facet"
+                   type="jakartaee:faces-config-facetType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="attribute"
+                   type="jakartaee:faces-config-attributeType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="renderer-extension"
+                   type="jakartaee:faces-config-renderer-extensionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-renderer-extensionType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> Extension element for renderer.  It may contain implementation
+        specific content.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:any minOccurs="0"
+               maxOccurs="unbounded"
+               namespace="##any"
+               processContents="lax"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-render-kit-extensionType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> Extension element for render-kit.  It may contain
+        implementation specific content.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:any minOccurs="0"
+               maxOccurs="unbounded"
+               namespace="##any"
+               processContents="lax"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-suggested-valueType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> The "suggested-value" contains the value for the property or
+        attribute in which this element resides.  This value is
+        advisory only and is intended for tools to use when
+        populating pallettes.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="jakartaee:string"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-supported-localeType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> The "supported-locale" element allows authors to declare
+        which locales are supported in this application instance.</p>
+        
+        <p class="modified_added_2_3">
+        To facilitate BCP 47 this element first needs to be parsed by the
+        Locale.forLanguageTag method. If it does not return a Locale with
+        a language the old specification below needs to take effect.
+        </p>
+        
+        <p>It must be specified as :language:[_:country:[_:variant:]]
+        without the colons, for example "ja_JP_SJIS".  The
+        separators between the segments may be '-' or '_'.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:extension base="jakartaee:faces-config-localeType">
+        <xsd:attribute name="id"
+                       type="xsd:ID"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-behaviorType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> The "behavior" element represents a concrete Behavior
+        implementation class that should be registered under the
+        specified behavior identifier.  Behavior identifiers must
+        be unique within the entire web application.</p>
+        
+        <p>Nested "attribute" elements identify generic attributes that
+        may be configured on the corresponding UIComponent in order
+        to affect the operation of the Behavior.  Nested "property"
+        elements identify JavaBeans properties of the Behavior
+        implementation class that may be configured to affect the
+        operation of the Behavior.  "attribute" and "property"
+        elements are intended to allow component developers to
+        more completely describe their components to tools and users.
+        These elements have no required runtime semantics.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="jakartaee:descriptionGroup"/>
+      <xsd:element name="behavior-id"
+                   type="jakartaee:string">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The "behavior-id" element represents the identifier
+            under which the corresponding Behavior class should
+            be registered.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="behavior-class"
+                   type="jakartaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The "behavior-class" element represents the fully
+            qualified class name of a concrete Behavior
+            implementation class.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="attribute"
+                   type="jakartaee:faces-config-attributeType"
+                   minOccurs="0"
+                   maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> Nested "attribute" elements identify generic
+            attributes that may be configured on the
+            corresponding UIComponent in order to affect the
+            operation of the Behavior.  This attribute is
+            primarily for design-time tools and is not
+            specified to have any meaning at runtime.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="property"
+                   type="jakartaee:faces-config-propertyType"
+                   minOccurs="0"
+                   maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> Nested "property" elements identify JavaBeans
+            properties of the Behavior implementation class
+            that may be configured to affect the operation of
+            the Behavior.  This attribute is primarily for
+            design-time tools and is not specified to have
+            any meaning at runtime.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="behavior-extension"
+                   type="jakartaee:faces-config-behavior-extensionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-behavior-extensionType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> Extension element for behavior.  It may contain
+        implementation specific content.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:any minOccurs="0"
+               maxOccurs="unbounded"
+               namespace="##any"
+               processContents="lax"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-validatorType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> The "validator" element represents a concrete Validator
+        implementation class that should be registered under the
+        specified validator identifier.  Validator identifiers must
+        be unique within the entire web application.</p>
+        
+        <p>Nested "attribute" elements identify generic attributes that
+        may be configured on the corresponding UIComponent in order
+        to affect the operation of the Validator.  Nested "property"
+        elements identify JavaBeans properties of the Validator
+        implementation class that may be configured to affect the
+        operation of the Validator.  "attribute" and "property"
+        elements are intended to allow component developers to
+        more completely describe their components to tools and users.
+        These elements have no required runtime semantics.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="jakartaee:descriptionGroup"/>
+      <xsd:element name="validator-id"
+                   type="jakartaee:string">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The "validator-id" element represents the identifier
+            under which the corresponding Validator class should
+            be registered.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="validator-class"
+                   type="jakartaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The "validator-class" element represents the fully
+            qualified class name of a concrete Validator
+            implementation class.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="attribute"
+                   type="jakartaee:faces-config-attributeType"
+                   minOccurs="0"
+                   maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> Nested "attribute" elements identify generic
+            attributes that may be configured on the
+            corresponding UIComponent in order to affect the
+            operation of the Validator.  This attribute is
+            primarily for design-time tools and is not
+            specified to have any meaning at runtime.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="property"
+                   type="jakartaee:faces-config-propertyType"
+                   minOccurs="0"
+                   maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> Nested "property" elements identify JavaBeans
+            properties of the Validator implementation class
+            that may be configured to affect the operation of
+            the Validator.  This attribute is primarily for
+            design-time tools and is not specified to have
+            any meaning at runtime.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="validator-extension"
+                   type="jakartaee:faces-config-validator-extensionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-validator-extensionType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> Extension element for validator.  It may contain
+        implementation specific content.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:any minOccurs="0"
+               maxOccurs="unbounded"
+               namespace="##any"
+               processContents="lax"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+  <xsd:simpleType name="faces-config-valueType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> The "value" element is the String representation of
+        a literal value to which a scalar managed property
+        will be set, or a value binding expression ("#{...}")
+        that will be used to calculate the required value.
+        It will be converted as specified for the actual
+        property type.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:union memberTypes="jakartaee:faces-config-el-expressionType xsd:string"/>
+  </xsd:simpleType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-system-event-listenerType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> The presence of this element within the "application" element in
+        an application configuration resource file indicates the
+        developer wants to add an SystemEventListener to this
+        application instance.  Elements nested within this element allow
+        selecting the kinds of events that will be delivered to the
+        listener instance, and allow selecting the kinds of classes that
+        can be the source of events that are delivered to the listener
+        instance.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="system-event-listener-class"
+                   type="jakartaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The "system-event-listener-class" element contains
+            the fully qualified class name of the concrete
+            SystemEventListener implementation class that will be
+            called when events of the type specified by the
+            "system-event-class" are sent by the runtime.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="system-event-class"
+                   type="jakartaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The "system-event-class" element contains the fully
+            qualified class name of the SystemEvent subclass for
+            which events will be delivered to the class whose fully
+            qualified class name is given by the
+            "system-event-listener-class" element.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="source-class"
+                   type="jakartaee:fully-qualified-classType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The "source-class" element, if present, contains the
+            fully qualified class name of the class that will be the
+            source for the event to be delivered to the class whose
+            fully qualified class name is given by the
+            "system-event-listener-class" element.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+  <xsd:simpleType name="faces-config-versionType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> This type contains the recognized versions of
+        faces-config supported.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="4.1"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+</xsd:schema>


### PR DESCRIPTION
Pulled from https://jakarta.ee/xml/ns/jakartaee/

1)  web services client xsd was pulled in to fix this error: 
```
jakarta.faces.FacesException: org.xml.sax.SAXParseException; systemId: file:... jakartaee_11.xsd; lineNumber: 106; columnNumber: 52; src-resolve: Cannot resolve the name ‘jakartaee:service-refGroup’ to a(n) ‘group’ component.
```

2) standard config xml was updated to 2.3 because `<client-window-factory>org.apache.myfaces.lifecycle.clientwindow.ClientWindowFactoryImpl</client-window-factory>` is used. It was added in 2.3. OTherwise validation failures for 2.0 to 2.2. 

3) Added support for XML validation for 2.2-4.1

4) DTD for 1.0 still works. Verifed via 
```
<?xml version="1.0"?>
<!DOCTYPE facelet-taglib PUBLIC
"-//Sun Microsystems, Inc.//DTD Facelet Taglib 1.0//EN"
"https://java.sun.com/dtd/facelet-taglib_1_0.dtd">
<facelet-taglib>
...
```

5) This change will be ported to earlier versions, but later on. I'll keep the JIRA open for now.