### PR TITLE
Add delay of 'none' value to 3.0.x

### DIFF
--- a/api/src/main/javascript/META-INF/resources/myfaces/_impl/core/Impl.js
+++ b/api/src/main/javascript/META-INF/resources/myfaces/_impl/core/Impl.js
@@ -316,6 +316,9 @@ _MF_SINGLTN(_PFX_CORE + "Impl", _MF_OBJECT, /**  @lends myfaces._impl.core.Impl.
         var delayTimeout = options.delay || this._RT.getLocalOrGlobalConfig(context, "delay", false);
 
         if (!!delayTimeout) {
+            if(delayTimeout.toLowerCase &&  delayTimeout.toLowerCase() === "none"){
+                delayTimeout = 0;
+            }
             if(!(delayTimeout >= 0)) {
                 // abbreviation which covers all cases of non positive values,
                 // including NaN and non-numeric strings, no type equality is deliberate here,


### PR DESCRIPTION
It previously was supported, but got lost in the refactoring. I'm adding it back in.

Added to 2.3.x here: e5966675d8cf869e60da8c948b9fc96d108e5868 