### PR TITLE
Remove old tomcat repos

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -662,18 +662,6 @@
         </pluginRepository>
     </pluginRepositories>
 
-    <repositories>
-
-        <!-- NOTE that apache.snapshots is defined in apache-parent -->
-
-        <!-- tomcat el-impl for test cases (see related tomcat-dependencies) -->
-        <repository>
-            <id>tomcat</id>
-            <url>http://tomcat.apache.org/dev/dist/m2-repository</url>
-        </repository>
-
-    </repositories>
-
     <!--
     <distributionManagement>
         <site>

--- a/pom.xml
+++ b/pom.xml
@@ -192,19 +192,7 @@
             </releases>
         </pluginRepository>
     </pluginRepositories>
-
-    <repositories>
-
-        <!-- NOTE that apache.snapshots is defined in apache-parent -->
-
-        <!-- tomcat el-impl for test cases (see related tomcat-dependencies) -->
-        <repository>
-            <id>tomcat</id>
-            <url>http://tomcat.apache.org/dev/dist/m2-repository</url>
-        </repository>
-
-    </repositories>
-    
+        
     <!-- 
     <distributionManagement>
         <site>


### PR DESCRIPTION
http://tomcat.apache.org/dev/dist/m2-repository has two problems.


1) HTTP (Not Secure)

2) Returns a 404: 
> Not Found
> The requested URL was not found on this server.