### PR TITLE
[4.0.x] Add serverError prefix to comply with TCK

### DIFF
--- a/api/src/client/typescript/faces/impl/xhrCore/ErrorData.ts
+++ b/api/src/client/typescript/faces/impl/xhrCore/ErrorData.ts
@@ -74,7 +74,7 @@ export class ErrorData extends EventData implements IErrorData {
         this.errorName = errorName;
 
         //tck requires that the type is prefixed to the message itself (jsdoc also) in case of a server error
-        this.errorMessage = errorMessage;
+        this.errorMessage = (type == ErrorType.SERVER_ERROR) ? type + ": " + errorMessage : errorMessage;
         this.responseCode = responseCode;
         this.responseText = responseText;
         this.responseXML = responseXML;

--- a/api/src/client/typescript/faces/test/xhrCore/EventTests.spec.ts
+++ b/api/src/client/typescript/faces/test/xhrCore/EventTests.spec.ts
@@ -111,7 +111,7 @@ describe('tests the addOnEvent and addOnError handling', function () {
             expect(onErrorCalled1).to.eq(1);
             expect(onErrorCalled2).to.eq(1);
             expect(errorTitle).to.eq('Erro21');
-            expect(errorMessage).to.eq('Error2 Text');
+            expect(errorMessage).to.eq('serverError: Error2 Text');
         } finally {
             console.error = oldErr;
         }

--- a/api/src/client/typescript/faces/test/xhrCore/ResponseTest.spec.ts
+++ b/api/src/client/typescript/faces/test/xhrCore/ResponseTest.spec.ts
@@ -739,7 +739,7 @@ describe('Tests of the various aspects of the response protocol functionality', 
             let errorCalled = 0;
             faces.ajax.addOnError((error) => {
                 expect(error.errorName).to.eq("jakarta.faces.application.ViewExpiredException");
-                expect(error.errorMessage).to.eq("View \"/testhmtl.xhtml\" could not be restored.");
+                expect(error.errorMessage).to.eq("serverError: View \"/testhmtl.xhtml\" could not be restored.");
                 expect(error.source.id).to.eq("form1x:button");
                 errorCalled++;
             });


### PR DESCRIPTION
The following test failed: 

ee.jakarta.tck.faces.test.servlet30.ajax_selenium.Issue2179IT#testDecodeException 

https://github.com/jakartaee/faces/blob/4.1.2-RELEASE/tck/faces22/ajax/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_selenium/Issue2179IT.java#L49 

**Expected:** 
Name: form:submit Error: serverError
**Actual:** 
Name: form:submit Error:  decode: A RuntimeException Has Occurred!

The `serverError` string was missing, so I added it back in. 