### PR TITLE
Add null check for contentTypeListString

### DIFF
--- a/impl/src/main/java/org/apache/myfaces/renderkit/html/HtmlRenderKitImpl.java
+++ b/impl/src/main/java/org/apache/myfaces/renderkit/html/HtmlRenderKitImpl.java
@@ -280,11 +280,18 @@ public class HtmlRenderKitImpl extends RenderKit implements LazyRenderKit
                 {
                     if (contentTypeListStringFromAccept != null)
                     {
-                        String[] contentTypes = ContentTypeUtils.splitContentTypeListString(
-                                contentTypeListStringFromAccept);
-                        if (ContentTypeUtils.containsContentType(ContentTypeUtils.ANY_CONTENT_TYPE, contentTypes))
+                        if(contentTypeListString == null) // Added for MYFACES-4703
                         {
                             selectedContentType = myfacesConfig.getDefaultResponseWriterContentTypeMode();
+                        }
+                        else
+                        {
+                            String[] contentTypes = ContentTypeUtils.splitContentTypeListString(
+                                contentTypeListStringFromAccept);
+                            if (ContentTypeUtils.containsContentType(ContentTypeUtils.ANY_CONTENT_TYPE, contentTypes))
+                            {
+                                selectedContentType = myfacesConfig.getDefaultResponseWriterContentTypeMode();
+                            }
                         }
                     }
                     else if (isAjaxRequest)
@@ -304,8 +311,11 @@ public class HtmlRenderKitImpl extends RenderKit implements LazyRenderKit
                     {
                         // Note this case falls when contentTypeListStringFromAccept == null and 
                         // contentTypeListString != null, but since this not an ajax request, 
-                        // contentTypeListString should fall back to default (MYFACES-4703)
-                        selectedContentType = myfacesConfig.getDefaultResponseWriterContentTypeMode();
+                        // contentTypeListString should be taken strictly and throw IllegalArgumentException
+                        throw new IllegalArgumentException(
+                                "ContentTypeList does not contain a supported content type: "
+                                        + ((contentTypeListString != null) ? 
+                                                contentTypeListString : contentTypeListStringFromAccept) );
                     }
                 }
             }


### PR DESCRIPTION
The JavaDoc for this method:
https://docs.oracle.com/javaee/7/api/javax/faces/render/RenderKit.html#createResponseWriter-java.io.Writer-java.lang.String-java.lang.String-

Key Points: 
`contentTypeList - an "Accept header style" list of content types for this response, or null if the RenderKit should choose the best fit. `

`[IllegalArgumentException](http://docs.oracle.com/javase/7/docs/api/java/lang/IllegalArgumentException.html?is-external=true) - if no matching content type can be found in contentTypeList, no appropriate content type can be found with the implementation dependent best fit algorithm, or no matching character encoding can be found for the argument characterEncoding.` 
_______ 

The  `contentTypeListString` is a parameter. If it is null, then we should should the best fit (i.e the default as in our case) as described in the javadoc. 

If it's not null, then myfaces should continue to try to find a match as on line 289. (If `*/*` is Accepted, then use the default. Otherwise, if `*/*` is not accepted, then the IllegalArgumentException is thrown since not match was found)


I don't like this code, but it looks to work for me locally to pass the TCK test while still avoid the infinite loop. 
