### PR TITLE
Key UIData/UIRepeat per-row EVH state by clientId, not row index

### DIFF
--- a/api/src/main/java/jakarta/faces/component/UIData.java
+++ b/api/src/main/java/jakarta/faces/component/UIData.java
@@ -166,13 +166,13 @@ public class UIData extends UIComponentBase implements NamingContainer, UniqueId
     private int _rowIndex = -1;
 
     /**
-     * Per-row EVH state.  Outer key is the row index; value is the list of per-EVH states
-     * indexed by position in {@link #_iterationEVHList} (null entry = component in default
-     * empty state).  A missing outer entry also means all EVH components are in default state.
-     * Using an Integer row-index key avoids string concatenation and leverages the JVM Integer
-     * cache for typical row counts, making map operations cheaper than string-key alternatives.
+     * Per-row EVH state.  Outer key is {@link #getContainerClientId(FacesContext)}, i.e. this table's clientId plus
+     * its current row index, which for a table nested inside another iterating component also carries the enclosing
+     * rows' indices; value is the list of per-EVH states indexed by position in {@link #_iterationEVHList} (null
+     * entry = component in default empty state).  A missing outer entry also means all EVH components are in default
+     * state.
      */
-    private Map<Integer, List<EditableValueHolderState>> _rowStates = new HashMap<>();
+    private Map<String, List<EditableValueHolderState>> _rowStates = new HashMap<>();
     private Map<String, Map<String, Object>> _rowDeltaStates = new HashMap<>();
     private Map<String, Map<String, Object>> _rowTransientStates = new HashMap<>();
 
@@ -765,13 +765,14 @@ public class UIData extends UIComponentBase implements NamingContainer, UniqueId
                 states.add(state);
             }
         }
+        String key = getContainerClientId(getFacesContext());
         if (states != null)
         {
-            _rowStates.put(_rowIndex, states);
+            _rowStates.put(key, states);
         }
         else
         {
-            _rowStates.remove(_rowIndex);
+            _rowStates.remove(key);
         }
     }
 
@@ -789,7 +790,7 @@ public class UIData extends UIComponentBase implements NamingContainer, UniqueId
         {
             return;
         }
-        List<EditableValueHolderState> states = _rowStates.get(_rowIndex);
+        List<EditableValueHolderState> states = _rowStates.get(getContainerClientId(getFacesContext()));
         for (int i = 0, n = evhList.size(); i < n; i++)
         {
             EditableValueHolderState state = (states != null && i < states.size()) ? states.get(i) : null;
@@ -1228,7 +1229,7 @@ public class UIData extends UIComponentBase implements NamingContainer, UniqueId
             }
             else
             {
-                _rowStates = (Map<Integer, List<EditableValueHolderState>>) rs;
+                _rowStates = (Map<String, List<EditableValueHolderState>>) rs;
             }
         }
         if (values.length > 3)

--- a/impl/src/main/java/org/apache/myfaces/view/facelets/component/UIRepeat.java
+++ b/impl/src/main/java/org/apache/myfaces/view/facelets/component/UIRepeat.java
@@ -103,13 +103,13 @@ public class UIRepeat extends UIComponentBase implements NamingContainer
     protected Map<String, Map<String, Object>> _rowTransientStates = new HashMap<>();
 
     /**
-     * Per-row EVH state.  Outer key is the row index; value is the list of per-EVH states
-     * indexed by position in {@link #_iterationEVHList} (null entry = component in default
-     * empty state).  A missing outer entry also means all EVH components are in default state.
-     * Using an Integer row-index key avoids string concatenation and leverages the JVM Integer
-     * cache for typical row counts, making map operations cheaper than string-key alternatives.
+     * Per-row EVH state.  Outer key is {@link #getContainerClientId(FacesContext)}, i.e. this repeat's clientId plus
+     * its current row index, which for a repeat nested inside another iterating component also carries the enclosing
+     * rows' indices; value is the list of per-EVH states indexed by position in {@link #_iterationEVHList} (null
+     * entry = component in default empty state).  A missing outer entry also means all EVH components are in default
+     * state.
      */
-    private Map<Integer, List<EditableValueHolderState>> _rowStates = new HashMap<>();
+    private Map<String, List<EditableValueHolderState>> _rowStates = new HashMap<>();
     
     /**
      * Handle case where this table is nested inside another table. See method getDataModel for more details.
@@ -769,11 +769,11 @@ public class UIRepeat extends UIComponentBase implements NamingContainer
         }
         if (hasState)
         {
-            _rowStates.put(_index, states);
+            _rowStates.put(getContainerClientId(getFacesContext()), states);
         }
         else
         {
-            _rowStates.remove(_index);
+            _rowStates.remove(getContainerClientId(getFacesContext()));
         }
     }
 
@@ -791,7 +791,7 @@ public class UIRepeat extends UIComponentBase implements NamingContainer
         {
             return;
         }
-        List<EditableValueHolderState> states = _rowStates.get(_index);
+        List<EditableValueHolderState> states = _rowStates.get(getContainerClientId(getFacesContext()));
         for (int i = 0, n = evhList.size(); i < n; i++)
         {
             EditableValueHolderState state = (states != null && i < states.size()) ? states.get(i) : null;
@@ -1794,7 +1794,7 @@ public class UIRepeat extends UIComponentBase implements NamingContainer
             }
             else
             {
-                _rowStates = (Map<Integer, List<EditableValueHolderState>>) rs;
+                _rowStates = (Map<String, List<EditableValueHolderState>>) rs;
             }
         }
         if (values.length > 3)

--- a/impl/src/test/java/jakarta/faces/component/UIDataTest.java
+++ b/impl/src/test/java/jakarta/faces/component/UIDataTest.java
@@ -1109,6 +1109,72 @@ public class UIDataTest extends AbstractFacesTestCase
                 "Nested UIInput row-1 state must be restored");
     }
 
+    /**
+     * A UIData nested inside another UIData keeps its per-row state per enclosing row: the inner table's row 0 in
+     * outer row 0 is a different cell from the inner table's row 0 in outer row 1. Keying the inner table's state by
+     * its own row index alone lets each enclosing row overwrite the previous one, which silently drops the submitted
+     * values of every enclosing row but the last.
+     */
+    @Test
+    public void testNestedTableRowStateIsScopedPerOuterRow()
+    {
+        UIViewRoot root = facesContext.getViewRoot();
+
+        UIData outer = new UIData();
+        outer.setId("outer");
+        outer.setVar("group");
+        outer.setValue(java.util.Arrays.asList("g0", "g1"));
+
+        UIColumn outerColumn = new UIColumn();
+        outerColumn.setId("outerCol");
+
+        UIData inner = new UIData();
+        inner.setId("inner");
+        inner.setVar("row");
+        inner.setValue(java.util.Arrays.asList("r0", "r1"));
+
+        UIColumn innerColumn = new UIColumn();
+        innerColumn.setId("innerCol");
+        UIInput input = new UIInput();
+        input.setId("inp");
+
+        innerColumn.getChildren().add(input);
+        inner.getChildren().add(innerColumn);
+        outerColumn.getChildren().add(inner);
+        outer.getChildren().add(outerColumn);
+        root.getChildren().add(outer);
+
+        facesContext.setCurrentPhaseId(PhaseId.APPLY_REQUEST_VALUES);
+
+        // Submit a distinct value into every cell of the 2x2 grid.
+        for (int outerRow = 0; outerRow < 2; outerRow++)
+        {
+            outer.setRowIndex(outerRow);
+            for (int innerRow = 0; innerRow < 2; innerRow++)
+            {
+                inner.setRowIndex(innerRow);
+                input.setSubmittedValue("v" + outerRow + innerRow);
+            }
+            inner.setRowIndex(-1);
+        }
+        outer.setRowIndex(-1);
+
+        // Every cell must still hold its own value.
+        for (int outerRow = 0; outerRow < 2; outerRow++)
+        {
+            outer.setRowIndex(outerRow);
+            for (int innerRow = 0; innerRow < 2; innerRow++)
+            {
+                inner.setRowIndex(innerRow);
+                Assertions.assertEquals("v" + outerRow + innerRow, input.getSubmittedValue(),
+                        "outer row " + outerRow + ", inner row " + innerRow
+                                + " must keep the value submitted into it");
+            }
+            inner.setRowIndex(-1);
+        }
+        outer.setRowIndex(-1);
+    }
+
     // -------------------------------------------------------------------------
     // Read-only (no EVH) flat-list clientId reset
     // -------------------------------------------------------------------------

--- a/impl/src/test/java/org/apache/myfaces/view/facelets/component/UIRepeatTest.java
+++ b/impl/src/test/java/org/apache/myfaces/view/facelets/component/UIRepeatTest.java
@@ -224,6 +224,64 @@ public class UIRepeatTest extends AbstractFacesTestCase
         }
     }
     
+    /**
+     * A UIRepeat nested inside another UIRepeat keeps its per-row state per enclosing row: the inner repeat's row 0
+     * in outer row 0 is a different cell from the inner repeat's row 0 in outer row 1. Keying the inner repeat's
+     * state by its own row index alone lets each enclosing row overwrite the previous one, which silently drops the
+     * submitted values of every enclosing row but the last.
+     */
+    @Test
+    public void testNestedRepeatRowStateIsScopedPerOuterRow()
+    {
+        UIViewRoot root = facesContext.getViewRoot();
+        root.setId(root.createUniqueId());
+
+        UIRepeat outer = new UIRepeat();
+        outer.setId(root.createUniqueId());
+        outer.setVar("group");
+        outer.setValue(Arrays.asList("g0", "g1"));
+
+        UIRepeat inner = new UIRepeat();
+        inner.setId(root.createUniqueId());
+        inner.setVar("row");
+        inner.setValue(Arrays.asList("r0", "r1"));
+
+        UIInput input = new UIInput();
+        input.setId(root.createUniqueId());
+
+        inner.getChildren().add(input);
+        outer.getChildren().add(inner);
+        root.getChildren().add(outer);
+
+        facesContext.setCurrentPhaseId(PhaseId.APPLY_REQUEST_VALUES);
+
+        for (int outerRow = 0; outerRow < 2; outerRow++)
+        {
+            outer.setRowIndex(outerRow);
+            for (int innerRow = 0; innerRow < 2; innerRow++)
+            {
+                inner.setRowIndex(innerRow);
+                input.setSubmittedValue("v" + outerRow + innerRow);
+            }
+            inner.setRowIndex(-1);
+        }
+        outer.setRowIndex(-1);
+
+        for (int outerRow = 0; outerRow < 2; outerRow++)
+        {
+            outer.setRowIndex(outerRow);
+            for (int innerRow = 0; innerRow < 2; innerRow++)
+            {
+                inner.setRowIndex(innerRow);
+                Assertions.assertEquals("v" + outerRow + innerRow, input.getSubmittedValue(),
+                        "outer row " + outerRow + ", inner row " + innerRow
+                                + " must keep the value submitted into it");
+            }
+            inner.setRowIndex(-1);
+        }
+        outer.setRowIndex(-1);
+    }
+
     // -------------------------------------------------------------------------
     // Helpers
     // -------------------------------------------------------------------------


### PR DESCRIPTION
### Problem

A `UIData` or `UIRepeat` nested inside another iterating component loses the submitted values of every enclosing row but the last — silently: no conversion, no validation, no model update, no message.

Reproduced on a 5×10 grid (outer table over 5 groups, inner over 10 rows, 3 text inputs per row) by submitting a marker into every input and counting how many the response echoes back:

| scenario | before | after |
|---|--:|--:|
| `h:dataTable` in `h:dataTable` | 30/150 | **150/150** |
| `ui:repeat` in `ui:repeat` | 30/150 | **150/150** |
| composite in `h:dataTable` | 30/150 | **150/150** |
| flat table (control) | 105/105 | 105/105 |

The 30 that survived were exactly the last outer row.

### Cause

Regression from 6336caf1d ([perf] optimize UIData/UIRepeat state saving), which changed the per-row `EditableValueHolder` state map from `Map<String, …>` keyed by `getContainerClientId(context)` to `Map<Integer, …>` keyed by the bare row index.

A nested iterating component is one instance reused across the enclosing rows, so the bare index makes every enclosing row map to the same key. `getContainerClientId()` is the clientId plus the current row index, carrying both dimensions; the index key kept only one. `_rowDeltaStates` and `_rowTransientStates` were never changed and still key on the clientId.

### Fix

Key `_rowStates` on `getContainerClientId()` again in both components. The precollected iteration lists, the positional `EditableValueHolderState` list and its deferred allocation are untouched — only the key type and the two key expressions change.

**The optimisation is not being asked back.** Measured against current `main` with only `UIData`/`UIRepeat` reverted to their state before 6336caf1d, on the Mojarra `test/perf` suite (Tomcat, 32 scenarios, two alternating rounds):

| | pre-rewrite | this PR | Δ |
|---|--:|--:|--:|
| whole suite | 78.23 s | 76.36 s | **−2.4%** |
| APPLY_REQUEST_VALUES | 3.43 s | 3.09 s | **−10.0%** |
| UPDATE_MODEL_VALUES | 4.79 s | 4.41 s | **−7.9%** |

### Tests

`UIDataTest.testNestedTableRowStateIsScopedPerOuterRow` and `UIRepeatTest.testNestedRepeatRowStateIsScopedPerOuterRow`: a 2×2 nested grid, a distinct value per cell, iterate away and back, assert each cell kept its own. Both fail without the fix (`expected: <v00> but was: <v10>`) and pass with it. Full `api` + `impl` suite green, 1651 tests.

### Notes

- **A backport to `4.1.x` is needed**: b4a4050f6 carries the same change there, so 4.1.x has the same defect. This PR targets `main` only.
- Neither line has released it — 4.1.3 predates 6336caf1d, so no MyFaces release is affected. 4.0.x is not affected either (still clientId-keyed).
- Mojarra had the identical defect, fixed the same way in eclipse-ee4j/mojarra#5874.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Opus 5)
