### PR TITLE
[4.1.x] Avoid NPE in logException's while loop

### DIFF
--- a/impl/src/main/java/org/apache/myfaces/context/ExceptionHandlerUtils.java
+++ b/impl/src/main/java/org/apache/myfaces/context/ExceptionHandlerUtils.java
@@ -74,17 +74,20 @@ public class ExceptionHandlerUtils
             return;
         }
 
-        while (exception instanceof FacesWrapper ||
-                (exception.getClass().equals(FacesException.class) || exception.getClass().equals(ELException.class)))
+        while (exception instanceof FacesWrapper)
         {
-            if (exception instanceof FacesWrapper)
-            {
-                exception = (Throwable) ((FacesWrapper) exception).getWrapped();
-            }
-            else if (exception.getClass().equals(FacesException.class)
-                    || exception.getClass().equals(ELException.class))
+            exception = (Throwable) ((FacesWrapper) exception).getWrapped();
+        }
+
+        while ((exception.getClass().equals(FacesException.class) || exception.getClass().equals(ELException.class)))
+        {
+            if (exception.getCause() != null)
             {
                 exception = exception.getCause();
+            }
+            else
+            {
+                break;
             }
         }
 
@@ -164,3 +167,4 @@ public class ExceptionHandlerUtils
         return location;
     }
 }
+


### PR DESCRIPTION
1) I split the loop up into two parts for readability/simplicity.  One for the FacesWrapper and the other for the FacesException/ELException.
2) Added a check for null. If so,  we exit the loop.