### PR TITLE
Revert "[perf] use precompiled pattern"

### DIFF
--- a/api/src/main/java/jakarta/faces/validator/BeanValidator.java
+++ b/api/src/main/java/jakarta/faces/validator/BeanValidator.java
@@ -27,7 +27,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.logging.Logger;
-import java.util.regex.Pattern;
 
 import jakarta.el.ValueExpression;
 import jakarta.el.ValueReference;
@@ -110,13 +109,6 @@ public class BeanValidator implements Validator, PartialStateHolder
      * Currently, a string containing only whitespace is classified as empty.
      */
     public static final String EMPTY_VALIDATION_GROUPS_PATTERN = "^[\\W,]*$";
-
-    /**
-     * Precompiled form of {@link #EMPTY_VALIDATION_GROUPS_PATTERN}; use this instead of
-     * {@code String.matches(EMPTY_VALIDATION_GROUPS_PATTERN)} to avoid recompiling the
-     * pattern on every postback.
-     */
-    public static final Pattern EMPTY_VALIDATION_GROUPS = Pattern.compile(EMPTY_VALIDATION_GROUPS_PATTERN);
     
     /**
      * Enable f:validateWholeBean use.
@@ -345,7 +337,7 @@ public class BeanValidator implements Validator, PartialStateHolder
      */
     private void postSetValidationGroups()
     {
-        if (this.validationGroups == null || EMPTY_VALIDATION_GROUPS.matcher(this.validationGroups).matches())
+        if (this.validationGroups == null || this.validationGroups.matches(EMPTY_VALIDATION_GROUPS_PATTERN))
         {
             this.validationGroupsArray = DEFAULT_VALIDATION_GROUPS_ARRAY;
         }

--- a/impl/src/main/java/org/apache/myfaces/component/validate/WholeBeanValidator.java
+++ b/impl/src/main/java/org/apache/myfaces/component/validate/WholeBeanValidator.java
@@ -42,7 +42,7 @@ import jakarta.faces.component.visit.VisitCallback;
 import jakarta.faces.component.visit.VisitContext;
 import jakarta.faces.component.visit.VisitResult;
 import jakarta.faces.context.FacesContext;
-import static jakarta.faces.validator.BeanValidator.EMPTY_VALIDATION_GROUPS;
+import static jakarta.faces.validator.BeanValidator.EMPTY_VALIDATION_GROUPS_PATTERN;
 import static jakarta.faces.validator.BeanValidator.MESSAGE_ID;
 import static jakarta.faces.validator.BeanValidator.VALIDATION_GROUPS_DELIMITER;
 import static jakarta.faces.validator.BeanValidator.VALIDATOR_FACTORY_KEY;
@@ -296,7 +296,7 @@ public class WholeBeanValidator implements Validator
     private void postSetValidationGroups(ValidateWholeBeanComponent component)
     {
         String validationGroups = getValidationGroups(component);
-        if (validationGroups == null || EMPTY_VALIDATION_GROUPS.matcher(validationGroups).matches())
+        if (validationGroups == null || validationGroups.matches(EMPTY_VALIDATION_GROUPS_PATTERN))
         {
             this.validationGroupsArray = DEFAULT_VALIDATION_GROUPS_ARRAY;
         }

--- a/impl/src/main/java/org/apache/myfaces/view/facelets/tag/faces/ComponentTagHandlerDelegate.java
+++ b/impl/src/main/java/org/apache/myfaces/view/facelets/tag/faces/ComponentTagHandlerDelegate.java
@@ -744,7 +744,7 @@ public class ComponentTagHandlerDelegate extends TagHandlerDelegate
             // check the validationGroups
             String validationGroups =  beanValidator.getValidationGroups();
             if (validationGroups == null 
-                    || BeanValidator.EMPTY_VALIDATION_GROUPS.matcher(validationGroups).matches())
+                    || validationGroups.matches(BeanValidator.EMPTY_VALIDATION_GROUPS_PATTERN))
             {
                 // no validationGroups available
                 // --> get the validationGroups from the stack
@@ -854,7 +854,7 @@ public class ComponentTagHandlerDelegate extends TagHandlerDelegate
                     // check the validationGroups
                     String validationGroups =  beanValidator.getValidationGroups();
                     if (validationGroups == null 
-                            || BeanValidator.EMPTY_VALIDATION_GROUPS.matcher(validationGroups).matches())
+                            || validationGroups.matches(BeanValidator.EMPTY_VALIDATION_GROUPS_PATTERN))
                     {
                         // no validationGroups available
                         // --> get the validationGroups from the stack


### PR DESCRIPTION
This reverts commit 5e56abd09afc9f1fbf08cf07b63dd75645866a19.

Binary compatibility tool reported that `jakarta.faces.validator.BeanValidator` changed:
<img width="1212" height="357" alt="image" src="https://github.com/user-attachments/assets/5a329254-22f9-437e-b733-c1ec3dc0c7ab" />


 I cannot recall if this is allowed (new field), but I think the specs needs to match 1:1. 