### PR TITLE
[4.1] MYFACES-4721: Update AUTOCOMPLETE_OFF_VIEW_STATE ('one-time-code' as default)

### DIFF
--- a/impl/src/main/java/org/apache/myfaces/config/webparameters/MyfacesConfig.java
+++ b/impl/src/main/java/org/apache/myfaces/config/webparameters/MyfacesConfig.java
@@ -516,13 +516,13 @@ public class MyfacesConfig
     private static final boolean USE_FLASH_SCOPE_PURGE_VIEWS_IN_SESSION_DEFAULT = false;
     
     /**
-     * Add autocomplete="off" to the view state hidden field. Enabled by default.
+     * Add autocomplete="..." to the view state hidden field. Set to "one-time-code" by default. (MYFACES-4721)
      */
-    @JSFWebConfigParam(since="2.2.8, 2.1.18, 2.0.24", expectedValues="true, false", 
-           defaultValue="false", group="state")
+    @JSFWebConfigParam(since="2.2.8, 2.1.18, 2.0.24", expectedValues="true, false, one-time-code", 
+           defaultValue="one-time-code", group="state")
     public static final String AUTOCOMPLETE_OFF_VIEW_STATE = 
             "org.apache.myfaces.AUTOCOMPLETE_OFF_VIEW_STATE";
-    private static final boolean AUTOCOMPLETE_OFF_VIEW_STATE_DEFAULT = false;
+    private static final String AUTOCOMPLETE_OFF_VIEW_STATE_DEFAULT = "one-time-code";
     
     /**
      * Set the max time in miliseconds set on the "Expires" header for a resource rendered by 
@@ -832,7 +832,7 @@ public class MyfacesConfig
     private boolean serializeStateInSession = false;
     private boolean compressStateInSession = COMPRESS_STATE_IN_SESSION_DEFAULT;
     private boolean useFlashScopePurgeViewsInSession = USE_FLASH_SCOPE_PURGE_VIEWS_IN_SESSION_DEFAULT;
-    private boolean autocompleteOffViewState = AUTOCOMPLETE_OFF_VIEW_STATE_DEFAULT;
+    private String autocompleteOffViewState = AUTOCOMPLETE_OFF_VIEW_STATE_DEFAULT;
     private long resourceMaxTimeExpires = RESOURCE_MAX_TIME_EXPIRES_DEFAULT;
     private boolean lazyLoadConfigObjects = LAZY_LOAD_CONFIG_OBJECTS_DEFAULT;
     private String elResolverComparator;
@@ -1158,7 +1158,7 @@ public class MyfacesConfig
         cfg.useFlashScopePurgeViewsInSession = getBoolean(extCtx, USE_FLASH_SCOPE_PURGE_VIEWS_IN_SESSION,
                 USE_FLASH_SCOPE_PURGE_VIEWS_IN_SESSION_DEFAULT);
 
-        cfg.autocompleteOffViewState = getBoolean(extCtx, AUTOCOMPLETE_OFF_VIEW_STATE,
+        cfg.autocompleteOffViewState = getString(extCtx, AUTOCOMPLETE_OFF_VIEW_STATE,
                 AUTOCOMPLETE_OFF_VIEW_STATE_DEFAULT);
         
         cfg.resourceMaxTimeExpires = getLong(extCtx, RESOURCE_MAX_TIME_EXPIRES,
@@ -1631,9 +1631,15 @@ public class MyfacesConfig
         return useFlashScopePurgeViewsInSession;
     }
 
-    public boolean isAutocompleteOffViewState()
+    public String getAutocompleteOffViewState()
     {
-        return autocompleteOffViewState;
+        if(autocompleteOffViewState.equals("false")){
+            return null;
+        }
+        if(autocompleteOffViewState.equals("true")){
+            return "off";
+        }
+        return autocompleteOffViewState; // return one-time-code
     }
 
     public long getResourceMaxTimeExpires()

--- a/impl/src/main/java/org/apache/myfaces/renderkit/html/HtmlResponseStateManager.java
+++ b/impl/src/main/java/org/apache/myfaces/renderkit/html/HtmlResponseStateManager.java
@@ -138,9 +138,10 @@ public class HtmlResponseStateManager extends MyfacesResponseStateManager
                 null);
         }
         responseWriter.writeAttribute(HTML.VALUE_ATTR, serializedState, null);
-        if (myfacesConfig.isAutocompleteOffViewState())
+        String autoCompleteValue = myfacesConfig.getAutocompleteOffViewState();
+        if (autoCompleteValue != null) // null is the "false" scenario
         {
-            responseWriter.writeAttribute(HTML.AUTOCOMPLETE_ATTR, "off", null);
+            responseWriter.writeAttribute(HTML.AUTOCOMPLETE_ATTR, autoCompleteValue, null);
         }
         responseWriter.endElement(HTML.INPUT_ELEM);
     }


### PR DESCRIPTION
Since we released 4.1.0 already, I want to keep the property name the same.

In 5.0, we can update `o.a.m.AUTOCOMPLETE_OFF_VIEW_STATE` to `o.a.m.AUTOCOMPLETE_VIEW_STATE_VALUE` or something similar. 