### PR TITLE
Revert "Only perform partial rendering for an ajax postback"

### DIFF
--- a/api/src/main/java/jakarta/faces/component/UIViewRoot.java
+++ b/api/src/main/java/jakarta/faces/component/UIViewRoot.java
@@ -562,15 +562,9 @@ public class UIViewRoot extends UIComponentBase implements UniqueIdVendor
             return;
         }
         PartialViewContext pContext = context.getPartialViewContext();
-
+        
         // If PartialViewContext.isAjaxRequest() returns true
-        // Additionally require a postback: a genuine ajax request is always a postback and carries a
-        // jakarta.faces.ViewState. A request flagged as ajax but without any view state is not restoring a
-        // view, so partial-rendering it is meaningless - it would only build a PartialVisitContext from the
-        // attacker-controlled jakarta.faces.partial.render parameter against a freshly created view. Treating
-        // it as a normal (full) render keeps that parameter from being parsed on a non-postback and hardens
-        // the pre-authentication resource-exhaustion path.
-        if (pContext.isAjaxRequest() && context.isPostback())
+        if (pContext.isAjaxRequest())
         {
             // Perform partial rendering by calling PartialViewContext.processPartial() with PhaseId.RENDER_RESPONSE.
             //sectin 13.4.3 of the jsf2 specification

--- a/impl/src/test/java/jakarta/faces/component/UIViewRootTest.java
+++ b/impl/src/test/java/jakarta/faces/component/UIViewRootTest.java
@@ -40,8 +40,6 @@ import jakarta.faces.application.Application;
 import jakarta.faces.application.ProjectStage;
 import jakarta.faces.application.ViewHandler;
 import jakarta.faces.context.ExternalContext;
-import jakarta.faces.context.FacesContext;
-import jakarta.faces.context.PartialViewContext;
 import jakarta.faces.event.AbortProcessingException;
 import jakarta.faces.event.ActionEvent;
 import jakarta.faces.event.ActionListener;
@@ -595,59 +593,6 @@ public class UIViewRootTest extends AbstractJsfTestCase
             return PhaseId.RENDER_RESPONSE;
         }
     }
-
-
-    /**
-     * a request flagged as ajax but without a jakarta.faces.ViewState
-     * is not a postback. UIViewRoot.encodeChildren must NOT trigger partial rendering for it, otherwise the
-     * attacker-controlled jakarta.faces.partial.render parameter would be parsed on a non-postback. It must
-     * fall back to a normal (full) render instead.
-     */
-    @Test
-    public void testEncodeChildrenSkipsPartialRenderingWhenNotPostback() throws Exception
-    {
-        IMocksControl ctrl = EasyMock.createControl();
-        FacesContext ctx = ctrl.createMock(FacesContext.class);
-        PartialViewContext pvc = ctrl.createMock(PartialViewContext.class);
-
-        expect(ctx.getResponseComplete()).andReturn(false);
-        expect(ctx.getPartialViewContext()).andReturn(pvc);
-        expect(pvc.isAjaxRequest()).andReturn(true);
-        expect(ctx.isPostback()).andReturn(false);
-        // processPartial() is intentionally not expected: the strict mock fails the test if it is called.
-        ctrl.replay();
-
-        // rendered=false makes the full-render fallback (super.encodeChildren) a clean no-op,
-        // so only the gate's calls hit the mock.
-        _testimpl.setRendered(false);
-        _testimpl.encodeChildren(ctx);
-
-        ctrl.verify();
-    }
-
-    /**
-     * Counterpart to {@link #testEncodeChildrenSkipsPartialRenderingWhenNotPostback()}: a genuine ajax
-     * postback (ViewState present) must still be partial-rendered.
-     */
-    @Test
-    public void testEncodeChildrenDoesPartialRenderingOnAjaxPostback() throws Exception
-    {
-        IMocksControl ctrl = EasyMock.createControl();
-        FacesContext ctx = ctrl.createMock(FacesContext.class);
-        PartialViewContext pvc = ctrl.createMock(PartialViewContext.class);
-
-        expect(ctx.getResponseComplete()).andReturn(false);
-        expect(ctx.getPartialViewContext()).andReturn(pvc);
-        expect(pvc.isAjaxRequest()).andReturn(true);
-        expect(ctx.isPostback()).andReturn(true);
-        pvc.processPartial(PhaseId.RENDER_RESPONSE);
-        ctrl.replay();
-
-        _testimpl.encodeChildren(ctx);
-
-        ctrl.verify();
-    }
-
 
     @Test
     public void testBroadcastEvents()


### PR DESCRIPTION
This reverts commit b01e8e5134e5338c1cc6324cc95bf69024e8a96b.

This breaks the spec so I'm reverting it.

https://jakarta.ee/specifications/faces/3.0/apidocs/jakarta/faces/component/uiviewroot#encodeChildren(jakarta.faces.context.FacesContext)

> If [PartialViewContext.isAjaxRequest()](https://jakarta.ee/specifications/faces/3.0/apidocs/jakarta/faces/context/partialviewcontext#isAjaxRequest()) returns true, perform partial rendering by calling [PartialViewContext.processPartial(jakarta.faces.event.PhaseId)](https://jakarta.ee/specifications/faces/3.0/apidocs/jakarta/faces/context/partialviewcontext#processPartial(jakarta.faces.event.PhaseId)) with [PhaseId.RENDER_RESPONSE](https://jakarta.ee/specifications/faces/3.0/apidocs/jakarta/faces/event/phaseid#RENDER_RESPONSE). If [PartialViewContext.isAjaxRequest()](https://jakarta.ee/specifications/faces/3.0/apidocs/jakarta/faces/context/partialviewcontext#isAjaxRequest()) returns false, delegate to the parent [UIComponentBase.encodeChildren(jakarta.faces.context.FacesContext)](https://jakarta.ee/specifications/faces/3.0/apidocs/jakarta/faces/component/uicomponentbase#encodeChildren(jakarta.faces.context.FacesContext)) method.