### PR TITLE
https://issues.apache.org/jira/browse/MYFACES-4710: Fix for swallowed parameters in commandscript

### DIFF
--- a/api/src/client/typescript/faces/@types/definitions/index.d.ts
+++ b/api/src/client/typescript/faces/@types/definitions/index.d.ts
@@ -125,7 +125,7 @@ declare global {
     }
 
     interface MyFacesAPI {
-        ab(source: Element, event: Event, eventName: string, execute: string, render: string, options: Context): void;
+        ab(source: Element, event: Event, eventName: string, execute: string, render: string, options?: Context, userParams?: Context): void;
 
         config: { [key: string]: any };
         oam: OAM;

--- a/api/src/client/typescript/faces/api/_api.ts
+++ b/api/src/client/typescript/faces/api/_api.ts
@@ -206,14 +206,14 @@ export module faces {
          * @param autoConnect Whether or not to automatically open the socket. Defaults to <code>false</code>.
          */
         export function init(socketClientId: string,
-                    url: string,
-                    channel: string,
-                    onopen: Function,
-                    onmessage: Function,
-                    onerror: Function,
-                    onclose: Function,
-                    behaviors: any,
-                    autoConnect: boolean): void {
+                             url: string,
+                             channel: string,
+                             onopen: Function,
+                             onmessage: Function,
+                             onerror: Function,
+                             onclose: Function,
+                             behaviors: any,
+                             autoConnect: boolean): void {
             PushImpl.init(socketClientId, url, channel, onopen, onmessage, onerror, onclose, behaviors, autoConnect);
         }
 
@@ -246,21 +246,37 @@ export module myfaces {
      *
      * @param source the event source
      * @param event the event
-     * @param eventName event name for java.jakarta.faces.behavior.evemnt
+     * @param eventName event name for java.jakarta.faces.behavior.event
      * @param execute execute list as passed down in faces.ajax.request
      * @param render the render list as string
-     * @param options the options which need to be mered in
+     * @param options the options which need to be merged in
+     * @param userParameters a set of user parameters which go into the final options under params, they can overide whatever is passed via options
      */
-    export function ab(source: Element, event: Event, eventName: string, execute: string, render: string, options: Options = {}): void {
+    export function ab(source: Element, event: Event, eventName: string, execute: string, render: string, options: Options = {}, userParameters: Options = {}): void {
+        if(!options) {
+            options = {};
+        }
+        if(!userParameters) {
+            userParameters = {};
+        }
         if (eventName) {
-           options[CTX_OPTIONS_PARAMS] = options?.[CTX_OPTIONS_PARAMS] ?? {};
-           options[CTX_OPTIONS_PARAMS][$nsp(P_BEHAVIOR_EVENT)] = eventName;
+            options[CTX_OPTIONS_PARAMS] = options?.[CTX_OPTIONS_PARAMS] ?? {};
+            options[CTX_OPTIONS_PARAMS][$nsp(P_BEHAVIOR_EVENT)] = eventName;
         }
         if (execute) {
             options[CTX_OPTIONS_EXECUTE] = execute;
         }
         if (render) {
             options[CTX_PARAM_RENDER] = render;
+        }
+
+        //we push the users parameters in
+        if (!options["params"]) {
+            options["params"] = {};
+        }
+
+        for (let key in userParameters) {
+            options["params"][key] = userParameters[key];
         }
 
         (window?.faces ?? window.jsf).ajax.request(source, event, options);

--- a/api/src/client/typescript/faces/test/api/MyFacesABTest.spec.ts
+++ b/api/src/client/typescript/faces/test/api/MyFacesABTest.spec.ts
@@ -1,0 +1,117 @@
+import {describe} from "mocha";
+import {StandardInits} from "../frameworkBase/_ext/shared/StandardInits";
+import defaultMyFaces = StandardInits.defaultMyFaces;
+import {expect} from "chai";
+
+describe('API tests', () => {
+
+    beforeEach(() => {
+        return defaultMyFaces();
+    });
+
+    it("must pass into ajax.request properly with user parameters", () => {
+        let passedSource = null;
+        let passedEvent = null;
+        let passedOptions = null;
+        let oldRequest = (window?.faces ?? window.jsf).ajax.request;
+        try {
+            (window?.faces ?? window.jsf).ajax.request = function(source, event, options) {
+                passedSource = source;
+                passedEvent = event;
+                passedOptions = options;
+            }
+            myfaces.ab(null, null, null, null, null, {}, {booga: "foobaz"});
+
+            expect(passedSource).to.eq(null);
+            expect(passedEvent).to.eq(null);
+            expect(passedOptions).to.deep.eq({params:{booga: "foobaz"}});
+        } finally {
+            (window?.faces ?? window.jsf).ajax.request = oldRequest;
+        }
+    })
+
+    it("must pass into ajax.request properly without user parameters", () => {
+        let passedSource = null;
+        let passedEvent = null;
+        let passedOptions = null;
+        let oldRequest = (window?.faces ?? window.jsf).ajax.request;
+        try {
+            (window?.faces ?? window.jsf).ajax.request = function(source, event, options) {
+                passedSource = source;
+                passedEvent = event;
+                passedOptions = options;
+            }
+            myfaces.ab(null, null, null, null, null, {});
+
+            expect(passedSource).to.eq(null);
+            expect(passedEvent).to.eq(null);
+            expect(passedOptions).to.deep.eq({params:{}});
+        } finally {
+            (window?.faces ?? window.jsf).ajax.request = oldRequest;
+        }
+    });
+
+    it("must pass into ajax.request properly with null options", () => {
+        let passedSource = null;
+        let passedEvent = null;
+        let passedOptions = null;
+        let oldRequest = (window?.faces ?? window.jsf).ajax.request;
+        try {
+            (window?.faces ?? window.jsf).ajax.request = function(source, event, options) {
+                passedSource = source;
+                passedEvent = event;
+                passedOptions = options;
+            }
+            myfaces.ab(null, null, null, null, null, null);
+
+            expect(passedSource).to.eq(null);
+            expect(passedEvent).to.eq(null);
+            expect(passedOptions).to.deep.eq({params:{}});
+        } finally {
+            (window?.faces ?? window.jsf).ajax.request = oldRequest;
+        }
+    });
+
+    it("must pass into ajax.request properly with null options and null user options", () => {
+        let passedSource = null;
+        let passedEvent = null;
+        let passedOptions = null;
+        let oldRequest = (window?.faces ?? window.jsf).ajax.request;
+        try {
+            (window?.faces ?? window.jsf).ajax.request = function(source, event, options) {
+                passedSource = source;
+                passedEvent = event;
+                passedOptions = options;
+            }
+            myfaces.ab(null, null, null, null, null, null, null);
+
+            expect(passedSource).to.eq(null);
+            expect(passedEvent).to.eq(null);
+            expect(passedOptions).to.deep.eq({params:{}});
+        } finally {
+            (window?.faces ?? window.jsf).ajax.request = oldRequest;
+        }
+    });
+
+    it("must pass into ajax.request properly without options and user params", () => {
+        let passedSource = null;
+        let passedEvent = null;
+        let passedOptions = null;
+        let oldRequest = (window?.faces ?? window.jsf).ajax.request;
+        try {
+            (window?.faces ?? window.jsf).ajax.request = function(source, event, options) {
+                passedSource = source;
+                passedEvent = event;
+                passedOptions = options;
+            }
+            myfaces.ab(null, null, null, null, null);
+
+            expect(passedSource).to.eq(null);
+            expect(passedEvent).to.eq(null);
+            expect(passedOptions).to.deep.eq({params:{}});
+        } finally {
+            (window?.faces ?? window.jsf).ajax.request = oldRequest;
+        }
+    });
+
+});

--- a/impl/src/main/java/org/apache/myfaces/renderkit/html/HtmlAjaxBehaviorRenderer.java
+++ b/impl/src/main/java/org/apache/myfaces/renderkit/html/HtmlAjaxBehaviorRenderer.java
@@ -79,7 +79,8 @@ public class HtmlAjaxBehaviorRenderer extends ClientBehaviorRenderer
                 ajaxBehavior.isResetValues(),
                 ajaxBehavior.getOnerror(),
                 ajaxBehavior.getOnevent(),
-                behaviorContext.getParameters());
+                behaviorContext.getParameters(),
+                null);
   
         return retVal.toString();
     }

--- a/impl/src/main/java/org/apache/myfaces/renderkit/html/HtmlCommandScriptRenderer.java
+++ b/impl/src/main/java/org/apache/myfaces/renderkit/html/HtmlCommandScriptRenderer.java
@@ -98,7 +98,8 @@ public class HtmlCommandScriptRenderer extends HtmlRenderer
                 commandScript.getResetValues(),
                 commandScript.getOnerror(),
                 commandScript.getOnevent(),
-                uiParams);
+                uiParams,
+                "o");
 
         script.append(ajax.toString());
         script.decreaseIndent();

--- a/impl/src/main/java/org/apache/myfaces/renderkit/html/util/AjaxScriptBuilder.java
+++ b/impl/src/main/java/org/apache/myfaces/renderkit/html/util/AjaxScriptBuilder.java
@@ -61,7 +61,8 @@ public class AjaxScriptBuilder
                              Boolean resetValues,
                              String onerror,
                              String onevent,
-                             List<UIParameter> uiParams)
+                             List<UIParameter> uiParams,
+                             String userParameters)
     {
         build(context,
                 sb,
@@ -75,7 +76,8 @@ public class AjaxScriptBuilder
                 onerror,
                 onevent,
                 null,
-                uiParams);
+                uiParams,
+                userParameters);
     }
 
     public static void build(FacesContext context,
@@ -89,7 +91,8 @@ public class AjaxScriptBuilder
                              boolean resetValues,
                              String onerror,
                              String onevent,
-                             Collection<ClientBehaviorContext.Parameter> params)
+                             Collection<ClientBehaviorContext.Parameter> params,
+                             String userParameters)
     {
         String execute = null;
         if (executeList != null && !executeList.isEmpty())
@@ -115,7 +118,8 @@ public class AjaxScriptBuilder
                 onerror,
                 onevent,
                 params,
-                null);
+                null,
+                userParameters);
     }
 
     public static void build(FacesContext context,
@@ -130,7 +134,8 @@ public class AjaxScriptBuilder
                              String onerror,
                              String onevent,
                              Collection<ClientBehaviorContext.Parameter> params,
-                             List<UIParameter> uiParams)
+                             List<UIParameter> uiParams,
+                             String userParameters)
     {
         // CHECKSTYLE:ON
         HtmlCommandScript commandScript = (component instanceof HtmlCommandScript hcs)
@@ -252,6 +257,15 @@ public class AjaxScriptBuilder
             }
 
             sb.append('}');
+        }
+        else
+        {
+            sb.append(",{}");
+        }
+        if(userParameters != null && !userParameters.isEmpty())
+        {
+            sb.append(',');
+            sb.append(userParameters);
         }
 
         sb.append(')');

--- a/impl/src/test/java/org/apache/myfaces/renderkit/html/util/AjaxScriptBuilderTest.java
+++ b/impl/src/test/java/org/apache/myfaces/renderkit/html/util/AjaxScriptBuilderTest.java
@@ -81,7 +81,8 @@ public class AjaxScriptBuilderTest extends AbstractFacesTestCase
                 false,
                 null,
                 "testJs",
-                params);
+                params,
+                null);
 
         String script = sb.toString();
 


### PR DESCRIPTION
This fixes the issue described in https://issues.apache.org/jira/browse/MYFACES-4710!
Please review the changes. I had to add an extenions in the AjaxScriptRenderer, and need additional eyes to review the changes.
The idea is that I have extended the myfaces.ab function with user parameters which allow additional parameters to be added which then later are properly merged in. This however required some code changes on the java side, because the original issue was that the "o" parameter was never passed in in the generated javascript!
Note for "speed" reasons I just dragged the typescript changes in, I will roll a proper script release once this bug is fixed because I need to add some typo fixes done on the myfaces side, back into the upstream project!
