### PR TITLE
4.0.x build issues (for use with Java 17)

### DIFF
--- a/api/src/main/java/jakarta/faces/convert/NumberConverter.java
+++ b/api/src/main/java/jakarta/faces/convert/NumberConverter.java
@@ -27,6 +27,7 @@ import java.text.ParseException;
 import java.text.ParsePosition;
 import java.util.Currency;
 import java.util.Locale;
+import java.util.regex.Pattern;
 
 import jakarta.el.ValueExpression;
 import jakarta.faces.component.PartialStateHolder;
@@ -61,6 +62,11 @@ public class NumberConverter implements Converter, PartialStateHolder
     public static final String PATTERN_ID = "jakarta.faces.converter.NumberConverter.PATTERN";
     public static final String PERCENT_ID = "jakarta.faces.converter.NumberConverter.PERCENT";
 
+    private static final Pattern FIXED_WIDTH_WHITESPACE =
+            Pattern.compile("[\u00a0\u1680\u2000-\u200a\u202f\u205f\u3000]");
+    private static final Pattern ZERO_WIDTH_WHITESPACE =
+            Pattern.compile("[\u200b-\u200d\u2060\ufeff]");
+
     private String _currencyCode;
     private String _currencySymbol;
     private Locale _locale;
@@ -89,17 +95,11 @@ public class NumberConverter implements Converter, PartialStateHolder
         Assert.notNull(facesContext, "facesContext");
         Assert.notNull(uiComponent, "uiComponent");
 
-        if (value == null)
+        if (value == null || value.isBlank())
         {
             return null;
         }
-        
-        value = value.trim();
-        if (value.length() < 1)
-        {
-            return null;
-        }
-        
+
         NumberFormat format = getNumberFormat(facesContext);
         format.setParseIntegerOnly(_integerOnly);
 
@@ -122,65 +122,89 @@ public class NumberConverter implements Converter, PartialStateHolder
             }
         }
 
-        DecimalFormatSymbols dfs = df.getDecimalFormatSymbols();
-        boolean changed = false;
-        if(dfs.getGroupingSeparator() == '\u00a0')
-        {
-            dfs.setGroupingSeparator(' ');
-            df.setDecimalFormatSymbols(dfs);
-            value = value.replace('\u00a0', ' ');
-            changed = true;
-        }
-
         formatCurrency(format);
 
         try
         {
+            DecimalFormatSymbols symbols = df.getDecimalFormatSymbols();
+            char origGroupingSep = symbols.getGroupingSeparator();
+            String origPrefix = df.getPositivePrefix();
+            String origSuffix = df.getPositiveSuffix();
+            String origNegPrefix = df.getNegativePrefix();
+            String origNegSuffix = df.getNegativeSuffix();
+
+            boolean hasFixedWidthWhitespace =
+                    FIXED_WIDTH_WHITESPACE.matcher(String.valueOf(origGroupingSep)).matches()
+                    || FIXED_WIDTH_WHITESPACE.matcher(origPrefix).find()
+                    || FIXED_WIDTH_WHITESPACE.matcher(origSuffix).find()
+                    || FIXED_WIDTH_WHITESPACE.matcher(origNegPrefix).find()
+                    || FIXED_WIDTH_WHITESPACE.matcher(origNegSuffix).find();
+
+            if (hasFixedWidthWhitespace)
+            {
+                String normalizedValue = normalizeWhitespace(value);
+
+                if (FIXED_WIDTH_WHITESPACE.matcher(String.valueOf(origGroupingSep)).matches())
+                {
+                    symbols.setGroupingSeparator(' ');
+                    symbols.setMonetaryGroupingSeparator(' ');
+                }
+
+                df.setDecimalFormatSymbols(symbols);
+                df.setPositivePrefix(normalizeWhitespace(origPrefix));
+                df.setPositiveSuffix(normalizeWhitespace(origSuffix));
+                df.setNegativePrefix(normalizeWhitespace(origNegPrefix));
+                df.setNegativeSuffix(normalizeWhitespace(origNegSuffix));
+
+                try
+                {
+                    return parse(normalizedValue, format, destType);
+                }
+                catch (ParseException pe)
+                {
+                    symbols.setGroupingSeparator(origGroupingSep);
+                    symbols.setMonetaryGroupingSeparator(origGroupingSep);
+                    df.setDecimalFormatSymbols(symbols);
+                    df.setPositivePrefix(origPrefix);
+                    df.setPositiveSuffix(origSuffix);
+                    df.setNegativePrefix(origNegPrefix);
+                    df.setNegativeSuffix(origNegSuffix);
+                }
+            }
+
             return parse(value, format, destType);
         }
         catch (ParseException e)
         {
-            if(changed)
+            if (getPattern() != null)
             {
-                dfs.setGroupingSeparator('\u00a0');
-                df.setDecimalFormatSymbols(dfs);
+                throw new ConverterException(MessageUtils.getErrorMessage(facesContext,
+                        PATTERN_ID,
+                        new Object[]{value, "$###,###", MessageUtils.getLabel(facesContext, uiComponent)}));
             }
-            try
+            else if (getType().equals("number"))
             {
-                return parse(value, format, destType);
+                throw new ConverterException(MessageUtils.getErrorMessage(facesContext,
+                        NUMBER_ID,
+                        new Object[]{value, format.format(21),
+                                     MessageUtils.getLabel(facesContext, uiComponent)}));
             }
-            catch (ParseException pe)
+            else if (getType().equals("currency"))
             {
-                if (getPattern() != null)
-                {
-                    throw new ConverterException(MessageUtils.getErrorMessage(facesContext,
-                            PATTERN_ID,
-                            new Object[]{value, "$###,###", MessageUtils.getLabel(facesContext, uiComponent)}));
-                }
-                else if (getType().equals("number"))
-                {
-                    throw new ConverterException(MessageUtils.getErrorMessage(facesContext,
-                            NUMBER_ID,
-                            new Object[]{value, format.format(21),
-                                         MessageUtils.getLabel(facesContext, uiComponent)}));
-                }
-                else if (getType().equals("currency"))
-                {
-                    throw new ConverterException(MessageUtils.getErrorMessage(facesContext,
-                            CURRENCY_ID,
-                            new Object[]{value, format.format(42.25),
-                                         MessageUtils.getLabel(facesContext, uiComponent)}));
-                }
-                else if (getType().equals("percent"))
-                {
-                    throw new ConverterException(MessageUtils.getErrorMessage(facesContext,
-                            PERCENT_ID,
-                            new Object[]{value, format.format(.90),
-                                         MessageUtils.getLabel(facesContext, uiComponent)}));
-                }
+                throw new ConverterException(MessageUtils.getErrorMessage(facesContext,
+                        CURRENCY_ID,
+                        new Object[]{value, format.format(42.25),
+                                     MessageUtils.getLabel(facesContext, uiComponent)}));
+            }
+            else if (getType().equals("percent"))
+            {
+                throw new ConverterException(MessageUtils.getErrorMessage(facesContext,
+                        PERCENT_ID,
+                        new Object[]{value, format.format(.90),
+                                     MessageUtils.getLabel(facesContext, uiComponent)}));
             }
         }
-        
+
         return null;
     }
 
@@ -585,6 +609,12 @@ public class NumberConverter implements Converter, PartialStateHolder
     {
         _type = type;
         clearInitialState();
+    }
+
+    private static String normalizeWhitespace(String text)
+    {
+        String normalized = FIXED_WIDTH_WHITESPACE.matcher(text).replaceAll(" ");
+        return ZERO_WIDTH_WHITESPACE.matcher(normalized).replaceAll("");
     }
 
     private DecimalFormatSymbols getDecimalFormatSymbols()

--- a/extensions/quarkus/pom.xml
+++ b/extensions/quarkus/pom.xml
@@ -43,6 +43,9 @@
     <properties>
         <quarkus.version>3.2.9.Final</quarkus.version>
         <xml-combiner.version>3.0.0</xml-combiner.version>
+        <java.version>17</java.version>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
     </properties>
 
     <build>

--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -35,7 +35,7 @@
     <url>https://myfaces.apache.org/#/core40</url>
 
     <properties>
-        <openwebbeans.version>2.0.19</openwebbeans.version>
+        <openwebbeans.version>2.0.27</openwebbeans.version>
     </properties>
 
     <build>
@@ -579,7 +579,7 @@
                             <value>COMPAT</value>
                         </property>
                     </systemProperties>
-                    <argLine>-Djava.locale.providers=COMPAT</argLine>
+                    <argLine>-Djava.locale.providers=COMPAT --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.security=ALL-UNNAMED</argLine>
                 </configuration>
 
                 <executions>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -195,13 +195,10 @@
                     <version>1.9.1</version>
                 </plugin>
 
-                <!-- Version 4.1.0 and higher does not output the version ranges for some packages
-                     when specified by <Import-Package> in API/IMPL plugins
-                     See https://issues.apache.org/jira/browse/FELIX-6566 -->
                 <plugin>
                     <groupId>org.apache.felix</groupId>
                     <artifactId>maven-bundle-plugin</artifactId>
-                    <version>4.0.0</version>
+                    <version>5.1.9</version>
                 </plugin>
 
                 <plugin>


### PR DESCRIPTION
4.0.x requires a min of Java 11, but it doesn't build with it due to error:

> [ERROR] Failed to execute goal io.quarkus:quarkus-maven-plugin:3.2.9.Final:build (default) on project quarkus-myfaces-showcase: 
> [ERROR] The plugin io.quarkus:quarkus-maven-plugin:3.2.9.Final has unmet prerequisites: 
> [ERROR] 	Required Java version 17 is not met by current version: 11.0.32

If I use Java 17, then I get: 

> [ERROR] Failed to execute goal org.apache.felix:maven-bundle-plugin:4.0.0:manifest (bundle-manifest) on project myfaces-api: Execution bundle-manifest of goal org.apache.felix:maven-bundle-plugin:4.0.0:manifest failed.: ConcurrentModificationException -> [Help 1]
> [ERROR]  

I've updated the dependencies to use Java 17 (but still have the source/target set to 11). Inadvertently, Java 17 caused number converter errors which I've also fixed. 