### PR TITLE
MYFACES-4760 QuarkusApplication.getELResolver() introduces data race

### DIFF
--- a/extensions/quarkus/runtime/src/main/java/org/apache/myfaces/core/extensions/quarkus/runtime/application/QuarkusApplication.java
+++ b/extensions/quarkus/runtime/src/main/java/org/apache/myfaces/core/extensions/quarkus/runtime/application/QuarkusApplication.java
@@ -28,11 +28,11 @@ import org.apache.myfaces.config.webparameters.MyfacesConfig;
 import org.apache.myfaces.config.RuntimeConfig;
 
 import org.apache.myfaces.core.extensions.quarkus.runtime.spi.QuarkusELResolverBuilder;
+import org.apache.myfaces.util.lang.Lazy;
 
 public class QuarkusApplication extends ApplicationWrapper
 {
-    private CompositeELResolver elResolver;
-
+    private final Lazy<CompositeELResolver> elResolver;
     private final RuntimeConfig runtimeConfig;
     private final MyfacesConfig myfacesConfig;
 
@@ -42,18 +42,19 @@ public class QuarkusApplication extends ApplicationWrapper
 
         runtimeConfig = RuntimeConfig.getCurrentInstance(FacesContext.getCurrentInstance());
         myfacesConfig = MyfacesConfig.getCurrentInstance(FacesContext.getCurrentInstance());
+        elResolver = new Lazy<>(() ->
+        {
+            CompositeELResolver celr = new CompositeELResolver();
+
+            new QuarkusELResolverBuilder(runtimeConfig, myfacesConfig).build(celr);
+
+            return celr;
+        });
     }
 
     @Override
     public final ELResolver getELResolver()
     {
-        if (elResolver == null)
-        {
-            elResolver = new CompositeELResolver();
-            new QuarkusELResolverBuilder(runtimeConfig, myfacesConfig).build(elResolver);
-        }
-
-        return elResolver;
+        return elResolver.get();
     }
-
 }


### PR DESCRIPTION
QuarkusApplication.getELResolver() first sets (and exposes) the instance variable and only then calls the resolver builder. The builder is not thread-safe. Thus concurrent requests can access an empty slot in the builder's internal array.

Now using Lazy just as ApplicationImpl does.

Fixes:
 jakarta.el.ELException: java.lang.NullPointerException: Cannot invoke
 "jakarta.el.ELResolver.convertToType(...)" because "this.elResolvers[i]" is null
     at jakarta.el.ELContext.convertToType(ELContext.java:435)
     at org.glassfish.expressly.lang.EvaluationContext.convertToType(EvaluationContext.java:141)
     at org.glassfish.expressly.ValueExpressionImpl.getValue(ValueExpressionImpl.java:142)
     at org.apache.myfaces.application.ApplicationImpl.evaluateExpressionGet(ApplicationImpl.java:515)
     ...
 Caused by: java.lang.NullPointerException: ... "this.elResolvers[i]" is null
     at jakarta.el.CompositeELResolver.convertToType(CompositeELResolver.java:446)