### PR TITLE
MYFACES-4709: Add FacesConfig to HandlesTypes

### DIFF
--- a/impl/src/main/java/org/apache/myfaces/webapp/MyFacesContainerInitializer.java
+++ b/impl/src/main/java/org/apache/myfaces/webapp/MyFacesContainerInitializer.java
@@ -27,6 +27,7 @@ import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import jakarta.faces.annotation.FacesConfig; 
 import jakarta.faces.application.ResourceDependencies;
 import jakarta.faces.application.ResourceDependency;
 import jakarta.faces.component.FacesComponent;
@@ -72,6 +73,7 @@ import org.apache.myfaces.spi.FacesConfigResourceProviderFactory;
         FacesBehavior.class,
         FacesBehaviorRenderer.class,
         FacesComponent.class,
+        FacesConfig.class,
         FacesConverter.class,
         FacesRenderer.class,
         FacesValidator.class,


### PR DESCRIPTION
As described in the comment: 

```
 * ... the listener checks if 
 * the FacesServlet has already been defined in web.xml and if not, it adds
 * the FacesServlet with the mappings (/faces/*, *.jsf, *.faces) dynamically.
```


In summary, if this annotation is found and the web.xml doesn't have any mappings listed for the faces servlet, they will be added automatically. 

I'm assuming this was mise when this annotation was added 2.3 