### PR TITLE
Lower tomcat-jasper-el dependency to 10.1.34 to avoid class file version mismatch

### DIFF
--- a/extensions/quarkus/runtime/pom.xml
+++ b/extensions/quarkus/runtime/pom.xml
@@ -51,7 +51,7 @@
         <dependency>
             <groupId>org.apache.tomcat</groupId>
             <artifactId>tomcat-jasper-el</artifactId>
-            <version>11.0.0</version>
+            <version>10.1.34</version>
             <exclusions>
                 <!-- Exclude it, we use quarkus EL as API -->
                 <exclusion>


### PR DESCRIPTION
4.0 uses Java 11, but Tomcat Jasper EL 11 is compiled with Java 17. So we need to downgrade 


[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.6.1:compile (default-compile) on project myfaces-quarkus-deployment: Compilation failure
[ERROR] ~/myfaces/extensions/quarkus/deployment/src/main/java/org/apache/myfaces/core/extensions/quarkus/deployment/MyFacesProcessor.java:[73,21] cannot access org.apache.el.ExpressionFactoryImpl
[ERROR]   bad class file ~/.m2/repository/org/apache/tomcat/tomcat-jasper-el/11.0.0/tomcat-jasper-el-11.0.0.jar(/org/apache/el/ExpressionFactoryImpl.class)
[ERROR]     class file has wrong version 61.0, should be 55.0
[ERROR]     Please remove or make sure it appears in the correct subdirectory of the classpath.