### PR TITLE
Remove default value from EXCEPTION_TYPES_TO_IGNORE_IN_LOGGING

### DIFF
--- a/impl/src/main/java/org/apache/myfaces/config/webparameters/MyfacesConfig.java
+++ b/impl/src/main/java/org/apache/myfaces/config/webparameters/MyfacesConfig.java
@@ -792,7 +792,7 @@ public class MyfacesConfig
     public static final String EL_RESOLVER_TRACING = "org.apache.myfaces.EL_RESOLVER_TRACING";
     public static final boolean EL_RESOLVER_TRACING_DEFAULT = false;
 
-    @JSFWebConfigParam(name="org.apache.myfaces.EXCEPTION_TYPES_TO_IGNORE_IN_LOGGING", since="4.0.3, 4.1.1, 5.0", defaultValue = "")
+    @JSFWebConfigParam(name="org.apache.myfaces.EXCEPTION_TYPES_TO_IGNORE_IN_LOGGING", since="4.0.3, 4.1.1, 5.0")
     public static final String EXCEPTION_TYPES_TO_IGNORE_IN_LOGGING =
             "org.apache.myfaces.EXCEPTION_TYPES_TO_IGNORE_IN_LOGGING";
 


### PR DESCRIPTION
If the _""_ default value is used, it produces the following code in 

`            logMessageToAppropriateLevel("No context init parameter 'org.apache.myfaces.EXCEPTION_TYPES_TO_IGNORE_IN_LOGGING' found, using default value '""'.");` 

This leads to a compilation error via ` value '""'."`.  I'll just exclude the default value to get this working again. 